### PR TITLE
fix(crud): update payload types in CRUD router functions to use speci…

### DIFF
--- a/src/svc_infra/api/fastapi/db/sql/crud_router.py
+++ b/src/svc_infra/api/fastapi/db/sql/crud_router.py
@@ -122,7 +122,7 @@ def make_crud_router_plus_sql(
     )
     async def create_item(
         session: SqlSessionDep,  # type: ignore[name-defined]
-        payload: Any = Body(...),
+        payload: create_schema = Body(...),
     ):
         if isinstance(payload, BaseModel):
             data = payload.model_dump(exclude_unset=True)
@@ -141,7 +141,7 @@ def make_crud_router_plus_sql(
     async def update_item(
         item_id: Any,
         session: SqlSessionDep,  # type: ignore[name-defined]
-        payload: Any = Body(...),
+        payload: update_schema = Body(...),
     ):
         if isinstance(payload, BaseModel):
             data = payload.model_dump(exclude_unset=True)
@@ -266,7 +266,7 @@ def make_tenant_crud_router_plus_sql(
     async def create_item(
         session: SqlSessionDep,  # type: ignore[name-defined]
         tenant_id: TenantId,
-        payload: Any = Body(...),
+        payload: create_schema = Body(...),
     ):
         svc = await _svc(session, tenant_id)
         if isinstance(payload, BaseModel):
@@ -282,7 +282,7 @@ def make_tenant_crud_router_plus_sql(
         item_id: Any,
         session: SqlSessionDep,  # type: ignore[name-defined]
         tenant_id: TenantId,
-        payload: Any = Body(...),
+        payload: update_schema = Body(...),
     ):
         svc = await _svc(session, tenant_id)
         if isinstance(payload, BaseModel):


### PR DESCRIPTION
This pull request updates the type annotations for the payload parameters in the `create_item` and `update_item` endpoints of the `crud_router.py` file. Instead of using the generic `Any` type, the endpoints now require specific schema types for payload validation, improving type safety and clarity.

**Improvements to endpoint payload typing:**

* Changed the `payload` parameter in the `create_item` endpoint to use `create_schema` instead of `Any` for both single-tenant and multi-tenant routes (`src/svc_infra/api/fastapi/db/sql/crud_router.py`). [[1]](diffhunk://#diff-cd60e94ca7b5608302fb767f019426173d321e9b9df6b9fe0d4e2cac3b465d05L125-R125) [[2]](diffhunk://#diff-cd60e94ca7b5608302fb767f019426173d321e9b9df6b9fe0d4e2cac3b465d05L269-R269)
* Changed the `payload` parameter in the `update_item` endpoint to use `update_schema` instead of `Any` for both single-tenant and multi-tenant routes (`src/svc_infra/api/fastapi/db/sql/crud_router.py`). [[1]](diffhunk://#diff-cd60e94ca7b5608302fb767f019426173d321e9b9df6b9fe0d4e2cac3b465d05L144-R144) [[2]](diffhunk://#diff-cd60e94ca7b5608302fb767f019426173d321e9b9df6b9fe0d4e2cac3b465d05L285-R285)