### PR TITLE
fix: use griffe labels for async method detection

### DIFF
--- a/docs/api/asyncbillingservice.json
+++ b/docs/api/asyncbillingservice.json
@@ -81,7 +81,7 @@
         }
       ],
       "returns": "int",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -122,7 +122,7 @@
         }
       ],
       "returns": "str",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -163,7 +163,7 @@
         }
       ],
       "returns": "list[UsageAggregate]",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -218,7 +218,7 @@
         }
       ],
       "returns": "str",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,

--- a/docs/api/authpolicy.json
+++ b/docs/api/authpolicy.json
@@ -25,7 +25,7 @@
         }
       ],
       "returns": "None",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -52,7 +52,7 @@
         }
       ],
       "returns": "None",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -79,7 +79,7 @@
         }
       ],
       "returns": "bool",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,

--- a/docs/api/defaultauthpolicy.json
+++ b/docs/api/defaultauthpolicy.json
@@ -60,7 +60,7 @@
         }
       ],
       "returns": "None",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -87,7 +87,7 @@
         }
       ],
       "returns": "None",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -114,7 +114,7 @@
         }
       ],
       "returns": "bool",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,

--- a/docs/api/githubloader.json
+++ b/docs/api/githubloader.json
@@ -165,7 +165,7 @@
         }
       ],
       "returns": "list[LoadedContent]",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,

--- a/docs/api/inmemoryscheduler.json
+++ b/docs/api/inmemoryscheduler.json
@@ -94,7 +94,7 @@
         }
       ],
       "returns": "None",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -114,7 +114,7 @@
         }
       ],
       "returns": "None",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,

--- a/docs/api/nosqlrepository.json
+++ b/docs/api/nosqlrepository.json
@@ -137,7 +137,7 @@
         }
       ],
       "returns": "int",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -178,7 +178,7 @@
         }
       ],
       "returns": "int",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -212,7 +212,7 @@
         }
       ],
       "returns": "dict[str, Any]",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -246,7 +246,7 @@
         }
       ],
       "returns": "bool",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -280,7 +280,7 @@
         }
       ],
       "returns": "bool",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -314,7 +314,7 @@
         }
       ],
       "returns": "dict | None",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -369,7 +369,7 @@
         }
       ],
       "returns": "builtins.list[dict[str, Any]]",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -431,7 +431,7 @@
         }
       ],
       "returns": "builtins.list[dict[str, Any]]",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -472,7 +472,7 @@
         }
       ],
       "returns": "dict | None",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,

--- a/docs/api/sqlrepository.json
+++ b/docs/api/sqlrepository.json
@@ -137,7 +137,7 @@
         }
       ],
       "returns": "int",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -185,7 +185,7 @@
         }
       ],
       "returns": "int",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -219,7 +219,7 @@
         }
       ],
       "returns": "Any",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -260,7 +260,7 @@
         }
       ],
       "returns": "bool",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -294,7 +294,7 @@
         }
       ],
       "returns": "bool",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -335,7 +335,7 @@
         }
       ],
       "returns": "Any | None",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -390,7 +390,7 @@
         }
       ],
       "returns": "Sequence[Any]",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -459,7 +459,7 @@
         }
       ],
       "returns": "Sequence[Any]",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,
@@ -507,7 +507,7 @@
         }
       ],
       "returns": "Any | None",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,

--- a/docs/api/urlloader.json
+++ b/docs/api/urlloader.json
@@ -137,7 +137,7 @@
         }
       ],
       "returns": "list[LoadedContent]",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,

--- a/docs/api/workerrunner.json
+++ b/docs/api/workerrunner.json
@@ -108,7 +108,7 @@
         }
       ],
       "returns": "None",
-      "is_async": false,
+      "is_async": true,
       "is_classmethod": false,
       "is_staticmethod": false,
       "is_property": false,

--- a/scripts/extract_api_docs.py
+++ b/scripts/extract_api_docs.py
@@ -417,7 +417,7 @@ def extract_function(func: Function) -> dict[str, Any]:
         "docstring": docstring_text,
         "parameters": extracted_params,
         "returns": return_type,
-        "is_async": func.is_async if hasattr(func, "is_async") else False,
+        "is_async": "async" in (func.labels if hasattr(func, "labels") else set()),
         "is_classmethod": is_classmethod,
         "is_staticmethod": is_staticmethod,
         "is_property": is_property,


### PR DESCRIPTION
fix: use griffe labels for async method detection