### PR TITLE
docs: add docstrings to classes missing API documentation

### DIFF
--- a/docs/api/asyncbillingservice.json
+++ b/docs/api/asyncbillingservice.json
@@ -1,7 +1,7 @@
 {
   "name": "AsyncBillingService",
   "module": "svc_infra.billing.async_service",
-  "docstring": null,
+  "docstring": "Async billing service for usage tracking and invoicing.\n\nProvides full async/await support for recording usage events,\naggregating metrics, and generating invoices for multi-tenant\nbilling workflows.\n\nAttributes:\n    session: SQLAlchemy async database session.\n    tenant_id: Tenant identifier for multi-tenant billing isolation.\n\nExample:\n    ```python\n    async with async_session_maker() as session:\n        service = AsyncBillingService(session, tenant_id=\"tenant_123\")\n        await service.record_usage(\n            metric=\"api_calls\",\n            amount=1,\n            at=datetime.now(timezone.utc),\n            idempotency_key=\"unique-key\",\n        )\n    ```",
   "parameters": [
     {
       "name": "session",

--- a/docs/api/authpolicy.json
+++ b/docs/api/authpolicy.json
@@ -1,7 +1,7 @@
 {
   "name": "AuthPolicy",
   "module": "svc_infra.api.fastapi.auth.policy",
-  "docstring": null,
+  "docstring": "Protocol defining authentication policy interface.\n\nImplement this protocol to customize authentication behavior including\nMFA requirements, login hooks, and challenge handling.",
   "parameters": [],
   "methods": [
     {

--- a/docs/api/defaultauthpolicy.json
+++ b/docs/api/defaultauthpolicy.json
@@ -1,7 +1,7 @@
 {
   "name": "DefaultAuthPolicy",
   "module": "svc_infra.api.fastapi.auth.policy",
-  "docstring": null,
+  "docstring": "Default authentication policy implementation.\n\nChecks user-level MFA settings and provides no-op hooks for login\nand challenge events. Override this class to customize MFA logic,\naudit logging, or add tenant/global policy rules.\n\nAttributes:\n    settings: Application settings for auth configuration.",
   "parameters": [
     {
       "name": "settings",

--- a/docs/api/jobqueue.json
+++ b/docs/api/jobqueue.json
@@ -1,7 +1,7 @@
 {
   "name": "JobQueue",
   "module": "svc_infra.jobs.queue",
-  "docstring": null,
+  "docstring": "Protocol defining a background job queue interface.\n\nImplementations must provide enqueue, reserve, acknowledge, and fail\noperations for reliable background job processing with retry semantics.",
   "parameters": [],
   "methods": [
     {

--- a/src/svc_infra/api/fastapi/auth/policy.py
+++ b/src/svc_infra/api/fastapi/auth/policy.py
@@ -4,6 +4,12 @@ from typing import Any, Protocol
 
 
 class AuthPolicy(Protocol):
+    """Protocol defining authentication policy interface.
+
+    Implement this protocol to customize authentication behavior including
+    MFA requirements, login hooks, and challenge handling.
+    """
+
     async def should_require_mfa(self, user: Any) -> bool:
         pass
 
@@ -15,6 +21,16 @@ class AuthPolicy(Protocol):
 
 
 class DefaultAuthPolicy:
+    """Default authentication policy implementation.
+
+    Checks user-level MFA settings and provides no-op hooks for login
+    and challenge events. Override this class to customize MFA logic,
+    audit logging, or add tenant/global policy rules.
+
+    Attributes:
+        settings: Application settings for auth configuration.
+    """
+
     def __init__(self, settings):
         self.settings = settings
 

--- a/src/svc_infra/api/fastapi/openapi/models.py
+++ b/src/svc_infra/api/fastapi/openapi/models.py
@@ -15,6 +15,12 @@ class License(BaseModel):
 
 
 class ServiceInfo(BaseModel):
+    """OpenAPI service metadata configuration.
+
+    Defines the top-level service information for OpenAPI documentation
+    including name, version, description, contact, and license details.
+    """
+
     name: str = "Service Infrastructure App"
     release: str = "0.1.0"
     description: str | None = None

--- a/src/svc_infra/billing/async_service.py
+++ b/src/svc_infra/billing/async_service.py
@@ -33,6 +33,29 @@ from .models import Invoice, InvoiceLine, UsageAggregate, UsageEvent
 
 
 class AsyncBillingService:
+    """Async billing service for usage tracking and invoicing.
+
+    Provides full async/await support for recording usage events,
+    aggregating metrics, and generating invoices for multi-tenant
+    billing workflows.
+
+    Attributes:
+        session: SQLAlchemy async database session.
+        tenant_id: Tenant identifier for multi-tenant billing isolation.
+
+    Example:
+        ```python
+        async with async_session_maker() as session:
+            service = AsyncBillingService(session, tenant_id="tenant_123")
+            await service.record_usage(
+                metric="api_calls",
+                amount=1,
+                at=datetime.now(timezone.utc),
+                idempotency_key="unique-key",
+            )
+        ```
+    """
+
     def __init__(self, session: AsyncSession, tenant_id: str):
         self.session = session
         self.tenant_id = tenant_id

--- a/src/svc_infra/db/sql/resource.py
+++ b/src/svc_infra/db/sql/resource.py
@@ -13,6 +13,20 @@ if TYPE_CHECKING:
 
 @dataclass
 class SqlResource:
+    """Configuration for SQL CRUD resource endpoints.
+
+    Defines the model, URL prefix, schemas, and behavior options for
+    auto-generated REST API endpoints with support for soft-delete,
+    search, ordering, and multi-tenant isolation.
+
+    Attributes:
+        model: SQLAlchemy model class for the resource.
+        prefix: URL prefix for the resource endpoints (e.g., "/users").
+        tags: OpenAPI tags for documentation grouping.
+        soft_delete: If True, delete marks records instead of removing them.
+        tenant_field: Field name for multi-tenant row-level isolation.
+    """
+
     model: type[object]
     prefix: str
     tags: list[str] | None = None

--- a/src/svc_infra/jobs/queue.py
+++ b/src/svc_infra/jobs/queue.py
@@ -42,6 +42,12 @@ class Job:
 
 
 class JobQueue(Protocol):
+    """Protocol defining a background job queue interface.
+
+    Implementations must provide enqueue, reserve, acknowledge, and fail
+    operations for reliable background job processing with retry semantics.
+    """
+
     def enqueue(self, name: str, payload: dict[str, Any], *, delay_seconds: int = 0) -> Job:
         pass
 

--- a/src/svc_infra/webhooks/service.py
+++ b/src/svc_infra/webhooks/service.py
@@ -10,6 +10,18 @@ from svc_infra.webhooks.encryption import encrypt_secret
 
 @dataclass
 class WebhookSubscription:
+    """Webhook subscription configuration.
+
+    Represents a registered webhook endpoint that receives events
+    for a specific topic with HMAC signature verification.
+
+    Attributes:
+        topic: Event topic to subscribe to (e.g., "order.created").
+        url: Destination URL for webhook delivery.
+        secret: HMAC signing secret for payload verification.
+        id: Unique subscription identifier (auto-generated).
+    """
+
     topic: str
     url: str
     secret: str
@@ -37,6 +49,17 @@ class InMemoryWebhookSubscriptions:
 
 
 class WebhookService:
+    """Service for publishing webhook events via the outbox pattern.
+
+    Provides reliable webhook delivery by encrypting secrets and
+    enqueuing messages to an outbox store for later processing.
+    Supports fan-out to multiple subscribers per topic.
+
+    Attributes:
+        _outbox: OutboxStore for reliable message persistence.
+        _subs: Subscription registry for topic-to-endpoint mapping.
+    """
+
     def __init__(self, outbox: OutboxStore, subs: InMemoryWebhookSubscriptions):
         self._outbox = outbox
         self._subs = subs


### PR DESCRIPTION
Adds docstrings to classes that were missing them in the generated API reference:

- AsyncBillingService
- AuthPolicy
- DefaultAuthPolicy
- JobQueue
- ServiceInfo
- SqlResource
- WebhookSubscription
- WebhookService

This ensures all exported classes have proper documentation in the API reference.