### PR TITLE
Feat/prod readiness v1

### DIFF
--- a/.github/instructions/PLANS.md
+++ b/.github/instructions/PLANS.md
@@ -47,9 +47,9 @@ Evidence: (PRs, tests, CI runs)
 
 - CLI (DB/Alembic) and Core CLIs
 	- [~] Research: existing commands (src/svc_infra/cli/cmds/db/sql/alembic_cmds.py; tests/unit/db/sql/*; dx/add.py).
-	- [ ] Implement: backfill unit tests for help flags and error paths (bad dotted paths, missing DB).
-	- [ ] Docs: CLI reference snippets in docs (db workflow, dx helpers).
-	- [ ] Acceptance (pre-deploy): migrate/rollback/seed exit 0 in ephemeral stack (A10-01).
+	- [x] Implement: backfill unit tests for help flags and error paths (bad dotted paths, missing DB). (tests/unit/cli/test_cli_help_and_errors.py)
+	- [x] Docs: CLI reference snippets in docs (db workflow, dx helpers). (docs/cli.md)
+	- [x] Acceptance (pre-deploy): migrate/rollback/seed exit 0 in ephemeral stack (A10-01). (Makefile runs sql-setup-and-migrate/current/downgrade/upgrade against ephemeral sqlite; then sql-seed no-op)
 
 - Observability (obs add + CLI)
 	- [~] Research: add_observability and obs CLI (src/svc_infra/obs/*; tests/unit/obs/*).

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -10,7 +10,7 @@ This guide describes the acceptance harness that runs post-build against an ephe
 ## Workflow
 1. Build image
 2. docker compose up -d (test stack)
-3. Seed acceptance data (admin, user, tenants, API key)
+3. CLI DB checks & seed: run `sql-setup-and-migrate`, `sql-current`, `sql-downgrade -1`, `sql-upgrade head` against an ephemeral SQLite DB, then call `sql-seed tests.acceptance._seed:acceptance_seed` (no-op by default)
 4. Run pytest inside tester: docker compose run --rm tester (Makefile wires this)
 5. OpenAPI lint & API Doctor
 6. Teardown

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,74 @@
+# CLI Quick Reference
+
+The `svc-infra` CLI wraps common database, observability, jobs, docs, and DX workflows using Typer.
+
+- Entry points:
+  - Global: `svc-infra ...` (installed via Poetry scripts)
+  - Module: `python -m svc_infra.cli ...` (works in editable installs and containers)
+
+## Top-level help
+
+Run:
+
+```
+svc-infra --help
+```
+
+You should see groups for SQL, Mongo, Observability, DX, Jobs, and SDK.
+
+## Database (Alembic) commands
+
+- End-to-end setup and migrate (detects async from URL):
+  - Environment variables (commonly): `SQL_URL` or compose parts `DB_*`.
+
+Example with SQLite for quick smoke tests:
+
+```
+python -m svc_infra.cli sql-setup-and-migrate --database-url sqlite+aiosqlite:///./accept.db \
+  --discover-packages "app.models" --with-payments false
+```
+
+- Current revision, history, upgrade/downgrade:
+
+```
+python -m svc_infra.cli sql-current
+python -m svc_infra.cli sql-history
+python -m svc_infra.cli sql-upgrade head
+python -m svc_infra.cli sql-downgrade -1
+```
+
+- Seed fixtures/reference data with your callable:
+
+```
+python -m svc_infra.cli sql-seed path.to.module:seed_func
+```
+
+Notes:
+- The target must be in the format `module.path:callable`.
+- If you previously referenced legacy test modules under `tests.db.*`, the CLI shims import to `tests.unit.db.*` when possible.
+
+## Jobs
+
+Start the local jobs runner loop:
+
+```
+svc-infra jobs run
+```
+
+## DX helpers
+
+- Generate CI workflow and checks template:
+
+```
+python -m svc_infra.cli dx ci --openapi openapi.json
+```
+
+- Lint OpenAPI and Problem+JSON samples:
+
+```
+python -m svc_infra.cli dx openapi openapi.json
+```
+
+## SDKs
+
+Generate SDKs from OpenAPI (dry-run by default): see `docs/docs-and-sdks.md` for full examples.

--- a/tests/acceptance/_seed.py
+++ b/tests/acceptance/_seed.py
@@ -1,0 +1,9 @@
+def acceptance_seed():
+    """
+    No-op acceptance seed callable.
+
+    This exists to verify that the CLI wiring in the acceptance harness works
+    end-to-end (module import via PYTHONPATH, Typer invocation, and exit 0).
+    Extend this to create tenants/users/API keys if your acceptance tests need them.
+    """
+    return None

--- a/tests/unit/cli/test_cli_help_and_errors.py
+++ b/tests/unit/cli/test_cli_help_and_errors.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import typer
+from typer.testing import CliRunner
+
+from svc_infra.cli import app as cli_app
+
+runner = CliRunner()
+
+
+def test_root_help_shows_commands():
+    result = runner.invoke(cli_app, ["--help"])
+    assert result.exit_code == 0
+    # A few representative commands we register
+    assert "sql-init" in result.stdout
+    assert "sql-setup-and-migrate" in result.stdout
+    assert "sql-seed" in result.stdout
+
+
+def test_sql_init_help():
+    result = runner.invoke(cli_app, ["sql-init", "--help"])
+    assert result.exit_code == 0
+    assert "Initialize Alembic scaffold" in result.stdout
+    assert "--discover-packages" in result.stdout
+
+
+def test_seed_bad_format_errors():
+    # Missing ':' separator
+    result = runner.invoke(cli_app, ["sql-seed", "badformat"])
+    assert result.exit_code != 0
+    out = (result.stdout or "") + (getattr(result, "output", "") or "") + (result.stderr or "")
+    assert "Expected format" in out or "Invalid value for 'TARGET'" in out
+
+
+def test_seed_missing_callable_errors():
+    # Point to this test module but a missing callable name
+    dotted = "tests.unit.cli.test_cli_help_and_errors:does_not_exist"
+    result = runner.invoke(cli_app, ["sql-seed", dotted])
+    assert result.exit_code != 0
+    out = (result.stdout or "") + (getattr(result, "output", "") or "") + (result.stderr or "")
+    assert "Callable 'does_not_exist' not found" in out or "Invalid value for 'TARGET'" in out
+
+
+def test_sql_current_missing_db_path(monkeypatch):
+    # Simulate a DB connection failure path by making the implementation raise.
+    import svc_infra.cli.cmds.db.sql.alembic_cmds as alembic_cmds
+
+    def fake_current(*args, **kwargs):  # noqa: ANN001
+        raise RuntimeError("DB missing or unreachable")
+
+    monkeypatch.setattr(alembic_cmds, "core_current", fake_current)
+
+    result = runner.invoke(cli_app, ["sql-current"])  # no SQL_URL set
+    # Typer propagates unhandled exceptions; ensure we see it
+    assert result.exit_code != 0
+    assert result.exception is not None
+    assert "DB missing or unreachable" in str(result.exception)


### PR DESCRIPTION
This pull request improves the acceptance harness and developer experience by enhancing the CLI workflow, adding documentation, and backfilling unit tests for CLI help and error handling. The changes ensure that the CLI commands are robust, well-documented, and verified in the acceptance environment.

**CLI Acceptance Workflow and Testing Improvements:**

* The `Makefile` acceptance `seed` step now runs a full cycle of database CLI commands (`sql-setup-and-migrate`, `sql-current`, `sql-downgrade`, `sql-upgrade`) against an ephemeral SQLite database, followed by seeding with a no-op callable to verify end-to-end CLI wiring. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L27-R37) [[2]](diffhunk://#diff-5695569e50860312aec346de5b48f04b8049ea3c7b12579494583811c3676d58R1-R9)
* Acceptance documentation (`docs/acceptance.md`) updated to reflect the new CLI-based DB setup and seeding process.

**CLI Documentation and Reference:**

* Added a new `docs/cli.md` file providing a quick reference for all major `svc-infra` CLI commands, including database, jobs, DX helpers, and SDK generation, with usage examples and notes on module/callable formats.

**CLI Unit Tests for Help and Error Paths:**

* Added `tests/unit/cli/test_cli_help_and_errors.py` to backfill unit tests for CLI help flags and error handling, covering root help, command-specific help, bad target formats, missing callables, and DB connection errors.

**Project Planning and Tracking:**

* Updated `.github/instructions/PLANS.md` to mark the implementation of CLI unit tests, documentation, and acceptance harness improvements as complete, with references to the relevant files and steps.