### PR TITLE
Reject reuse of rotated refresh tokens

### DIFF
--- a/src/svc_infra/api/fastapi/auth/routers/oauth_router.py
+++ b/src/svc_infra/api/fastapi/auth/routers/oauth_router.py
@@ -739,7 +739,11 @@ def _create_oauth_router(
             raise HTTPException(401, "invalid_refresh_token")
 
         # Rotate refresh token
-        new_raw, _new_rt = await rotate_session_refresh(session, current=found)
+        try:
+            new_raw, _new_rt = await rotate_session_refresh(session, current=found)
+        except ValueError:
+            # Token expired between validation and rotation; treat as invalid
+            raise HTTPException(401, "invalid_refresh_token") from None
 
         # Write response (204) with new cookies
         resp = Response(status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Summary
- reject attempts to rotate a refresh token once it has been revoked or expired
- extend the session rotation test to assert revocation metadata and guard against reusing the old token

## Testing
- PYTHONPATH=src poetry run pytest -q tests/security/test_session_rotation.py

------
https://chatgpt.com/codex/tasks/task_e_68eefccbd2f08323b151edb4a779db50