### PR TITLE
feat: Add documentation command to retrieve and display available doc…

### DIFF
--- a/src/svc_infra/cli/cmds/help.py
+++ b/src/svc_infra/cli/cmds/help.py
@@ -21,4 +21,8 @@ How to run (pick what fits your workflow):
 Notes:
 * Make sure you’re in the right virtual environment (or use `pipx`).
 * You can point `--project-root` at your Alembic root; if omitted we auto-detect.
+
+Learn more:
+* For full integration guides and all topics, run: `svc-infra docs list`
+* To explore docs commands, run: `svc-infra docs --help`
 """


### PR DESCRIPTION
This pull request adds a new MCP function to support listing documentation topics for `svc-infra` via the command line, and improves the user help output to guide users towards available documentation commands. The main changes include introducing the `svc_infra_docs_list` function, updating imports to enable this, and enhancing the help text for better discoverability.

**Documentation discovery improvements:**

* Added a new async function `svc_infra_docs_list` in `svc_infra_mcp.py` to run `svc-infra docs list` and return its output, using `run_cli` with a fallback for older signatures. This function is now exposed as a dedicated MCP function for clients to quickly discover documentation topics. [[1]](diffhunk://#diff-49e1b1f24bfd056e269d70db4445c7b2df700825fef206c3afd2deab1779a2b0R23-R41) [[2]](diffhunk://#diff-49e1b1f24bfd056e269d70db4445c7b2df700825fef206c3afd2deab1779a2b0R117-R126)
* Updated the import statement in `svc_infra_mcp.py` to include `run_cli`, enabling the new docs listing functionality.

**User help enhancements:**

* Improved the help text in `help.py` to inform users about the `svc-infra docs list` and `svc-infra docs --help` commands for full integration guides and documentation topics.