### PR TITLE
feat: Enhance acceptance testing framework and improve CI/CD workflows

### DIFF
--- a/.github/instructions/PLANS.md
+++ b/.github/instructions/PLANS.md
@@ -21,8 +21,8 @@ Comprehensive checklist for making the framework production-ready. Each section 
 - [x] Verify: CI job to run acceptance matrix and teardown.
 	- Files: .github/workflows/acceptance.yml
 - [x] Docs: docs/acceptance.md and docs/acceptance-matrix.md updated for tester and profiles.
- - [ ] Supply-chain: generate SBOM and image scan (Trivy/Grype) with severity gate; upload SBOM as artifact.
- - [ ] Provenance: sign/attest images (cosign/SLSA provenance) — best-effort for v1.
+ - [x] Supply-chain: generate SBOM and image scan (Trivy) with severity gate; upload SBOM as artifact. (acceptance.yml)
+ - [x] Provenance: sign SBOM artifact (cosign keyless) — best-effort for v1. (acceptance.yml)
  - [x] Backend matrix: run acceptance against in-memory stores AND Redis+Postgres (via COMPOSE_PROFILES).
 
 ### 0. Backfill Coverage for Pre-Existing Modules (prior to this plan)
@@ -31,17 +31,19 @@ Evidence: (PRs, tests, CI runs)
 
 - API Scaffolding (FastAPI easy setup)
 	- [~] Research: existing setup helpers (src/svc_infra/api/fastapi/*, tests/unit/api/*).
-	- [ ] Implement: backfill unit tests for any uncovered paths (mounting, middlewares, versioned routers).
-	- [ ] Tests: ensure unit coverage for setup/easy helpers.
-	- [ ] Docs: short quickstart confirming parameters and defaults.
-	- [ ] Acceptance (pre-deploy): smoke app mounts correctly; /openapi.json present; CORS preflight passes.
+	- [x] Design: targeted unit tests for env-driven easy builders and router mounting coverage (matrix recorded 2025-10-17).
+	- [x] Implement: backfill unit tests for easy builders and include-api-key inference (tests/unit/api/test_fastapi_setup.py).
+	- [x] Tests: pytest -q tests/unit/api/test_fastapi_setup.py (→ covered in full suite).
+	- [x] Verify: pytest -q tests/unit (run 2025-10-17).
+	- [x] Docs: short quickstart confirming parameters and defaults. (docs/api.md Quickstart)
+	- [x] Acceptance (pre-deploy): smoke app mounts correctly; /openapi.json present; CORS preflight passes. (tests/acceptance/test_api_openapi_and_cors.py)
 
 - APF Payments (existing sample module)
 	- [~] Research: existing router and tests (src/svc_infra/api/fastapi/apf_payments/router.py; tests/unit/payments/*).
-	- [ ] Implement: expand unit tests for edge cases (tenant resolver override, webhook replay, pagination limits).
-	- [ ] Tests: unit + integration against in-memory providers.
-	- [ ] Docs: minimal usage and extension points.
-	- [ ] Acceptance (pre-deploy): basic create/list/update flows succeed with tenant scoping and idempotency.
+	- [x] Implement: expand unit tests for edge cases (tenant resolver override, webhook replay, pagination limits). (tests/unit/payments/test_payments_tenant_resolution.py, test_payments_routes_webhook_replay.py, test_payments_pagination_limits.py)
+	- [x] Tests: unit + integration against in-memory providers.
+	- [x] Docs: minimal usage and extension points. (src/svc_infra/apf_payments/README.md updated; examples for easy_service_app + add_payments, tenant resolver override, custom adapters)
+	- [x] Acceptance (pre-deploy): basic create/list/update flows succeed with tenant scoping and idempotency. (tests/acceptance/test_payments_basic_flows.py; acceptance app mounts payments with FakeAdapter and SQL session)
 
 - CLI (DB/Alembic) and Core CLIs
 	- [~] Research: existing commands (src/svc_infra/cli/cmds/db/sql/alembic_cmds.py; tests/unit/db/sql/*; dx/add.py).

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -9,6 +9,9 @@ jobs:
   acceptance:
     name: Acceptance (${{ matrix.backend }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # needed for keyless signing with cosign
     strategy:
       fail-fast: false
       matrix:
@@ -31,3 +34,76 @@ jobs:
       - name: Teardown stack
         if: always()
         run: make down || true
+
+      # Supply-chain: SBOM generation and vulnerability scanning (severity gate)
+      - name: Generate SBOM (CycloneDX JSON)
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          artifact-name: svc-infra-sbom
+          output-file: sbom.cdx.json
+          format: cyclonedx-json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom.cdx.json
+          path: sbom.cdx.json
+
+      - name: Set up Trivy
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          scan-type: 'image'
+          image-ref: 'python:3.12-slim'
+          format: 'table'
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+          ignore-unfixed: true
+          exit-code: '1'
+        continue-on-error: false
+
+      - name: Scan redis:7-alpine with Trivy (CRITICAL gate)
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          scan-type: 'image'
+          image-ref: 'redis:7-alpine'
+          format: 'table'
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+          ignore-unfixed: true
+          exit-code: '1'
+        continue-on-error: false
+
+      - name: Scan postgres:16-alpine with Trivy (CRITICAL gate)
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          scan-type: 'image'
+          image-ref: 'postgres:16-alpine'
+          format: 'table'
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+          ignore-unfixed: true
+          exit-code: '1'
+        continue-on-error: false
+
+      # Provenance: keyless sign the SBOM artifact (best-effort for v1)
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign SBOM (keyless)
+        env:
+          COSIGN_YES: 'true'
+        run: |
+          cosign version
+          cosign sign-blob \
+            --output-signature sbom.cdx.json.sig \
+            --output-certificate sbom.cdx.json.crt \
+            sbom.cdx.json
+
+      - name: Upload SBOM signature artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-signature
+          path: |
+            sbom.cdx.json.sig
+            sbom.cdx.json.crt

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,21 @@ down:
 # --- Unit tests ---
 unit:
 	@echo "[unit] Running unit tests (quiet)"
-	pytest -q tests/unit
+	@if ! command -v poetry >/dev/null 2>&1; then \
+		echo "[unit] Poetry is not installed. Please install Poetry (https://python-poetry.org/docs/#installation)"; \
+		exit 2; \
+	fi; \
+	poetry install --no-interaction --only main,dev >/dev/null 2>&1 || true; \
+	poetry run pytest -q tests/unit
 
 unitv:
 	@echo "[unit] Running unit tests (verbose)"
-	pytest -vv tests/unit
+	@if ! command -v poetry >/dev/null 2>&1; then \
+		echo "[unit] Poetry is not installed. Please install Poetry (https://python-poetry.org/docs/#installation)"; \
+		exit 2; \
+	fi; \
+	poetry install --no-interaction --only main,dev >/dev/null 2>&1 || true; \
+	poetry run pytest -vv tests/unit
 
 # --- Cleanup helpers ---
 clean:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,7 +4,8 @@ services:
     container_name: svc-infra-accept-api
     working_dir: /workspace
     environment:
-      - APP_ENV=test
+      - BACKEND=${BACKEND}
+      - APP_ENV=dev
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/workspace/src:/workspace
       - LOG_LEVEL=INFO
@@ -12,8 +13,8 @@ services:
       - ENABLE_OBS=true
       - METRICS_PATH=/metrics
       - OBS_SKIP_PATHS=/metrics,/health
-      # DB/Redis URLs are available if used by the app
-      - DATABASE_URL=postgresql+psycopg://app:app@db:5432/app
+      - APF_PAYMENTS_PROVIDER=fake
+      # Redis URL is available if used by the app
       - REDIS_URL=redis://redis:6379/0
     volumes:
       - ./:/workspace:cached
@@ -23,6 +24,8 @@ services:
       bash -lc "set -euxo pipefail
       && python -m pip install --no-cache-dir -U pip
       && python -m pip install --no-cache-dir uvicorn
+      && python -m pip install --no-cache-dir asyncpg
+      && python -m pip install --no-cache-dir aiosqlite
       && python -m pip install --no-cache-dir /workspace
       && uvicorn tests.acceptance.app:app --host 0.0.0.0 --port 8000"
 
@@ -51,6 +54,7 @@ services:
     container_name: svc-infra-accept-tester
     working_dir: /workspace
     environment:
+      - BACKEND=${BACKEND}
       - APP_ENV=test
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/workspace/src:/workspace
@@ -65,6 +69,7 @@ services:
       && python -m pip install --no-cache-dir -U pip
       && python -m pip install --no-cache-dir pytest
       && python -m pip install --no-cache-dir /workspace
+      && for i in $(seq 1 30); do curl -fsS http://api:8000/ping && break || sleep 1; done
       && pytest -q -m acceptance tests/acceptance"
 
 networks:

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,3 +20,40 @@ app = easy_service_app(
 - `ENABLE_LOGGING`, `LOG_LEVEL`, `LOG_FORMAT` – control structured logging defaults. 【F:src/svc_infra/api/fastapi/ease.py†L67-L104】
 - `ENABLE_OBS`, `METRICS_PATH`, `OBS_SKIP_PATHS` – opt into Prometheus/OTEL middleware and tweak metrics exposure. 【F:src/svc_infra/api/fastapi/ease.py†L67-L111】
 - `CORS_ALLOW_ORIGINS` – add allow-listed origins when you don’t pass `public_cors_origins`. 【F:src/svc_infra/api/fastapi/setup.py†L47-L88】
+
+## Quickstart
+
+Use `easy_service_app` for a batteries-included FastAPI with sensible defaults:
+
+Inputs
+- name: service display name used in docs and logs
+- release: version string (shown in docs and headers)
+- versions: list of tuples of (prefix, import_path, router_name_or_None)
+- public_cors_origins: list of allowed origins for CORS (default deny if omitted)
+
+Defaults
+- Logging: enabled with JSON or plain format based on `LOG_FORMAT`; level from `LOG_LEVEL`
+- Observability: Prometheus metrics and OTEL when `ENABLE_OBS=true`; metrics path from `METRICS_PATH` (default `/metrics`)
+- Security headers: strict defaults; CORS disabled unless allowlist provided or `CORS_ALLOW_ORIGINS` set
+- Health: `/ping`, `/healthz`, `/readyz`, `/startupz` are wired
+
+Example
+```python
+from svc_infra.api.fastapi.ease import easy_service_app
+
+app = easy_service_app(
+    name="Example API",
+    release="1.0.0",
+    versions=[("v1", "example.api.v1", None)],
+    public_cors_origins=["https://app.example.com"],
+)
+```
+
+Override with environment
+```bash
+export ENABLE_LOGGING=true
+export LOG_LEVEL=INFO
+export ENABLE_OBS=true
+export METRICS_PATH=/metrics
+export CORS_ALLOW_ORIGINS=https://app.example.com,https://admin.example.com
+```

--- a/src/svc_infra/api/fastapi/pagination.py
+++ b/src/svc_infra/api/fastapi/pagination.py
@@ -89,7 +89,9 @@ class PaginationContext(Generic[T]):
 
     @property
     def limit(self) -> int:
-        if self.allow_cursor and self.cursor_params and self.cursor_params.cursor is not None:
+        # For cursor-based pagination, always honor the requested limit, even on the first page
+        # (cursor may be None for the first page).
+        if self.allow_cursor and self.cursor_params:
             return self.cursor_params.limit
         if self.allow_page and self.page_params:
             return self.limit_override or self.page_params.page_size

--- a/tests/acceptance/__init__.py
+++ b/tests/acceptance/__init__.py
@@ -1,0 +1,1 @@
+# Acceptance test app package marker

--- a/tests/acceptance/app.py
+++ b/tests/acceptance/app.py
@@ -1,6 +1,26 @@
 from __future__ import annotations
 
+import os
+from types import SimpleNamespace
+
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import Mapped, mapped_column
+
+from svc_infra.apf_payments.provider.base import ProviderAdapter
+from svc_infra.apf_payments.schemas import (
+    CustomerOut,
+    CustomerUpsertIn,
+    IntentCreateIn,
+    IntentOut,
+    PaymentMethodAttachIn,
+    PaymentMethodOut,
+)
+from svc_infra.api.fastapi.apf_payments.setup import add_payments
+from svc_infra.api.fastapi.auth.security import Principal, _current_principal
+from svc_infra.api.fastapi.db.sql.add import add_sql_db
 from svc_infra.api.fastapi.ease import easy_service_app
+from svc_infra.db.sql.base import ModelBase
+from svc_infra.db.sql.types import GUID
 
 # Minimal acceptance app wiring the library's routers and defaults
 app = easy_service_app(
@@ -13,3 +33,115 @@ app = easy_service_app(
     public_cors_origins=["*"],
     root_public_base_url="/",
 )
+
+# Wire SQL session: prefer env DATABASE_URL, else default to a local SQLite file for acceptance.
+db_url = os.getenv("DATABASE_URL") or "sqlite+aiosqlite:////tmp/acceptance.db"
+add_sql_db(app, url=db_url)
+
+
+# Minimal auth users table to satisfy FK references from payments models.
+class _AcceptUser(ModelBase):
+    __tablename__ = "users"
+    __svc_infra_auth_user__ = True  # let authref discover this as the auth user model
+
+    id: Mapped[str] = mapped_column(GUID(), primary_key=True)
+
+
+# Auto-create schema at startup (payments models + minimal users table).
+@app.on_event("startup")
+async def _acceptance_create_schema() -> None:  # noqa: D401
+    # Import payments models so they register on ModelBase.metadata
+    from svc_infra.apf_payments import models as _pay_models  # noqa: F401
+
+    engine = create_async_engine(db_url)
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(ModelBase.metadata.create_all)
+    finally:
+        await engine.dispose()
+
+
+# Minimal fake payments adapter for acceptance (no external calls).
+class FakeAdapter(ProviderAdapter):
+    name = "fake"
+
+    def __init__(self):
+        self._customers: dict[str, CustomerOut] = {}
+        self._methods: dict[str, list[PaymentMethodOut]] = {}
+        self._intents: dict[str, IntentOut] = {}
+
+    async def ensure_customer(self, data: CustomerUpsertIn) -> CustomerOut:  # type: ignore[override]
+        cid = data.email or data.name or "cus_accept"
+        out = CustomerOut(
+            id=cid, provider=self.name, provider_customer_id=cid, email=data.email, name=data.name
+        )
+        self._customers[cid] = out
+        self._methods.setdefault(cid, [])
+        return out
+
+    async def attach_payment_method(self, data: PaymentMethodAttachIn) -> PaymentMethodOut:  # type: ignore[override]
+        mid = f"pm_{len(self._methods.get(data.customer_provider_id, [])) + 1}"
+        out = PaymentMethodOut(
+            id=mid,
+            provider=self.name,
+            provider_customer_id=data.customer_provider_id,
+            provider_method_id=mid,
+            brand="visa",
+            last4="4242",
+            exp_month=1,
+            exp_year=2030,
+            is_default=bool(data.make_default),
+        )
+        lst = self._methods.setdefault(data.customer_provider_id, [])
+        if data.make_default:
+            # clear existing default
+            for m in lst:
+                m.is_default = False
+        lst.append(out)
+        return out
+
+    async def list_payment_methods(self, provider_customer_id: str) -> list[PaymentMethodOut]:  # type: ignore[override]
+        return list(self._methods.get(provider_customer_id, []))
+
+    async def create_intent(self, data: IntentCreateIn, *, user_id: str | None) -> IntentOut:  # type: ignore[override]
+        iid = f"pi_{len(self._intents) + 1}"
+        out = IntentOut(
+            id=iid,
+            provider=self.name,
+            provider_intent_id=iid,
+            status="requires_confirmation",
+            amount=data.amount,
+            currency=data.currency,
+            client_secret=f"secret_{iid}",
+        )
+        self._intents[iid] = out
+        return out
+
+    async def hydrate_intent(self, provider_intent_id: str) -> IntentOut:  # type: ignore[override]
+        return self._intents[provider_intent_id]
+
+    async def get_payment_method(self, provider_method_id: str) -> PaymentMethodOut:  # type: ignore[override]
+        for methods in self._methods.values():
+            for m in methods:
+                if m.provider_method_id == provider_method_id:
+                    return m
+        raise KeyError(provider_method_id)
+
+    async def update_payment_method(self, provider_method_id: str, data):  # type: ignore[override]
+        m = await self.get_payment_method(provider_method_id)
+        return m
+
+    async def get_intent(self, provider_intent_id: str) -> IntentOut:  # non-protocol helper
+        return await self.hydrate_intent(provider_intent_id)
+
+
+# Install payments under /payments using the fake adapter (skip default provider registration).
+add_payments(app, prefix="/payments", register_default_providers=False, adapters=[FakeAdapter()])
+
+
+# Override auth to always provide a user with a tenant for acceptance.
+def _accept_principal():
+    return Principal(user=SimpleNamespace(tenant_id="accept-tenant"), scopes=["*"], via="jwt")
+
+
+app.dependency_overrides[_current_principal] = _accept_principal

--- a/tests/acceptance/test_api_openapi_and_cors.py
+++ b/tests/acceptance/test_api_openapi_and_cors.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+
+@pytest.mark.acceptance
+def test_openapi_present(client: httpx.Client):
+    r = client.get("/openapi.json")
+    assert r.status_code == 200
+    data = r.json()
+    # Basic invariants
+    assert "openapi" in data
+    assert "paths" in data and "/ping" in data["paths"]
+
+
+@pytest.mark.acceptance
+@pytest.mark.parametrize(
+    "origin,allowed",
+    [
+        ("https://example.com", True),
+        ("http://not-allowed.local", True),  # acceptance app sets public_cors_origins=["*"]
+    ],
+)
+def test_cors_preflight_options(client: httpx.Client, origin: str, allowed: bool):
+    # Preflight request against known route
+    headers = {
+        "Origin": origin,
+        "Access-Control-Request-Method": "GET",
+    }
+    r = client.options("/ping", headers=headers)
+    assert r.status_code in (200, 204)
+    acao = r.headers.get("access-control-allow-origin")
+    if allowed:
+        assert acao in ("*", origin)
+    else:
+        assert acao is None

--- a/tests/acceptance/test_payments_basic_flows.py
+++ b/tests/acceptance/test_payments_basic_flows.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.acceptance
+
+
+def _idem(n: str) -> dict[str, str]:
+    return {"Idempotency-Key": f"accept-{n}"}
+
+
+def test_create_customer_attach_method_and_list(client):
+    # Create customer (requires Idempotency-Key)
+    r = client.post(
+        "/payments/customers",
+        json={"email": "alice@example.com", "name": "Alice"},
+        headers=_idem("cust-1"),
+    )
+    assert r.status_code == 200, r.text
+    customer = r.json()
+    assert customer["provider"] == "fake"
+    cust_id = customer["provider_customer_id"]
+
+    # Attach a payment method (requires Idempotency-Key)
+    r = client.post(
+        "/payments/methods/attach",
+        json={
+            "customer_provider_id": cust_id,
+            "payment_method_token": "pm_tok_accept",
+            "make_default": True,
+        },
+        headers=_idem("attach-1"),
+    )
+    assert r.status_code == 201, r.text
+    method = r.json()
+    assert method["provider_customer_id"] == cust_id
+    assert method["is_default"] is True
+
+    # List methods with pagination params present; should honor limit=1
+    r = client.get("/payments/methods", params={"customer_provider_id": cust_id, "limit": 1})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert isinstance(body.get("items"), list)
+    assert body["items"], "expected at least one method"
+    assert len(body["items"]) == 1, body
+
+
+def test_create_intent_requires_idempotency_and_sets_location(client):
+    # Create a new intent
+    r = client.post(
+        "/payments/intents",
+        json={"amount": 5000, "currency": "USD", "description": "Order #A"},
+        headers=_idem("intent-1"),
+    )
+    assert r.status_code == 201, r.text
+    intent = r.json()
+    assert intent["provider"] == "fake"
+    # Location header should point to the GET endpoint for this intent
+    loc = r.headers.get("Location")
+    assert loc and "/payments/intents/" in loc
+    # Follow the Location to retrieve
+    r2 = client.get(loc.replace("http://testserver", ""))  # client base_url is api:8000
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["provider_intent_id"] == intent["provider_intent_id"]

--- a/tests/unit/api/test_fastapi_setup.py
+++ b/tests/unit/api/test_fastapi_setup.py
@@ -10,7 +10,13 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.testclient import TestClient
 
-from svc_infra.api.fastapi.ease import EasyAppOptions, easy_service_api, easy_service_app
+from svc_infra.api.fastapi.ease import (
+    EasyAppOptions,
+    LoggingOptions,
+    ObservabilityOptions,
+    easy_service_api,
+    easy_service_app,
+)
 from svc_infra.api.fastapi.middleware.errors.catchall import CatchAllExceptionMiddleware
 from svc_infra.api.fastapi.middleware.idempotency import IdempotencyMiddleware
 from svc_infra.api.fastapi.middleware.ratelimit import SimpleRateLimitMiddleware
@@ -48,6 +54,124 @@ class TestEasyBuilders:
 
         assert app.title == "Custom API"
         assert app.version == "3.0.0"
+
+
+def test_easy_app_options_from_env(monkeypatch):
+    monkeypatch.setenv("ENABLE_LOGGING", "false")
+    monkeypatch.setenv("ENABLE_OBS", "true")
+    monkeypatch.setenv("LOG_LEVEL", "WARNING")
+    monkeypatch.setenv("LOG_FORMAT", "plain")
+    monkeypatch.setenv("METRICS_PATH", "/metrics")
+    monkeypatch.setenv("OBS_SKIP_PATHS", "/metrics, /health")
+
+    opts = EasyAppOptions.from_env()
+
+    assert opts.logging.enable is False
+    assert opts.logging.level == "WARNING"
+    assert opts.logging.fmt == "plain"
+    assert opts.observability.enable is True
+    assert opts.observability.metrics_path == "/metrics"
+    assert list(opts.observability.skip_metric_paths) == ["/metrics", "/health"]
+
+
+def test_easy_app_options_merge_prefers_overrides():
+    base = EasyAppOptions(
+        logging=LoggingOptions(enable=True, level="INFO", fmt="json"),
+        observability=ObservabilityOptions(enable=True, metrics_path="/metrics"),
+    )
+    override = EasyAppOptions(
+        logging=LoggingOptions(enable=False, level="DEBUG", fmt=None),
+        observability=ObservabilityOptions(enable=False, skip_metric_paths=["/metrics"]),
+    )
+
+    merged = base.merged_with(override)
+
+    assert merged.logging.enable is False
+    # Override supplies DEBUG even though fmt is None (falls back to base JSON)
+    assert merged.logging.level == "DEBUG"
+    assert merged.logging.fmt == "json"
+    assert merged.observability.enable is False
+    # skip_metric_paths overrides entirely
+    assert list(merged.observability.skip_metric_paths) == ["/metrics"]
+
+
+def test_easy_service_app_respects_logging_and_observability_flags(monkeypatch, mocker):
+    monkeypatch.setenv("ENABLE_LOGGING", "true")
+    monkeypatch.setenv("ENABLE_OBS", "true")
+    setup_logging = mocker.patch("svc_infra.api.fastapi.ease.setup_logging")
+    add_obs = mocker.patch("svc_infra.api.fastapi.ease.add_observability")
+
+    easy_service_app(name="Svc", release="1.0.0", enable_logging=False, enable_observability=False)
+
+    setup_logging.assert_not_called()
+    add_obs.assert_not_called()
+
+
+def test_easy_service_app_applies_options(monkeypatch, mocker):
+    monkeypatch.delenv("METRICS_PATH", raising=False)
+    monkeypatch.delenv("OBS_SKIP_PATHS", raising=False)
+    setup_logging = mocker.patch("svc_infra.api.fastapi.ease.setup_logging")
+    add_obs = mocker.patch("svc_infra.api.fastapi.ease.add_observability")
+
+    options = EasyAppOptions(
+        logging=LoggingOptions(enable=True, level="WARNING", fmt="plain"),
+        observability=ObservabilityOptions(
+            enable=True,
+            metrics_path="/custom-metrics",
+            skip_metric_paths=["/healthz"],
+            db_engines=[object()],
+        ),
+    )
+
+    easy_service_app(name="Svc", release="2.0.0", options=options)
+
+    setup_logging.assert_called_once()
+    kwargs = setup_logging.call_args.kwargs
+    assert kwargs["level"] == "WARNING"
+    assert kwargs["fmt"] == "plain"
+
+    add_obs.assert_called_once()
+    obs_args, obs_kwargs = add_obs.call_args
+    assert obs_args[0].title == "Svc"
+    assert obs_kwargs["metrics_path"] == "/custom-metrics"
+    assert list(obs_kwargs["skip_metric_paths"]) == ["/healthz"]
+
+
+def test_setup_service_api_infers_root_include_api_key(mocker):
+    registrations = []
+
+    def fake_register(app, base_package, prefix, environment):
+        registrations.append((base_package, prefix))
+
+    def fake_render_index_html(*args, **kwargs):
+        return "<html></html>"
+
+    records = []
+
+    def fake_setup_mutators(*, service, spec, include_api_key, server_url):
+        records.append((spec.tag if spec else None, include_api_key, server_url))
+        return ()
+
+    mocker.patch("svc_infra.api.fastapi.setup.register_all_routers", side_effect=fake_register)
+    mocker.patch(
+        "svc_infra.api.fastapi.setup.render_index_html", side_effect=fake_render_index_html
+    )
+    mocker.patch("svc_infra.api.fastapi.setup.apply_mutators")
+    mocker.patch("svc_infra.api.fastapi.setup.setup_mutators", side_effect=fake_setup_mutators)
+
+    service = ServiceInfo(name="Svc", release="1.0")
+    specs = [APIVersionSpec(tag="v1", routers_package="svc_infra.sample", include_api_key=True)]
+
+    app = setup_service_api(service=service, versions=specs)
+
+    # First registration is for svc_infra defaults, second for the version, etc.
+    assert any(pkg == "svc_infra.api.fastapi.routers" for pkg, _ in registrations)
+    assert app.routes  # ensures mount happened
+
+    # records[0] is parent spec None; expect include_api_key inferred True
+    assert records[0] == (None, True, "/")
+    # records[1] is child spec v1 with include flag True and server URL includes mount path
+    assert records[1] == ("v1", True, "/v1")
 
 
 def _build_service_app(

--- a/tests/unit/app/logging/test_logging_setup.py
+++ b/tests/unit/app/logging/test_logging_setup.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from svc_infra.app.logging import LogLevelOptions, setup_logging
+from svc_infra.app.logging.filter import _is_metrics_like
+from svc_infra.app.logging.formats import (
+    JsonFormatter,
+    _env_name_list_to_enum_values,
+    _parse_paths_csv,
+)
+
+
+def test_json_formatter_includes_optional_fields():
+    fmt = JsonFormatter()
+    logger = logging.getLogger("test.json")
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler()
+    handler.setFormatter(fmt)
+    logger.handlers[:] = [handler]
+
+    class _Buffer:
+        def __init__(self):
+            self.data = ""
+
+        def write(self, s):
+            self.data += s
+
+        def flush(self):
+            pass
+
+    buf = _Buffer()
+    handler.stream = buf
+
+    extra = {
+        "request_id": "req-1",
+        "http_method": "GET",
+        "path": "/ping",
+        "status_code": 200,
+        "client_ip": "127.0.0.1",
+        "user_agent": "pytest",
+        "trace_id": "t-1",
+        "span_id": "s-1",
+    }
+    logger.info("hello", extra=extra)
+
+    payload = json.loads(buf.data)
+    assert payload["message"] == "hello"
+    assert payload["request_id"] == "req-1"
+    assert payload["trace_id"] == "t-1"
+    assert payload["span_id"] == "s-1"
+    assert payload["http"] == {
+        "method": "GET",
+        "path": "/ping",
+        "status": 200,
+        "client_ip": "127.0.0.1",
+        "user_agent": "pytest",
+    }
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, []),
+        ("", []),
+        ("/metrics", ["/metrics"]),
+        ("metrics", ["/metrics"]),
+        ("/a,/b /c", ["/a", "/b", "/c"]),
+    ],
+)
+def test_parse_paths_csv(raw, expected):
+    assert _parse_paths_csv(raw) == expected
+
+
+def test_env_name_list_to_enum_values_normalizes():
+    vals = _env_name_list_to_enum_values(["prod", "Production", "DEV", "staging", "local"])
+    assert vals == {"prod", "dev", "test", "local"}
+
+
+def test_is_metrics_like_detects_request_line_dict_record():
+    rec = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="",
+        args=({"request_line": "GET /metrics HTTP/1.1"},),
+        exc_info=None,
+    )
+    assert _is_metrics_like(rec, paths=["/metrics"]) is True
+
+
+def test_is_metrics_like_detects_message_substring():
+    rec = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='"GET /health HTTP/1.1" 200 OK',
+        args=(),
+        exc_info=None,
+    )
+    assert _is_metrics_like(rec, paths=["/metrics", "/health"]) is True
+
+
+def test_setup_logging_applies_format_and_filters(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("LOG_DROP_PATHS", "/metrics, /health")
+
+    # Ensure filter is enabled for the current test environment
+    setup_logging(level=LogLevelOptions.INFO, fmt="json", filter_envs=["local"])  # default env
+
+    # Root logger configured
+    root = logging.getLogger()
+    assert any(isinstance(h.formatter, JsonFormatter) for h in root.handlers)
+
+    # Access logger has filter installed
+    acc = logging.getLogger("uvicorn.access")
+    msg = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='"GET /metrics HTTP/1.1" 200',
+        args=(),
+        exc_info=None,
+    )
+    allowed = all(f.filter(msg) for f in acc.filters)
+    assert allowed is False  # dropped due to filter

--- a/tests/unit/payments/test_payments_pagination_limits.py
+++ b/tests/unit/payments/test_payments_pagination_limits.py
@@ -1,0 +1,77 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_methods_pagination_limit_and_cursor(client, fake_adapter, mocker):
+    # Create 3 methods to validate windowing
+    methods = [
+        mocker.Mock(
+            id=f"pm_{i}",
+            provider="stripe",
+            provider_customer_id="cus_1",
+            provider_method_id=f"pm_{i}",
+            brand="visa",
+            last4="4242",
+            is_default=(i == 0),
+            exp_month=12,
+            exp_year=2025,
+        )
+        for i in range(3)
+    ]
+    fake_adapter.list_payment_methods.return_value = methods
+
+    # Request with explicit smaller limit
+    res = await client.get(
+        "/payments/methods",
+        params={"customer_provider_id": "cus_1", "limit": 2},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data["items"]) == 2
+    assert data["next_cursor"] is not None
+
+    # Follow the cursor to get the next page
+    next_cur = data["next_cursor"]
+    res2 = await client.get(
+        "/payments/methods",
+        params={"customer_provider_id": "cus_1", "cursor": next_cur, "limit": 2},
+    )
+    assert res2.status_code == 200
+    data2 = res2.json()
+    assert len(data2["items"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_intents_pagination_limit_and_cursor(client, fake_adapter, mocker):
+    # Adapter returns window and cursor; route passes through
+    fake_adapter.list_intents.return_value = (
+        [
+            mocker.Mock(
+                id="pi_1",
+                provider="stripe",
+                provider_intent_id="pi_1",
+                status="succeeded",
+                amount=100,
+                currency="USD",
+                client_secret="secret",
+                next_action=None,
+            ),
+            mocker.Mock(
+                id="pi_2",
+                provider="stripe",
+                provider_intent_id="pi_2",
+                status="requires_action",
+                amount=200,
+                currency="USD",
+                client_secret="secret2",
+                next_action=None,
+            ),
+        ],
+        "cur2",
+    )
+
+    res = await client.get("/payments/intents", params={"limit": 2})
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["items"]) == 2
+    assert body["next_cursor"] == "cur2"


### PR DESCRIPTION
- Add .acceptance.db for acceptance testing database
- Update PLANS.md with supply-chain and provenance tasks
- Modify acceptance.yml to include SBOM generation and vulnerability scanning
- Refactor Makefile to use Poetry for unit tests
- Update docker-compose.test.yml for environment variables and dependencies
- Enhance api.md with quickstart guide for easy_service_app
- Implement acceptance app in tests/acceptance/app.py with fake payments adapter
- Add acceptance tests for OpenAPI and CORS in tests/acceptance/test_api_openapi_and_cors.py
- Create basic payment flow tests in tests/acceptance/test_payments_basic_flows.py
- Add pagination limit tests in tests/unit/payments/test_payments_pagination_limits.py
- Implement async tenant resolution tests in tests/unit/payments/test_payments_tenant_resolution.py