### PR TITLE
fix(sql): Update env.py templates to use build_engine for proper SSL …

### DIFF
--- a/src/svc_infra/db/sql/templates/setup/env_async.py.tmpl
+++ b/src/svc_infra/db/sql/templates/setup/env_async.py.tmpl
@@ -101,7 +101,6 @@ def _coerce_to_async(u: URL) -> URL:
 
 u = make_url(effective_url)
 u = _coerce_to_async(u)
-u = _ensure_ssl_default(u)
 config.set_main_option("sqlalchemy.url", u.render_as_string(hide_password=False))
 
 # feature flags

--- a/src/svc_infra/db/sql/templates/setup/env_async.py.tmpl
+++ b/src/svc_infra/db/sql/templates/setup/env_async.py.tmpl
@@ -7,12 +7,8 @@ import sys, pathlib, importlib, pkgutil, traceback
 
 from alembic import context
 from sqlalchemy.engine import make_url, URL
-from sqlalchemy.ext.asyncio import create_async_engine
 
-from svc_infra.db.sql.utils import (
-    get_database_url_from_env,
-    _ensure_ssl_default_async as _ensure_ssl_default,
-)
+from svc_infra.db.sql.utils import get_database_url_from_env
 
 try:
     from svc_infra.db.sql.types import GUID as _GUID  # type: ignore
@@ -360,7 +356,9 @@ def _do_run_migrations(connection):
 
 async def run_migrations_online() -> None:
     url = config.get_main_option("sqlalchemy.url")
-    engine = create_async_engine(url)
+    # Use build_engine to ensure proper driver-specific handling (e.g., asyncpg SSL)
+    from svc_infra.db.sql.utils import build_engine
+    engine = build_engine(url)
     async with engine.connect() as connection:
         await connection.run_sync(_do_run_migrations)
     await engine.dispose()

--- a/src/svc_infra/db/sql/templates/setup/env_sync.py.tmpl
+++ b/src/svc_infra/db/sql/templates/setup/env_sync.py.tmpl
@@ -9,8 +9,6 @@ from alembic import context
 from sqlalchemy.engine import make_url, URL
 
 from svc_infra.db.sql.utils import (
-    _coerce_sync_driver,
-    _ensure_ssl_default,
     get_database_url_from_env,
     build_engine,
 )

--- a/src/svc_infra/db/sql/templates/setup/env_sync.py.tmpl
+++ b/src/svc_infra/db/sql/templates/setup/env_sync.py.tmpl
@@ -101,7 +101,6 @@ if not effective_url:
 
 u = make_url(effective_url)
 u = _coerce_sync_driver(u)
-u = _ensure_ssl_default(u)
 config.set_main_option("sqlalchemy.url", u.render_as_string(hide_password=False))
 
 


### PR DESCRIPTION
This pull request updates the Alembic migration environment scripts to standardize and improve how database engines are created, especially for handling driver-specific features like SSL (notably for asyncpg). The main change is to use the shared `build_engine` utility function instead of directly instantiating engines or handling SSL defaults in multiple places. This improves maintainability and ensures consistent engine configuration across both example and template migration scripts.

**Migration engine creation improvements:**

* Replaced direct use of `create_async_engine` in both `examples/migrations/env.py` and `src/svc_infra/db/sql/templates/setup/env_async.py.tmpl` with the shared `build_engine` function from `svc_infra.db.sql.utils` to ensure proper driver-specific handling and consistent configuration [[1]](diffhunk://#diff-227c70a979dadffd9d864a4115dc4d54bc500e7ddbfc182755611c1f651767b5L392-R393) [[2]](diffhunk://#diff-e9ace364e7eb4fe4417c09b9456eedcbb76d05a1acb2184ec4e4f8ab4fd5b53aL363-R361).
* Removed direct imports and usage of `_ensure_ssl_default_async` and `_ensure_ssl_default` from both example and template migration scripts, as SSL defaults are now handled centrally in `build_engine` [[1]](diffhunk://#diff-227c70a979dadffd9d864a4115dc4d54bc500e7ddbfc182755611c1f651767b5L15-L17) [[2]](diffhunk://#diff-e9ace364e7eb4fe4417c09b9456eedcbb76d05a1acb2184ec4e4f8ab4fd5b53aL10-R11) [[3]](diffhunk://#diff-9d5a6e421b2bf5149f2d6fd8dc83ecd72bf50fdb573a5b990b743047ed1c4d9fL12-L13).

**Configuration handling:**

* Updated the configuration setup in `examples/migrations/env.py` to no longer call `_ensure_ssl_default` directly, with a clarifying comment that SSL defaults are now handled in `build_engine()`.