### PR TITLE
feat: Add documentation command group with dynamic topic subcommands …

### DIFF
--- a/src/svc_infra/cli/__init__.py
+++ b/src/svc_infra/cli/__init__.py
@@ -6,6 +6,7 @@ from svc_infra.cli.cmds import (
     _HELP,
     jobs_app,
     register_alembic,
+    register_docs,
     register_dx,
     register_mongo,
     register_mongo_scaffold,
@@ -39,6 +40,9 @@ app.add_typer(jobs_app, name="jobs")
 
 # -- sdk commands ---
 register_sdk(app)
+
+# -- docs commands ---
+register_docs(app)
 
 
 def main():

--- a/src/svc_infra/cli/cmds/__init__.py
+++ b/src/svc_infra/cli/cmds/__init__.py
@@ -5,6 +5,7 @@ from svc_infra.cli.cmds.db.nosql.mongo.mongo_scaffold_cmds import (
 from svc_infra.cli.cmds.db.sql.alembic_cmds import register as register_alembic
 from svc_infra.cli.cmds.db.sql.sql_export_cmds import register as register_sql_export
 from svc_infra.cli.cmds.db.sql.sql_scaffold_cmds import register as register_sql_scaffold
+from svc_infra.cli.cmds.docs.docs_cmds import register as register_docs
 from svc_infra.cli.cmds.dx import register_dx
 from svc_infra.cli.cmds.jobs.jobs_cmds import app as jobs_app
 from svc_infra.cli.cmds.obs.obs_cmds import register as register_obs
@@ -22,5 +23,6 @@ __all__ = [
     "jobs_app",
     "register_sdk",
     "register_dx",
+    "register_docs",
     "_HELP",
 ]

--- a/src/svc_infra/cli/cmds/docs/docs_cmds.py
+++ b/src/svc_infra/cli/cmds/docs/docs_cmds.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import typer
+
+from svc_infra.app.root import resolve_project_root
+
+
+def _discover_docs(root: Path) -> List[Tuple[str, Path]]:
+    """Return a list of (topic, file_path) for top-level Markdown files under docs/.
+
+    Topic is the filename stem (e.g. security.md -> "security").
+    """
+    docs_dir = root / "docs"
+    topics: List[Tuple[str, Path]] = []
+    if not docs_dir.exists() or not docs_dir.is_dir():
+        return topics
+    for p in sorted(docs_dir.glob("*.md")):
+        if p.is_file():
+            topics.append((p.stem.replace(" ", "-"), p))
+    return topics
+
+
+def register(app: typer.Typer) -> None:
+    """Register the `docs` command group and dynamic topic subcommands."""
+
+    root = resolve_project_root()
+    discovered = _discover_docs(root)
+
+    # Build help text listing available topics
+    if discovered:
+        topic_names = ", ".join(name for name, _ in discovered)
+        docs_help = (
+            f"Show docs from the repository's docs/ directory.\n\nAvailable topics: {topic_names}"
+        )
+    else:
+        docs_help = "Show docs from the repository's docs/ directory.\n\nNo topics discovered."
+
+    docs_app = typer.Typer(no_args_is_help=True, help=docs_help, add_completion=False)
+
+    @docs_app.command("list", help="List available documentation topics")
+    def list_topics() -> None:
+        for name, path in discovered:
+            typer.echo(f"{name}\t{path.relative_to(root)}")
+
+    # Freeze mapping for use in dynamic commands and generic fallback
+    topic_map: Dict[str, Path] = {name: path for name, path in discovered}
+
+    def _make_topic_cmd(topic: str, file_path: Path):
+        @docs_app.command(name=topic, help=f"Show docs for topic: {topic}")
+        def _show_topic() -> None:  # noqa: WPS430 (nested function OK for closure)
+            content = file_path.read_text(encoding="utf-8", errors="replace")
+            typer.echo(content)
+
+    for name, path in discovered:
+        _make_topic_cmd(name, path)
+
+    # Optional generic fallback: allow `svc-infra docs --topic <name>`
+    @docs_app.callback(invoke_without_command=True)
+    def _maybe_show_topic(topic: str = typer.Option(None, "--topic", help="Topic to show")) -> None:  # type: ignore[no-redef]
+        if topic:
+            p = topic_map.get(topic)
+            if not p:
+                raise typer.BadParameter(f"Unknown topic: {topic}")
+            typer.echo(p.read_text(encoding="utf-8", errors="replace"))
+
+    app.add_typer(docs_app, name="docs")

--- a/tests/unit/cli/test_docs_cli.py
+++ b/tests/unit/cli/test_docs_cli.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from svc_infra.cli import app as cli_app
+
+runner = CliRunner()
+
+
+def test_docs_list_shows_known_topics(tmp_path: Path):
+    # sanity: ensure some docs exist in repo
+    result = runner.invoke(cli_app, ["docs", "list"])
+    assert result.exit_code == 0
+    out = result.stdout
+    assert "cache\t" in out
+    assert "security\t" in out
+
+
+def test_docs_topic_command_prints_file_contents():
+    result = runner.invoke(cli_app, ["docs", "cache"])
+    assert result.exit_code == 0
+    out = result.stdout
+    # basic content smoke check
+    assert "Cache guide" in out
+    assert "cashews" in out
+
+
+def test_docs_topic_option_and_unknown_topic_error():
+    # --topic fallback
+    result = runner.invoke(cli_app, ["docs", "--topic", "security"])
+    assert result.exit_code == 0
+    assert "Security" in result.stdout or "security" in result.stdout
+
+    # unknown topic
+    bad = runner.invoke(cli_app, ["docs", "--topic", "does-not-exist"])
+    assert bad.exit_code != 0
+    # Typer shows error text in either stdout or exception depending on version
+    combined = (bad.stdout or "") + (getattr(bad, "output", "") or "") + (bad.stderr or "")
+    assert "Unknown topic" in combined or (bad.exception and "Unknown topic" in str(bad.exception))


### PR DESCRIPTION
This pull request introduces a new CLI command group for accessing documentation topics from the repository's `docs/` directory. The main changes add a dynamic `docs` command with topic subcommands, integrate it into the CLI, and provide corresponding unit tests.

**New CLI documentation commands:**

* Added `register_docs` function and imported it in `src/svc_infra/cli/cmds/__init__.py`, enabling registration of documentation commands.
* Registered the new `docs` command group in the CLI application initialization (`src/svc_infra/cli/__init__.py`), making documentation commands available to users. [[1]](diffhunk://#diff-f144831208b727d953ca719145fdb9c44c88002d5f5c7599ee14454058cc9b31R9) [[2]](diffhunk://#diff-f144831208b727d953ca719145fdb9c44c88002d5f5c7599ee14454058cc9b31R44-R46)

**Implementation of dynamic documentation topics:**

* Implemented `src/svc_infra/cli/cmds/docs/docs_cmds.py` to discover Markdown files in `docs/`, register topic subcommands, and provide a fallback `--topic` option for generic access.

**Testing and validation:**

* Added unit tests in `tests/unit/cli/test_docs_cli.py` to verify listing of topics, topic command output, and error handling for unknown topics.

**CLI exports update:**

* Updated the CLI exports in `src/svc_infra/cli/cmds/__init__.py` to include `register_docs`.