### PR TITLE
feat: Add acceptance tests for rate limiting and abuse heuristics, en…

### DIFF
--- a/.github/instructions/PLANS.md
+++ b/.github/instructions/PLANS.md
@@ -135,7 +135,16 @@ Owner: TBD
 - [x] Tests: bucket depletion/reset, per-route override, Retry-After presence. (tests added)
 - [x] Verify: rate limiting test marker. (`-m ratelimit` available; auto-tagged tests)
 - [x] Docs: usage & tuning. (see docs/rate-limiting.md)
-- [ ] Acceptance (pre-deploy): A2-01..A2-03 green in CI (see docs/acceptance-matrix.md)
+- [x] Acceptance (pre-deploy): A2-01..A2-03 green in CI (see docs/acceptance-matrix.md)
+	- [x] A2-01: Dependency rate limit returns 429 with Retry-After
+		- Files: tests/acceptance/test_rate_limiting_acceptance.py (/rl/dep using rate_limiter)
+		- Result: test added; exercises 429 + Retry-After headers (uses header-isolated key)
+	- [x] A2-02: Middleware sets X-RateLimit-* headers on success
+		- Files: tests/acceptance/test_rate_limiting_acceptance.py (/ping with X-API-Key)
+		- Result: test added; asserts presence of X-RateLimit-Limit/Remaining/Reset
+	- [x] A2-03: Abuse heuristics acceptance (metrics hook)
+		- Files: tests/acceptance/test_abuse_heuristics_acceptance.py; tests/acceptance/app.py (acceptance-only hooks under /_accept/abuse)
+		- Result: metrics hook captures rate-limit events; acceptance asserts key/limit/retry_after. All acceptance tests pass.
 Evidence: (PRs, tests, CI runs)
 
 ### 3. Idempotency & Concurrency Controls

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 RMI ?= all
 
-.PHONY: accept compose_up wait seed down pytest_accept unit unitv clean test
+.PHONY: accept compose_up wait seed down pytest_accept unit unitv clean clean-pycache test
 
 compose_up:
 	@echo "[accept] Starting test stack..."
@@ -89,6 +89,11 @@ unitv:
 clean:
 	@echo "[clean] Removing Python caches, build artifacts, and logs"
 	rm -rf **/__pycache__ __pycache__ .pytest_cache .mypy_cache .ruff_cache build dist *.egg-info *.log
+
+# Remove only Python __pycache__ directories (recursive)
+clean-pycache:
+	@echo "[clean] Removing all __pycache__ directories recursively"
+	@find . -type d -name '__pycache__' -prune -exec rm -rf {} +
 
 # --- Combined test target ---
 test:

--- a/tests/acceptance/test_abuse_heuristics_acceptance.py
+++ b/tests/acceptance/test_abuse_heuristics_acceptance.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+@pytest.mark.acceptance
+class TestAbuseHeuristicsAcceptance:
+    def test_rate_limit_metrics_hook_captures_events(self, client):
+        # Enable capture hook
+        r = client.post("/_accept/abuse/hooks/rate-limit/enable")
+        assert r.status_code == 200 and r.json().get("enabled") is True
+
+        # Trip dependency-based limiter 4 times (limit=3) to produce one 429.
+        # Use a unique RL key so this test doesn't affect others.
+        headers = {"X-RL-Key": "abuse-accept-test"}
+        for _ in range(3):
+            ok = client.get("/rl/dep", headers=headers)
+            assert ok.status_code == 200
+        too_many = client.get("/rl/dep", headers=headers)
+        assert too_many.status_code == 429
+        # sanity: Retry-After present (covered by RL tests as well)
+        assert too_many.headers.get("Retry-After") is not None
+
+        # Read captured events
+        events_resp = client.get("/_accept/abuse/hooks/rate-limit/events")
+        assert events_resp.status_code == 200
+        events = events_resp.json().get("events") or []
+        assert isinstance(events, list)
+        # At least one event recorded with expected fields
+        assert len(events) >= 1
+        evt = events[-1]
+        assert set(evt.keys()) == {"key", "limit", "retry_after"}
+        assert evt["key"] == "abuse-accept-test"  # matches header-provided key
+        assert int(evt["limit"]) == 3
+        # retry_after should be >= 0 integer
+        assert isinstance(evt["retry_after"], int)
+        assert evt["retry_after"] >= 0
+
+        # Disable capture hook
+        r = client.post("/_accept/abuse/hooks/rate-limit/disable")
+        assert r.status_code == 200 and r.json().get("enabled") is False

--- a/tests/acceptance/test_rate_limiting_acceptance.py
+++ b/tests/acceptance/test_rate_limiting_acceptance.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.acceptance
+class TestRateLimitingAcceptance:
+    def test_dependency_rate_limit_429_and_retry_after(self, client):
+        # Hit /rl/dep 4 times; limit is 3 per minute using a fixed key
+        headers = {"X-RL-Key": "rl-accept-test-1"}
+        r1 = client.get("/rl/dep", headers=headers)
+        r2 = client.get("/rl/dep", headers=headers)
+        r3 = client.get("/rl/dep", headers=headers)
+        r4 = client.get("/rl/dep", headers=headers)
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert r3.status_code == 200
+        assert r4.status_code == 429
+        assert r4.headers.get("Retry-After") is not None
+
+    def test_middleware_rate_limit_headers_present(self, client):
+        # Global SimpleRateLimitMiddleware is active; it uses X-API-Key or client IP as key.
+        # Use a distinct X-API-Key so this test is isolated.
+        headers = {"X-API-Key": "accept-test-key"}
+        r = client.get("/ping", headers=headers)
+        # Success response should include RL headers
+        assert r.status_code == 200
+        assert r.headers.get("X-RateLimit-Limit") is not None
+        assert r.headers.get("X-RateLimit-Remaining") is not None
+        assert r.headers.get("X-RateLimit-Reset") is not None
+
+        # Now exceed the limit quickly by reusing same key if the default limit/window are small enough.
+        # We don't assume the global limit; just ensure headers present on success. The 429 path
+        # itself is exercised in unit tests; acceptance focuses on integration presence.


### PR DESCRIPTION
This pull request adds comprehensive acceptance tests and supporting code for rate limiting and abuse heuristics, ensuring that critical scenarios like 429 responses, Retry-After headers, and metrics hooks are properly validated. It also improves error handling to preserve response headers, and introduces a new Makefile target for cleaning Python caches. The most important changes are grouped below.

**Acceptance Tests & Supporting Infrastructure:**

* Added acceptance tests for rate limiting and abuse heuristics, covering 429 responses, Retry-After headers, and metrics hook event capture in `tests/acceptance/test_rate_limiting_acceptance.py` and `tests/acceptance/test_abuse_heuristics_acceptance.py`. [[1]](diffhunk://#diff-0e666e88e1fddfe74d59b9346d5046cbd75e8c52e136de9b3a286dd23886d8efR1-R34) [[2]](diffhunk://#diff-e526e3bbe15fd65771efbfbb93b31dcc665c7766b595b86225297ec8afedded9R1-R43)
* Implemented new acceptance-only endpoints in `tests/acceptance/app.py` for dependency-based rate limiting (`/rl/dep`) and abuse heuristics hooks (`/_accept/abuse/hooks/rate-limit/*`), including in-memory event tracking and enabling/disabling of metrics hooks.

**Error Handling Improvements:**

* Enhanced error response handling in `src/svc_infra/api/fastapi/middleware/errors/handlers.py` to preserve and return custom headers (such as Retry-After) for HTTP exceptions, including 429 Too Many Requests. [[1]](diffhunk://#diff-4247b1e5b7b15948459955647a6fe193e75cf8b0d0853c99465b23a71d101e81R49) [[2]](diffhunk://#diff-4247b1e5b7b15948459955647a6fe193e75cf8b0d0853c99465b23a71d101e81L65-R66) [[3]](diffhunk://#diff-4247b1e5b7b15948459955647a6fe193e75cf8b0d0853c99465b23a71d101e81L107-R164)

**Documentation & Planning:**

* Updated `.github/instructions/PLANS.md` to reflect that acceptance tests for rate limiting (A2-01..A2-03) are implemented and passing, with detailed evidence and test descriptions.

**Build & Maintenance Tools:**

* Added a new `clean-pycache` target to the `Makefile` for recursively removing Python `__pycache__` directories, improving developer workflow. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L4-R4) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R93-R97)