### PR TITLE
feat: Update version in pyproject.toml and enhance documentation comm…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "svc-infra"
-version = "0.1.612"
+version = "0.1.613"
 description = "Infrastructure for building and deploying prod-ready services"
 authors = ["Ali Khatami <aliikhatami94@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
This pull request enhances the `svc-infra docs` CLI command to support documentation topics bundled within the installed package, allowing users to access documentation even when a local `docs/` directory is not present. The changes ensure that both filesystem and packaged docs are discoverable, listed, and viewable, with local docs taking precedence in case of conflicts.

**Packaged documentation support:**

* Added `_discover_pkg_topics` to find and expose Markdown docs shipped in the package wheel, enabling fallback when local docs are missing.
* Updated topic listing and command registration to include both filesystem and packaged topics, with filesystem topics taking precedence and packaged topics added for visibility. [[1]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L59-R89) [[2]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L117-R172)

**Topic display improvements:**

* Modified topic display logic so that both filesystem and packaged topics can be shown via dynamic subcommands and the generic `show` command. [[1]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L82-R121) [[2]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9R182-R185)

**Dependency and version update:**

* Added import of `distribution` and `PackageNotFoundError` from `importlib.metadata` to support packaged docs discovery.
* Bumped package version to `0.1.613` in `pyproject.toml` to reflect the new feature.