### PR TITLE
push old commits

### DIFF
--- a/.github/instructions/PLANS.md
+++ b/.github/instructions/PLANS.md
@@ -29,6 +29,7 @@ Comprehensive checklist for making the framework production-ready. Each section 
 - [x] Implement: secret management abstraction + rotation API. (RotatingJWTStrategy with old_secrets support)
 - [x] Implement: JWT/crypto key rolling script (dual key validity window). (config via AUTH_JWT__OLD_SECRETS and tests)
 - [x] Implement: audit log model (append-only + hash chain field). (AuditLog + compute_audit_hash + append_audit_event + service wrapper + tests)
+- [x] Implement: easy-setup helpers (add/setup/ease) for one-line integration. (see api.fastapi.auth.add.add_auth_users and security.add)
 - [x] Tests: password policy + lockout (cooldown escalation).
 - [x] Tests: session revocation + RBAC enforcement.
 - [x] Tests: breach password rejection & pass cases with stubbed checker.
@@ -44,6 +45,7 @@ Comprehensive checklist for making the framework production-ready. Each section 
 - [x] Implement: 429 Retry-After logic. (headers in 429 + OpenAPI conventions already present)
 - [x] Implement: request size & body parse timeout guard. (size limit middleware; parse timeout TBD)
 - [x] Implement: basic bot/DoS heuristic metrics hook. (metrics hooks + middleware emits)
+- [x] Implement: easy-setup helper for wiring global/per-route rate limits. (integrated via setup_service_api/easy_service_api)
 - [x] Tests: bucket depletion/reset, per-route override, Retry-After presence. (tests added)
 - [x] Verify: rate limiting test marker. (`-m ratelimit` available; auto-tagged tests)
 - [x] Docs: usage & tuning. (see docs/rate-limiting.md)
@@ -55,6 +57,7 @@ Comprehensive checklist for making the framework production-ready. Each section 
 - [x] Implement: optimistic locking (version columns) + conflict exception.
 - [x] Implement: transactional outbox (in-memory store) + relay skeleton API. (SQL impl TBD)
 - [x] Implement: inbox pattern (in-memory dedupe store with TTL). (SQL impl TBD)
+- [x] Implement: easy-setup helper to enable idempotency middleware/inbox/outbox. (integrated via setup_service_api/easy_service_api)
 - [x] Tests: idempotent replay and conflict on mismatched payload (concurrency marker added).
 - [x] Verify: idempotency tests selectable via marker (`-m concurrency`).
 - [x] Docs: idempotency middleware usage & semantics. (see docs/idempotency.md)
@@ -73,6 +76,7 @@ Comprehensive checklist for making the framework production-ready. Each section 
  - [x] Tests: enqueue/dequeue, retry/backoff, cron triggers, DLQ path. (tests/jobs/* incl. fakeredis and CLI)
 - [x] Verify: job test marker. (tests/jobs/* using in-memory queue and scheduler pass under -m jobs)
  - [x] Docs: job authoring guide. (see docs/jobs.md)
+- [x] Implement: easy-setup helper to choose queue and start scheduler. (see jobs/easy.py)
 
 ### 5. Webhooks Framework
 - [x] Research: existing webhook verification logic. (note) Use HMAC-SHA256 over canonical JSON; header X-Signature; reuse outbox/jobs for delivery.
@@ -84,6 +88,7 @@ Comprehensive checklist for making the framework production-ready. Each section 
 - [x] Tests: signature validation, retry escalation, version handling. (unit + e2e under -m webhooks)
 - [x] Verify: webhook test marker. (pyproject marker added)
 - [x] Docs: integration guide. (see docs/webhooks.md)
+- [x] Implement: easy-setup helper to add webhook producer/verify middleware. (see webhooks/add.py)
 
 ### 6. Tenancy
 - [x] Research: tenant_id coverage across existing models (payments models, audit/session models, SQL/Mongo scaffolds; enforcement gaps in generic SQL service/routers now addressed).
@@ -98,6 +103,7 @@ Comprehensive checklist for making the framework production-ready. Each section 
  - [x] Tests: rate limits per-tenant; export correctness.
 - [x] Verify: tenancy test marker.
 - [x] Docs: isolation strategy (soft vs schema vs dedicated DB). (see docs/tenancy.md)
+- [x] Implement: easy-setup helper for tenant resolution and tenant-aware CRUD. (see api.fastapi.tenancy.add.add_tenancy and SQL router wiring)
 
 ### 7. Data Lifecycle
 - [ ] Research: migrations tooling & soft delete usage.
@@ -110,6 +116,7 @@ Comprehensive checklist for making the framework production-ready. Each section 
 - [ ] Tests: soft delete filter, erasure pipeline, retention purge logic.
 - [ ] Verify: data lifecycle test marker.
 - [ ] Docs: lifecycle & retention policies.
+ - [x] Implement: easy-setup helpers for migrator/fixtures/retention/erasure wiring. (see data/add.py:add_data_lifecycle)
 
 ### 8. SLOs & Ops
 - [ ] Research: existing metrics/logging instrumentation.
@@ -120,6 +127,7 @@ Comprehensive checklist for making the framework production-ready. Each section 
 - [ ] Tests: probe behavior, breaker trip/reset.
 - [ ] Verify: ops test marker.
 - [ ] Docs: SLO definitions & ops playbook.
+ - [x] Implement: easy-setup helpers for probes/maintenance-mode/circuit-breaker. (see api/fastapi/ops/add.py)
 
 ### 9. DX & Quality Gates
 - [ ] Research: current CI pipeline steps & gaps.
@@ -131,6 +139,7 @@ Comprehensive checklist for making the framework production-ready. Each section 
 - [ ] Tests: error spec adherence & migration check script.
 - [ ] Verify: CI dry-run locally.
 - [ ] Docs: contributing & release process.
+ - [x] Implement: easy-setup helper/CLI to scaffold CI, checks, and OpenAPI lint steps. (see dx/add.py)
 
 ### 10. Docs & SDKs
 - [ ] Research: existing OpenAPI & docs endpoints.
@@ -142,6 +151,7 @@ Comprehensive checklist for making the framework production-ready. Each section 
 - [ ] Tests: OpenAPI lint, SDK smoke import & sample call.
 - [ ] Verify: docs test marker / manual review.
 - [ ] Docs: Developer quickstart & API usage.
+ - [x] Implement: easy-setup helper to mount docs endpoints and run SDK generation. (see api/fastapi/docs/add.py)
 
 ---
 ## Nice-to-have (Fast Follows)

--- a/src/svc_infra/api/fastapi/docs/add.py
+++ b/src/svc_infra/api/fastapi/docs/add.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI
+
+
+def add_docs(
+    app: FastAPI,
+    *,
+    redoc_url: str = "/redoc",
+    swagger_url: str = "/docs",
+    openapi_url: str = "/openapi.json",
+    export_openapi_to: Optional[str] = None,
+) -> None:
+    """Enable docs endpoints and optionally export OpenAPI schema to disk on startup."""
+    # Configure FastAPI docs URLs
+    app.docs_url = swagger_url
+    app.redoc_url = redoc_url
+    app.openapi_url = openapi_url
+
+    if export_openapi_to:
+        export_path = Path(export_openapi_to)
+
+        @app.on_event("startup")
+        async def _export_spec() -> None:  # noqa: ANN202
+            spec = app.openapi()
+            export_path.parent.mkdir(parents=True, exist_ok=True)
+            export_path.write_text(json.dumps(spec, indent=2))
+
+
+def add_sdk_generation_stub(
+    app: FastAPI,
+    *,
+    on_generate: Optional[callable] = None,
+    openapi_path: str = "/openapi.json",
+) -> None:
+    """Hook to add an SDK generation stub.
+
+    Provide `on_generate()` to run generation (e.g., openapi-generator). This is a stub only; we
+    don't ship a hard dependency. If `on_generate` is provided, we expose `/_docs/generate-sdk`.
+    """
+    from svc_infra.api.fastapi.dual.public import public_router
+
+    if not on_generate:
+        return
+
+    router = public_router(prefix="/_docs", include_in_schema=False)
+
+    @router.post("/generate-sdk")
+    async def _generate() -> dict:  # noqa: ANN201
+        on_generate()
+        return {"status": "ok"}
+
+    app.include_router(router)
+
+
+__all__ = ["add_docs", "add_sdk_generation_stub"]

--- a/src/svc_infra/api/fastapi/ops/add.py
+++ b/src/svc_infra/api/fastapi/ops/add.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+from typing import Callable
+
+from fastapi import FastAPI, HTTPException, Request
+from starlette.responses import JSONResponse
+
+
+def add_probes(
+    app: FastAPI,
+    *,
+    prefix: str = "/_ops",
+    include_in_schema: bool = False,
+) -> None:
+    """Mount basic liveness/readiness/startup probes under prefix."""
+    from svc_infra.api.fastapi.dual.public import public_router
+
+    router = public_router(prefix=prefix, tags=["ops"], include_in_schema=include_in_schema)
+
+    @router.get("/live")
+    async def live() -> JSONResponse:  # noqa: D401, ANN201
+        return JSONResponse({"status": "ok"})
+
+    @router.get("/ready")
+    async def ready() -> JSONResponse:  # noqa: D401, ANN201
+        # In the future, add checks (DB ping, cache ping) via DI hooks.
+        return JSONResponse({"status": "ok"})
+
+    @router.get("/startup")
+    async def startup_probe() -> JSONResponse:  # noqa: D401, ANN201
+        return JSONResponse({"status": "ok"})
+
+    app.include_router(router)
+
+
+def add_maintenance_mode(app: FastAPI, *, env_var: str = "MAINTENANCE_MODE") -> None:
+    """Enable a simple maintenance gate controlled by an env var.
+
+    When MAINTENANCE_MODE is truthy, all non-GET requests return 503.
+    """
+
+    @app.middleware("http")
+    async def _maintenance_gate(request: Request, call_next):  # noqa: ANN001, ANN202
+        flag = str(os.getenv(env_var, "")).lower() in {"1", "true", "yes", "on"}
+        if flag and request.method not in {"GET", "HEAD", "OPTIONS"}:
+            return JSONResponse({"detail": "maintenance"}, status_code=503)
+        return await call_next(request)
+
+
+def circuit_breaker_dependency(limit: int = 100, window_seconds: int = 60) -> Callable:
+    """Return a dependency that can trip rejective errors based on external metrics.
+
+    This is a placeholder; callers can swap with a provider that tracks failures and opens the
+    breaker. Here, we read an env var to simulate an open breaker.
+    """
+
+    async def _dep(_: Request) -> None:  # noqa: D401, ANN202
+        if str(os.getenv("CIRCUIT_OPEN", "")).lower() in {"1", "true", "yes", "on"}:
+            raise HTTPException(status_code=503, detail="circuit open")
+
+    return _dep
+
+
+__all__ = ["add_probes", "add_maintenance_mode", "circuit_breaker_dependency"]

--- a/src/svc_infra/data/add.py
+++ b/src/svc_infra/data/add.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Callable, Iterable, Optional
+
+from fastapi import FastAPI
+
+from svc_infra.cli.cmds.db.sql.alembic_cmds import cmd_setup_and_migrate
+
+
+def add_data_lifecycle(
+    app: FastAPI,
+    *,
+    auto_migrate: bool = True,
+    database_url: str | None = None,
+    discover_packages: Optional[list[str]] = None,
+    with_payments: bool | None = None,
+    on_load_fixtures: Optional[Callable[[], None]] = None,
+    retention_jobs: Optional[Iterable[Callable[[], None]]] = None,
+    erasure_job: Optional[Callable[[str], None]] = None,
+) -> None:
+    """
+    Wire data lifecycle conveniences:
+
+    - auto_migrate: run end-to-end Alembic setup-and-migrate on startup (idempotent).
+    - on_load_fixtures: optional callback to load reference/fixture data once at startup.
+    - retention_jobs: optional list of callables to register purge tasks (scheduler integration is external).
+    - erasure_job: optional callable to trigger a GDPR erasure workflow for a given principal ID.
+
+    This helper is intentionally minimal: it coordinates existing building blocks
+    and offers extension points. Jobs should be scheduled using svc_infra.jobs helpers.
+    """
+
+    @app.on_event("startup")
+    async def _data_lifecycle_startup() -> None:  # noqa: D401, ANN202
+        if auto_migrate:
+            # Use existing CLI function to perform end-to-end setup and migrate.
+            cmd_setup_and_migrate(
+                database_url=database_url,
+                overwrite_scaffold=False,
+                create_db_if_missing=True,
+                create_followup_revision=True,
+                initial_message="initial schema",
+                followup_message="autogen",
+                discover_packages=discover_packages,
+                with_payments=with_payments,
+            )
+
+        if on_load_fixtures:
+            # Run user-provided fixture loader (idempotent expected).
+            on_load_fixtures()
+
+    # Store optional jobs on app.state for external schedulers to discover/register.
+    if retention_jobs is not None:
+        app.state.data_retention_jobs = list(retention_jobs)
+    if erasure_job is not None:
+        app.state.data_erasure_job = erasure_job
+
+
+__all__ = ["add_data_lifecycle"]

--- a/src/svc_infra/dx/add.py
+++ b/src/svc_infra/dx/add.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def write_ci_workflow(
+    *,
+    target_dir: str | Path,
+    name: str = "ci.yml",
+    python_version: str = "3.12",
+) -> Path:
+    """Write a minimal CI workflow file (GitHub Actions) with tests/lint/type steps."""
+    p = Path(target_dir) / ".github" / "workflows" / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    content = f"""
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '{python_version}'
+      - name: Install Poetry
+        run: pipx install poetry
+      - name: Install deps
+        run: poetry install
+      - name: Lint
+        run: poetry run flake8 --select=E,F
+      - name: Typecheck
+        run: poetry run mypy src
+      - name: Tests
+        run: poetry run pytest -q -W error
+"""
+    p.write_text(content.strip() + "\n")
+    return p
+
+
+def write_openapi_lint_config(*, target_dir: str | Path, name: str = ".redocly.yaml") -> Path:
+    """Write a minimal OpenAPI lint config placeholder (Redocly)."""
+    p = Path(target_dir) / name
+    content = """
+apis:
+  main:
+    root: openapi.json
+
+rules:
+  operation-operationId: warn
+  no-unused-components: warn
+  security-defined: off
+"""
+    p.write_text(content.strip() + "\n")
+    return p
+
+
+__all__ = ["write_ci_workflow", "write_openapi_lint_config"]


### PR DESCRIPTION
This pull request adds a suite of "easy-setup" helpers and stubs to streamline integration of key production-readiness features in the framework. These helpers enable one-line configuration for docs endpoints, data lifecycle management, operational probes, maintenance mode, circuit breaker, and developer experience (DX) quality gates. The changes focus on improving developer ergonomics and reducing boilerplate for common infrastructure tasks.

**New easy-setup helpers and stubs:**

* **Docs & SDKs Integration**
  - Added `add_docs` and `add_sdk_generation_stub` helpers in `src/svc_infra/api/fastapi/docs/add.py` to mount docs endpoints (Swagger, Redoc, OpenAPI), export OpenAPI schema on startup, and provide a stub for SDK generation.
* **Operational Readiness**
  - Added `add_probes`, `add_maintenance_mode`, and `circuit_breaker_dependency` helpers in `src/svc_infra/api/fastapi/ops/add.py` for liveness/readiness probes, maintenance mode via env var, and circuit breaker dependency injection.
* **Data Lifecycle Management**
  - Added `add_data_lifecycle` helper in `src/svc_infra/data/add.py` to wire up migrations, fixture loading, retention jobs, and erasure workflows on FastAPI startup.
* **Developer Experience & Quality Gates**
  - Added `write_ci_workflow` and `write_openapi_lint_config` helpers in `src/svc_infra/dx/add.py` to scaffold a CI workflow file and OpenAPI lint config for DX automation.

**Checklist and documentation updates:**

* Updated `.github/instructions/PLANS.md` to reflect the addition of easy-setup helpers for docs, ops, data lifecycle, tenancy, idempotency, job queueing, rate limiting, and CI/DX tasks, with references to the new helpers and stubs. [[1]](diffhunk://#diff-87e28ffff424e9bd82b373f3fde42b4f75966bd8c0f99131cafb2c7f18c1d8b7R32) [[2]](diffhunk://#diff-87e28ffff424e9bd82b373f3fde42b4f75966bd8c0f99131cafb2c7f18c1d8b7R48) [[3]](diffhunk://#diff-87e28ffff424e9bd82b373f3fde42b4f75966bd8c0f99131cafb2c7f18c1d8b7R60) [[4]](diffhunk://#diff-87e28ffff424e9bd82b373f3fde42b4f75966bd8c0f99131cafb2c7f18c1d8b7R79) [[5]](diffhunk://#diff-87e28ffff424e9bd82b373f3fde42b4f75966bd8c0f99131cafb2c7f18c1d8b7R91) [[6]](diffhunk://#diff-87e28ffff424e9bd82b373f3fde42b4f75966bd8c0f99131cafb2c7f18c1d8b7R106) [[7]](diffhunk://#diff-87e28ffff424e9bd82b373f3fde42b4f75966bd8c0f99131cafb2c7f18c1d8b7R119) [[8]](diffhunk://#diff-87e28ffff424e9bd82b373f3fde42b4f75966bd8c0f99131cafb2c7f18c1d8b7R130) [[9]](diffhunk://#diff-87e28ffff424e9bd82b373f3fde42b4f75966bd8c0f99131cafb2c7f18c1d8b7R142) [[10]](diffhunk://#diff-87e28ffff424e9bd82b373f3fde42b4f75966bd8c0f99131cafb2c7f18c1d8b7R154)