### PR TITLE
feat(docs): Add scoped documentation registration for SQL resources

### DIFF
--- a/src/svc_infra/api/fastapi/db/sql/add.py
+++ b/src/svc_infra/api/fastapi/db/sql/add.py
@@ -16,6 +16,13 @@ from .session import dispose_session, initialize_session
 
 
 def add_sql_resources(app: FastAPI, resources: Sequence[SqlResource]) -> None:
+    # Register scoped docs for _sql prefix (only once)
+    if not getattr(app.state, "_sql_docs_registered", False):
+        from svc_infra.api.fastapi.docs.scoped import add_prefixed_docs
+
+        add_prefixed_docs(app, prefix="/_sql", title="SQL Resources", auto_exclude_from_root=True)
+        app.state._sql_docs_registered = True
+
     for r in resources:
         repo = SqlRepository(model=r.model, id_attr=r.id_attr, soft_delete=r.soft_delete)
 


### PR DESCRIPTION
This pull request updates the SQL resource registration in the FastAPI application to ensure that documentation for SQL endpoints is registered only once, preventing duplicate documentation and improving maintainability.

Documentation registration improvements:

* Added logic to register prefixed documentation for SQL resources (under the `/_sql` prefix) only once per application instance by checking and setting a flag on `app.state`. This avoids duplicate documentation and ensures consistent API docs for SQL endpoints.