### PR TITLE
feat: Refactor documentation topic discovery to normalize topic names…

### DIFF
--- a/src/svc_infra/cli/cmds/docs/docs_cmds.py
+++ b/src/svc_infra/cli/cmds/docs/docs_cmds.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import sys
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 from typing import Dict, List
@@ -10,7 +11,15 @@ import click
 import typer
 from typer.core import TyperGroup
 
-from svc_infra.app.root import resolve_project_root
+
+def _norm(name: str) -> str:
+    """Normalize a topic name for stable CLI commands.
+
+    - Lowercase
+    - Replace spaces and underscores with hyphens
+    - Strip leading/trailing whitespace
+    """
+    return name.strip().lower().replace(" ", "-").replace("_", "-")
 
 
 def _discover_fs_topics(docs_dir: Path) -> Dict[str, Path]:
@@ -18,7 +27,7 @@ def _discover_fs_topics(docs_dir: Path) -> Dict[str, Path]:
     if docs_dir.exists() and docs_dir.is_dir():
         for p in sorted(docs_dir.glob("*.md")):
             if p.is_file():
-                topics[p.stem.replace(" ", "-")] = p
+                topics[_norm(p.stem)] = p
     return topics
 
 
@@ -46,7 +55,7 @@ def _discover_pkg_topics() -> Dict[str, Path]:
             s = str(f)
             if not s.startswith("docs/") or not s.endswith(".md"):
                 continue
-            topic_name = Path(s).stem.replace(" ", "-")
+            topic_name = _norm(Path(s).stem)
             try:
                 abs_path = Path(dist.locate_file(f))
                 if abs_path.exists() and abs_path.is_file():
@@ -55,60 +64,145 @@ def _discover_pkg_topics() -> Dict[str, Path]:
                 # Best effort; continue to next
                 continue
 
-    # 2) Fallback: site-packages sibling 'docs/' directory
+    # 2) Fallback: site-packages sibling 'docs/' directory (and repo-root docs in editable installs)
     try:
         spec = importlib.util.find_spec("svc_infra")
         if spec and spec.submodule_search_locations:
             pkg_dir = Path(next(iter(spec.submodule_search_locations)))
-            candidate = pkg_dir.parent / "docs"
-            if candidate.exists() and candidate.is_dir():
-                for p in sorted(candidate.glob("*.md")):
-                    if p.is_file():
-                        topics.setdefault(p.stem.replace(" ", "-"), p)
+            candidates = [
+                pkg_dir.parent / "docs",  # site-packages/docs OR src/docs
+                pkg_dir / "docs",  # site-packages/svc_infra/docs OR src/svc_infra/docs
+                pkg_dir.parent.parent
+                / "docs",  # repo-root/docs when running editable from repo (src/svc_infra → ../../docs)
+            ]
+            for candidate in candidates:
+                if candidate.exists() and candidate.is_dir():
+                    for p in sorted(candidate.glob("*.md")):
+                        if p.is_file():
+                            topics.setdefault(_norm(p.stem), p)
+                    # If one candidate had docs, that's sufficient
+                    if any(k for k in topics):
+                        break
     except Exception:
         # Optional fallback only
+        pass
+
+    # 3) Last-resort: scan sys.path entries that look like site-/dist-packages for a top-level docs/
+    #    directory containing markdown files. This covers non-standard installs/editable modes.
+    try:
+        if not topics:
+            for entry in sys.path:
+                try:
+                    if not entry or ("site-packages" not in entry and "dist-packages" not in entry):
+                        continue
+                    docs_dir = Path(entry) / "docs"
+                    if docs_dir.exists() and docs_dir.is_dir():
+                        found = _discover_fs_topics(docs_dir)
+                        if found:
+                            # Merge but do not override anything already found
+                            for k, v in found.items():
+                                topics.setdefault(k, v)
+                            # If we found one valid docs dir, it's enough
+                            break
+                except Exception:
+                    continue
+    except Exception:
+        pass
+
+    # 4) Parse dist-info/RECORD or egg-info/SOURCES.txt to enumerate docs if available
+    try:
+        if not topics:
+            spec = importlib.util.find_spec("svc_infra")
+            base_dir: Path | None = None
+            if spec and spec.submodule_search_locations:
+                base_dir = Path(next(iter(spec.submodule_search_locations))).parent
+            # Fallback to first site-packages on sys.path
+            if base_dir is None:
+                for entry in sys.path:
+                    if entry and "site-packages" in entry:
+                        base_dir = Path(entry)
+                        break
+            if base_dir and base_dir.exists():
+                # Check for both hyphen and underscore dist-info names
+                candidates = list(base_dir.glob("svc_infra-*.dist-info")) + list(
+                    base_dir.glob("svc-infra-*.dist-info")
+                )
+                for di in candidates:
+                    record = di / "RECORD"
+                    if record.exists():
+                        try:
+                            for line in record.read_text(
+                                encoding="utf-8", errors="ignore"
+                            ).splitlines():
+                                rel = line.split(",", 1)[0]
+                                if rel.startswith("docs/") and rel.endswith(".md"):
+                                    abs_p = base_dir / rel
+                                    if abs_p.exists() and abs_p.is_file():
+                                        topics.setdefault(_norm(Path(rel).stem), abs_p)
+                        except Exception:
+                            continue
+                # egg-info fallback
+                if not topics:
+                    egg_candidates = list(base_dir.glob("svc_infra-*.egg-info")) + list(
+                        base_dir.glob("svc-infra-*.egg-info")
+                    )
+                    for ei in egg_candidates:
+                        sources = ei / "SOURCES.txt"
+                        if sources.exists():
+                            try:
+                                for rel in sources.read_text(
+                                    encoding="utf-8", errors="ignore"
+                                ).splitlines():
+                                    rel = rel.strip()
+                                    if rel.startswith("docs/") and rel.endswith(".md"):
+                                        abs_p = base_dir / rel
+                                        if abs_p.exists() and abs_p.is_file():
+                                            topics.setdefault(_norm(Path(rel).stem), abs_p)
+                            except Exception:
+                                continue
+    except Exception:
+        pass
+
+    # 5) Deep fallback: recursively search site-packages/dist-packages for any 'docs' folder
+    #    containing markdown files (limited depth to keep overhead reasonable).
+    try:
+        if not topics:
+            for entry in sys.path:
+                if not entry or ("site-packages" not in entry and "dist-packages" not in entry):
+                    continue
+                base = Path(entry)
+                if not base.exists() or not base.is_dir():
+                    continue
+                base_parts = len(base.parts)
+                for root, dirs, files in os.walk(base):
+                    root_path = Path(root)
+                    # Limit search depth to avoid expensive scans
+                    if len(root_path.parts) - base_parts > 4:
+                        # prune
+                        dirs[:] = []
+                        continue
+                    if root_path.name == "docs":
+                        for p in sorted(root_path.glob("*.md")):
+                            if p.is_file():
+                                topics.setdefault(_norm(p.stem), p)
+                        # do not break; there might be multiple doc dirs
+    except Exception:
         pass
 
     return topics
 
 
 def _resolve_docs_dir(ctx: click.Context) -> Path | None:
-    # CLI option takes precedence; walk up parent contexts because Typer
-    # executes subcommands in child contexts that do not inherit params.
-    current: click.Context | None = ctx
-    while current is not None:
-        docs_dir_opt = (current.params or {}).get("docs_dir")
-        if docs_dir_opt:
-            path = docs_dir_opt if isinstance(docs_dir_opt, Path) else Path(docs_dir_opt)
-            path = path.expanduser()
-            if path.exists():
-                return path
-        current = current.parent
-
-    # Env var next
-    env_dir = os.getenv("SVC_INFRA_DOCS_DIR")
-    if env_dir:
-        p = Path(env_dir).expanduser()
-        if p.exists():
-            return p
-
-    # Project docs
-    root = resolve_project_root()
-    proj_docs = root / "docs"
-    if proj_docs.exists():
-        return proj_docs
+    # Deprecated: we no longer read docs from arbitrary paths or env.
+    # All docs are sourced from the packaged svc-infra distribution only.
     return None
 
 
 class DocsGroup(TyperGroup):
     def list_commands(self, ctx: click.Context) -> List[str]:
         names: List[str] = list(super().list_commands(ctx) or [])
-        dir_to_use = _resolve_docs_dir(ctx)
-        fs = _discover_fs_topics(dir_to_use) if dir_to_use else {}
         pkg = _discover_pkg_topics()
-        # FS topics win on conflicts; add both for visibility
-        names.extend([k for k in fs.keys()])
-        names.extend([k for k in pkg.keys() if k not in fs])
+        names.extend([k for k in pkg.keys()])
         # Deduplicate and sort
         return sorted({*names})
 
@@ -118,19 +212,7 @@ class DocsGroup(TyperGroup):
         if cmd is not None:
             return cmd
 
-        # Dynamic topic resolution from FS
-        dir_to_use = _resolve_docs_dir(ctx)
-        fs = _discover_fs_topics(dir_to_use) if dir_to_use else {}
-        if name in fs:
-            file_path = fs[name]
-
-            @click.command(name=name)
-            def _show_fs() -> None:
-                click.echo(file_path.read_text(encoding="utf-8", errors="replace"))
-
-            return _show_fs
-
-        # Packaged fallback
+        # Packaged topics only
         pkg = _discover_pkg_topics()
         if name in pkg:
             file_path = pkg[name]
@@ -151,21 +233,10 @@ def register(app: typer.Typer) -> None:
 
     @docs_app.callback(invoke_without_command=True)
     def _docs_options(
-        docs_dir: Path | None = typer.Option(
-            None,
-            "--docs-dir",
-            help="Path to a docs directory to read from (overrides env/project root)",
-        ),
         topic: str | None = typer.Option(None, "--topic", help="Topic to show directly"),
     ) -> None:
-        """Support --docs-dir and --topic at group level."""
+        """Support --topic at group level (packaged docs only)."""
         if topic:
-            ctx = click.get_current_context()
-            dir_to_use = _resolve_docs_dir(ctx)
-            fs = _discover_fs_topics(dir_to_use) if dir_to_use else {}
-            if topic in fs:
-                typer.echo(fs[topic].read_text(encoding="utf-8", errors="replace"))
-                raise typer.Exit(code=0)
             pkg = _discover_pkg_topics()
             if topic in pkg:
                 typer.echo(pkg[topic].read_text(encoding="utf-8", errors="replace"))
@@ -174,36 +245,18 @@ def register(app: typer.Typer) -> None:
 
     @docs_app.command("list", help="List available documentation topics")
     def list_topics() -> None:
-        ctx = click.get_current_context()
-        root = resolve_project_root()
-        dir_to_use = _resolve_docs_dir(ctx)
-        fs = _discover_fs_topics(dir_to_use) if dir_to_use else {}
         pkg = _discover_pkg_topics()
 
-        # Print FS topics first (project/env/option), then packaged topics not shadowed by FS
+        # Print packaged topics only
         def _print(name: str, path: Path) -> None:
-            try:
-                rel = path.relative_to(root)
-                typer.echo(f"{name}\t{rel}")
-            except Exception:
-                # For packaged topics, path will be site-packages absolute path
-                typer.echo(f"{name}\t{path}")
+            typer.echo(f"{name}\t{path}")
 
-        for name, path in fs.items():
-            _print(name, path)
         for name, path in pkg.items():
-            if name not in fs:
-                _print(name, path)
+            _print(name, path)
 
     # Also support a generic "show" command
     @docs_app.command("show", help="Show docs for a topic (alternative to dynamic subcommand)")
     def show(topic: str) -> None:
-        ctx = click.get_current_context()
-        dir_to_use = _resolve_docs_dir(ctx)
-        fs = _discover_fs_topics(dir_to_use) if dir_to_use else {}
-        if topic in fs:
-            typer.echo(fs[topic].read_text(encoding="utf-8", errors="replace"))
-            return
         pkg = _discover_pkg_topics()
         if topic in pkg:
             typer.echo(pkg[topic].read_text(encoding="utf-8", errors="replace"))


### PR DESCRIPTION
This pull request refactors the documentation command handling in `src/svc_infra/cli/cmds/docs/docs_cmds.py` to exclusively source documentation topics from the packaged `svc-infra` distribution, removing support for arbitrary filesystem or environment-based docs directories. It also introduces more robust and comprehensive logic to discover packaged documentation topics across a variety of installation layouts. The normalization of topic names is improved for consistency, and several deprecated options and code paths are removed.

**Packaged Documentation Discovery Enhancements**
* Added multiple fallback strategies to discover documentation topics from various possible locations within the packaged distribution, including site-packages, dist-info/egg-info metadata, sys.path scanning, and recursive search for `docs` folders. This ensures documentation topics are reliably found regardless of installation mode.
* Introduced a `_norm` function to standardize topic names by lowercasing and replacing spaces/underscores with hyphens, ensuring stable CLI command names and topic resolution.

**Deprecation and Removal of Filesystem/Env Docs Support**
* Removed all support for reading documentation topics from arbitrary filesystem paths, environment variables, or CLI options (e.g., `--docs-dir`). Documentation is now always sourced from the packaged distribution. [[1]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L58-R205) [[2]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L154-L168)
* Deprecated and removed `_resolve_docs_dir` and related logic, as well as the `docs_dir` option from CLI commands and callbacks. [[1]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L58-R205) [[2]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L154-L168)

**CLI Behavior and Output Simplification**
* Updated all CLI commands (`list`, `show`, dynamic topic commands) to only display and resolve topics from the packaged docs, removing logic for merging or prioritizing filesystem topics. Output now consistently shows only packaged documentation topics. [[1]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L177-L206) [[2]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L121-R215)
* Simplified command listing and topic resolution logic to deduplicate and sort topics exclusively from the packaged docs. [[1]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L58-R205) [[2]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L177-L206)

**Code Cleanup**
* Removed unused imports and legacy code paths related to project root resolution and filesystem scanning, further clarifying the source of documentation topics. [[1]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9R5) [[2]](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L177-L206)