### PR TITLE
fix(tests): update test assertions and add missing refresh mocks for …

### DIFF
--- a/tests/unit/db/sql/test_sql_repository.py
+++ b/tests/unit/db/sql/test_sql_repository.py
@@ -24,9 +24,10 @@ class TestSqlRepository:
 
     @pytest.mark.asyncio
     async def test_save_success(self, sql_repository, mock_sqlalchemy_session):
-        """Test successful record saving."""
+        """Test successful record save."""
         # Mock the session.flush to simulate successful save
         mock_sqlalchemy_session.flush = AsyncMock()
+        mock_sqlalchemy_session.refresh = AsyncMock()
 
         user_data = {"email": "test@example.com", "name": "Test User"}
         result = await sql_repository.create(mock_sqlalchemy_session, user_data)
@@ -163,6 +164,7 @@ class TestSqlRepository:
 
         # Mock the session.flush to simulate successful update
         mock_sqlalchemy_session.flush = AsyncMock()
+        mock_sqlalchemy_session.refresh = AsyncMock()
 
         update_data = {"name": "New Name", "email": "new@example.com"}
         result = await sql_repository.update(mock_sqlalchemy_session, 1, update_data)

--- a/tests/unit/db/test_sql_repository_soft_delete.py
+++ b/tests/unit/db/test_sql_repository_soft_delete.py
@@ -74,6 +74,9 @@ class _Session:
     async def flush(self):
         return
 
+    async def refresh(self, obj):
+        return
+
     def delete(self, obj):
         self.store._rows.remove(obj)
 


### PR DESCRIPTION
This pull request focuses on improving test reliability and maintainability in the unit tests for SQL repositories and tenant CRUD operations. The main changes include enhancing mock session behavior, making the tenant test model more robust, and switching to Pydantic models for clearer data handling in test schemas.

**Test infrastructure improvements:**

* Added `refresh` method mocks to SQLAlchemy session mocks in `test_sql_repository.py` and `test_sql_repository_soft_delete.py` to better simulate ORM behavior in tests. [[1]](diffhunk://#diff-253f5cd779200434d24c9e3892d797b89f0ecb51e1325af13007038b825f4cd0L27-R30) [[2]](diffhunk://#diff-253f5cd779200434d24c9e3892d797b89f0ecb51e1325af13007038b825f4cd0R167) [[3]](diffhunk://#diff-b9568c85e21ce1a4f0f8a29675997b097c5973d3d7a5931c5fef66f3cb098bb9R77-R79)
* Updated test descriptions for clarity in `test_sql_repository.py`.

**Tenant CRUD router test enhancements:**

* Improved `_Model._tenant_from_where` to support both tuple and SQLAlchemy expression formats, making tenant extraction more robust.
* Updated CRUD methods in `_Model` to coerce string IDs to integers for consistent comparison, preventing type mismatch issues in tests. [[1]](diffhunk://#diff-732bc8dd1ab904022a0fdb2ef101114bd31fb116b5ba3a6c53f1cbd14cdbce41R70-R72) [[2]](diffhunk://#diff-732bc8dd1ab904022a0fdb2ef101114bd31fb116b5ba3a6c53f1cbd14cdbce41R87-R89) [[3]](diffhunk://#diff-732bc8dd1ab904022a0fdb2ef101114bd31fb116b5ba3a6c53f1cbd14cdbce41R98-R104)

**Test schema refactoring:**

* Replaced custom `_Create`, `_Update`, and `_Read` classes with Pydantic `BaseModel` subclasses, simplifying data validation and serialization in test schemas.

**Test environment handling:**

* Added conditional import and skip logic for FastAPI tests, so tests are skipped gracefully if FastAPI is not installed.