### PR TITLE
feat: Update healthcheck parameters and improve documentation command…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ compose_up:
 wait:
 	@echo "[accept] Waiting for API to become ready (inside api container)..."
 		@ : "Poll the API from inside the running api container to avoid host/port quirks"; \
-		end=$$(($(shell date +%s) + 60)); \
+		end=$$(($(shell date +%s) + 240)); \
 		while [ $$(date +%s) -lt $$end ]; do \
 			if docker compose -f docker-compose.test.yml exec -T api \
 				python -c "import sys,urllib.request; sys.exit(0) if urllib.request.urlopen('http://localhost:8000/ping', timeout=2).status==200 else sys.exit(1)" >/dev/null 2>&1; then \

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -22,18 +22,15 @@ services:
       - "8000:8000"
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0) if urllib.request.urlopen('http://localhost:8000/ping', timeout=2).status==200 else sys.exit(1)"]
-      interval: 2s
-      timeout: 2s
-      retries: 60
-      start_period: 60s
+      interval: 3s
+      timeout: 3s
+      retries: 120
+      start_period: 180s
     command: >-
       bash -lc "set -euxo pipefail
       && python -m pip install --root-user-action=ignore --no-cache-dir -U pip
-      && python -m pip install --root-user-action=ignore --no-cache-dir uvicorn
-      && python -m pip install --root-user-action=ignore --no-cache-dir asyncpg
-      && python -m pip install --root-user-action=ignore --no-cache-dir aiosqlite
-      && python -m pip install --root-user-action=ignore --no-cache-dir prometheus-client
-      && python -m pip install --root-user-action=ignore --no-cache-dir /workspace
+      && python -m pip install --root-user-action=ignore --no-cache-dir --prefer-binary uvicorn asyncpg aiosqlite prometheus-client
+      && python -m pip install --root-user-action=ignore --no-cache-dir --prefer-binary /workspace
       && uvicorn tests.acceptance.app:app --host 0.0.0.0 --port 8000"
 
   redis:

--- a/src/svc_infra/cli/cmds/help.py
+++ b/src/svc_infra/cli/cmds/help.py
@@ -23,6 +23,6 @@ Notes:
 * You can point `--project-root` at your Alembic root; if omitted we auto-detect.
 
 Learn more:
-* For full integration guides and all topics, run: `svc-infra docs list`
-* To explore docs commands, run: `svc-infra docs --help`
+* Explore available topics: `svc-infra docs --help`
+* Show a topic directly: `svc-infra docs <topic>` or `svc-infra docs show <topic>`
 """

--- a/src/svc_infra/mcp/svc_infra_mcp.py
+++ b/src/svc_infra/mcp/svc_infra_mcp.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-from ai_infra.llm.tools.custom.cli import cli_cmd_help, cli_subcmd_help, run_cli
+from ai_infra.llm.tools.custom.cli import cli_cmd_help, cli_subcmd_help
 from ai_infra.mcp.server.tools import mcp_from_functions
 
 from svc_infra.app.env import prepare_env
@@ -26,13 +26,17 @@ async def svc_infra_cmd_help() -> dict:
 async def svc_infra_docs_help() -> dict:
     """
     Run 'svc-infra docs --help' and return its output.
-    Uses the generic run_cli helper for portability.
+    Prepares the project environment and executes from the repo root so
+    environment-provided docs directories and local topics are discoverable.
     """
-    result = await run_cli(CLI_PROG, ["docs", "--help"])
-    # Normalize to a dict with a 'help' field if run_cli returns raw text
-    if isinstance(result, dict):
-        return result
-    return {"ok": True, "action": "docs_help", "help": result}
+    root = prepare_env()
+    text = await run_from_root(root, CLI_PROG, ["docs", "--help"])
+    return {
+        "ok": True,
+        "action": "docs_help",
+        "project_root": str(root),
+        "help": text,
+    }
 
 
 class Subcommand(str, Enum):

--- a/tests/unit/cli/test_docs_cli.py
+++ b/tests/unit/cli/test_docs_cli.py
@@ -9,15 +9,6 @@ from svc_infra.cli import app as cli_app
 runner = CliRunner()
 
 
-def test_docs_list_shows_known_topics(tmp_path: Path):
-    # sanity: ensure some docs exist in repo
-    result = runner.invoke(cli_app, ["docs", "list"])
-    assert result.exit_code == 0
-    out = result.stdout
-    assert "cache\t" in out
-    assert "security\t" in out
-
-
 def test_docs_topic_command_prints_file_contents():
     result = runner.invoke(cli_app, ["docs", "cache"])
     assert result.exit_code == 0
@@ -27,18 +18,17 @@ def test_docs_topic_command_prints_file_contents():
     assert "cashews" in out
 
 
-def test_docs_topic_option_and_unknown_topic_error():
-    # --topic fallback
-    result = runner.invoke(cli_app, ["docs", "--topic", "security"])
+def test_docs_dynamic_and_unknown_topic_error():
+    # dynamic command works
+    result = runner.invoke(cli_app, ["docs", "security"])
     assert result.exit_code == 0
     assert "Security" in result.stdout or "security" in result.stdout
 
-    # unknown topic
-    bad = runner.invoke(cli_app, ["docs", "--topic", "does-not-exist"])
+    # unknown topic as dynamic subcommand
+    bad = runner.invoke(cli_app, ["docs", "does-not-exist"])
     assert bad.exit_code != 0
-    # Typer shows error text in either stdout or exception depending on version
     combined = (bad.stdout or "") + (getattr(bad, "output", "") or "") + (bad.stderr or "")
-    assert "Unknown topic" in combined or (bad.exception and "Unknown topic" in str(bad.exception))
+    assert "No such command" in combined
 
 
 def test_docs_env_override(monkeypatch, tmp_path):
@@ -48,74 +38,32 @@ def test_docs_env_override(monkeypatch, tmp_path):
     f = custom_docs / "custom-topic.md"
     f.write_text("# Custom Topic\nThis is custom docs.")
 
-    # Point CLI at this docs dir via env var
+    # Point CLI at this docs dir via env var and ensure content is shown
     monkeypatch.setenv("SVC_INFRA_DOCS_DIR", str(custom_docs))
 
-    # list should include custom-topic
-    res_list = runner.invoke(cli_app, ["docs", "list"])
-    assert res_list.exit_code == 0
-    assert "custom-topic\t" in res_list.stdout
-
-    # topic should render content
     res_topic = runner.invoke(cli_app, ["docs", "custom-topic"])
     assert res_topic.exit_code == 0
     assert "Custom Topic" in res_topic.stdout
 
 
-def test_docs_dir_option_propagates_to_subcommands(tmp_path: Path):
-    custom_docs = tmp_path / "docs"
-    custom_docs.mkdir()
-    f = custom_docs / "option-topic.md"
-    f.write_text("# Option Topic\nDocs from option.")
-
-    docs_dir_arg = str(custom_docs)
-
-    result_list = runner.invoke(cli_app, ["docs", "--docs-dir", docs_dir_arg, "list"])
-    assert result_list.exit_code == 0
-    assert "option-topic\t" in result_list.stdout
-
-    result_topic = runner.invoke(cli_app, ["docs", "--docs-dir", docs_dir_arg, "option-topic"])
-    assert result_topic.exit_code == 0
-    assert "Option Topic" in result_topic.stdout
+def test_docs_dir_option_removed_shows_error(tmp_path: Path):
+    # --docs-dir is no longer supported; ensure Typer rejects it
+    result = runner.invoke(cli_app, ["docs", "--docs-dir", str(tmp_path), "show", "x"])
+    assert result.exit_code != 0
 
 
-def test_docs_topic_name_normalization_with_option(tmp_path: Path):
+def test_docs_topic_name_normalization_with_env(tmp_path: Path, monkeypatch):
     # Create docs with mixed case and underscores/spaces
     custom_docs = tmp_path / "docs"
     custom_docs.mkdir()
     f = custom_docs / "Mixed_Name Topic.md"
     f.write_text("# Normalized Topic\nThis should be found via normalized key.")
 
-    docs_dir_arg = str(custom_docs)
+    monkeypatch.setenv("SVC_INFRA_DOCS_DIR", str(custom_docs))
 
     # Dynamic subcommand with normalized name should work
-    res_topic = runner.invoke(cli_app, ["docs", "--docs-dir", docs_dir_arg, "mixed-name-topic"])
+    res_topic = runner.invoke(cli_app, ["docs", "mixed-name-topic"])
     assert res_topic.exit_code == 0
     assert "Normalized Topic" in res_topic.stdout
 
-    # --topic should also work with un-normalized input
-    res_topic_flag = runner.invoke(
-        cli_app, ["docs", "--docs-dir", docs_dir_arg, "--topic", "Mixed_Name Topic"]
-    )
-    assert res_topic_flag.exit_code == 0
-    assert "Normalized Topic" in res_topic_flag.stdout
-
-
-def test_docs_dir_option_precedes_env(monkeypatch, tmp_path: Path):
-    # Prepare two docs directories; CLI should pick --docs-dir over env
-    env_docs = tmp_path / "env_docs"
-    env_docs.mkdir()
-    (env_docs / "from-env.md").write_text("# From Env\n")
-
-    opt_docs = tmp_path / "opt_docs"
-    opt_docs.mkdir()
-    (opt_docs / "from-opt.md").write_text("# From Option\n")
-
-    monkeypatch.setenv("SVC_INFRA_DOCS_DIR", str(env_docs))
-
-    # list should include only from-opt when --docs-dir is provided (first hit wins)
-    res_list = runner.invoke(cli_app, ["docs", "--docs-dir", str(opt_docs), "list"])
-    assert res_list.exit_code == 0
-    out = res_list.stdout
-    assert "from-opt\t" in out
-    assert "from-env\t" not in out
+    # Un-normalized input is not a valid dynamic command name; only normalized works


### PR DESCRIPTION
This pull request refactors the documentation command group in the CLI and its related infrastructure, focusing on simplifying topic selection and removing support for the `--docs-dir` CLI option. The changes streamline how documentation topics are discovered and presented, clarify user guidance, and update tests and MCP (micro control plane) functions to match the new behavior.

### CLI and Documentation Command Refactor

* Removed the `--docs-dir` CLI option from the documentation command group; now, documentation directories are selected only via the `SVC_INFRA_DOCS_DIR` environment variable or in-repo defaults. The CLI no longer supports overriding the docs directory via command-line options. (`src/svc_infra/cli/cmds/docs/docs_cmds.py`, [src/svc_infra/cli/cmds/docs/docs_cmds.pyL54-R64](diffhunk://#diff-017688f18528747e9f85f3257f496618cc6492a6dfaf7ed9854a64fc06a241c9L54-R64))
* Simplified the CLI documentation commands: removed the `list` subcommand and replaced it with topic discovery via `docs --help`. The dynamic subcommand approach (`docs <topic>`) and the explicit `show` command are now the main ways to access documentation topics. (`src/svc_infra/cli/cmds/docs/docs_cmds.py`, [src/svc_infra/cli/cmds/help.pyL26-R27](diffhunk://#diff-f84f4691baec3696a679fa04c14eced2221b69415ee5b8c9b485a7a30e0f9e61L26-R27))

### MCP and API Changes

* Updated MCP functions to remove the dedicated `docs list` API and replace it with a generic `docs --help` function for topic discovery. The `Subcommand` enum and related logic were updated to match this change. (`src/svc_infra/mcp/svc_infra_mcp.py`, [[1]](diffhunk://#diff-49e1b1f24bfd056e269d70db4445c7b2df700825fef206c3afd2deab1779a2b0L23-R35) [[2]](diffhunk://#diff-49e1b1f24bfd056e269d70db4445c7b2df700825fef206c3afd2deab1779a2b0L74-R70) [[3]](diffhunk://#diff-49e1b1f24bfd056e269d70db4445c7b2df700825fef206c3afd2deab1779a2b0L117-R114)

### Test Suite Updates

* Refactored and removed tests related to the deprecated `--docs-dir` option and the `list` subcommand. Added new tests to ensure that the environment variable is the only override mechanism and that invalid options are rejected. (`tests/unit/cli/test_docs_cli.py`, [[1]](diffhunk://#diff-13006fef900fb3b71f4e62cfffeaae5aafa208b3eca8691c934e1599bf53ffa3L12-L20) [[2]](diffhunk://#diff-13006fef900fb3b71f4e62cfffeaae5aafa208b3eca8691c934e1599bf53ffa3L30-R31) [[3]](diffhunk://#diff-13006fef900fb3b71f4e62cfffeaae5aafa208b3eca8691c934e1599bf53ffa3L51-R69)

### User Guidance Improvements

* Updated help text to reflect the new usage patterns: users are now directed to use `docs --help` to discover topics and `docs <topic>` or `docs show <topic>` to view documentation. (`src/svc_infra/cli/cmds/help.py`, [src/svc_infra/cli/cmds/help.pyL26-R27](diffhunk://#diff-f84f4691baec3696a679fa04c14eced2221b69415ee5b8c9b485a7a30e0f9e61L26-R27))

### Infrastructure and Compose Tweaks

* Increased healthcheck and wait timeouts in the Docker Compose and Makefile to improve reliability of service startup in CI environments. (`docker-compose.test.yml`, [[1]](diffhunk://#diff-f4824493351fb6e294d8fcc9cd83a3d4536b8b0539a0c957afc94fa18a45ab3aL25-R33); `Makefile`, [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L13-R13)