### PR TITLE
fix: resolve JWT secret from AUTH_JWT_SECRET / JWT_SECRET env vars

### DIFF
--- a/src/svc_infra/api/fastapi/auth/mfa/pre_auth.py
+++ b/src/svc_infra/api/fastapi/auth/mfa/pre_auth.py
@@ -1,24 +1,11 @@
 from datetime import UTC, datetime
 
-from svc_infra.api.fastapi.auth.settings import get_auth_settings
-from svc_infra.app.env import require_secret
+from svc_infra.api.fastapi.auth.settings import get_auth_settings, resolve_jwt_secret
 
 
 def get_mfa_pre_jwt_writer():
+    secret = str(resolve_jwt_secret(dev_default="dev-only-mfa-jwt-secret-not-for-production"))
     st = get_auth_settings()
-    jwt_block = getattr(st, "jwt", None)
-
-    # Force to plain string - use require_secret to ensure it's set in production
-    if jwt_block and getattr(jwt_block, "secret", None):
-        secret = jwt_block.secret.get_secret_value()
-    else:
-        secret = require_secret(
-            None,
-            "JWT_SECRET (via auth settings jwt.secret for MFA)",
-            dev_default="dev-only-mfa-jwt-secret-not-for-production",
-        )
-    secret = str(secret)
-
     lifetime = int(getattr(st, "mfa_pre_token_lifetime_seconds", 300))
 
     class PreTokenWriter:

--- a/src/svc_infra/api/fastapi/auth/settings.py
+++ b/src/svc_infra/api/fastapi/auth/settings.py
@@ -116,13 +116,15 @@ def resolve_jwt_secret(*, dev_default: str = "dev-only-jwt-secret-not-for-produc
     st = get_auth_settings()
     jwt_block = getattr(st, "jwt", None)
     if jwt_block and getattr(jwt_block, "secret", None):
-        return jwt_block.secret.get_secret_value()
+        return str(jwt_block.secret.get_secret_value())
 
     env_secret = os.getenv("AUTH_JWT_SECRET") or os.getenv("JWT_SECRET")
-    return require_secret(
-        env_secret,
-        "JWT_SECRET (via auth settings jwt.secret)",
-        dev_default=dev_default,
+    return str(
+        require_secret(
+            env_secret,
+            "JWT_SECRET (via auth settings jwt.secret)",
+            dev_default=dev_default,
+        )
     )
 
 

--- a/src/svc_infra/jobs/easy.py
+++ b/src/svc_infra/jobs/easy.py
@@ -24,7 +24,9 @@ def easy_jobs(*, driver: str | None = None) -> tuple[JobQueue, InMemoryScheduler
     # Choose backend
     queue: JobQueue
     if cfg.driver == "redis":
-        url: str = os.getenv("JOBS_REDIS_URL") or os.getenv("REDIS_URL") or "redis://localhost:6379/0"
+        url: str = (
+            os.getenv("JOBS_REDIS_URL") or os.getenv("REDIS_URL") or "redis://localhost:6379/0"
+        )
         client = Redis.from_url(url)
         queue = RedisJobQueue(client)
     else:

--- a/src/svc_infra/jobs/easy.py
+++ b/src/svc_infra/jobs/easy.py
@@ -24,7 +24,7 @@ def easy_jobs(*, driver: str | None = None) -> tuple[JobQueue, InMemoryScheduler
     # Choose backend
     queue: JobQueue
     if cfg.driver == "redis":
-        url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        url = os.getenv("JOBS_REDIS_URL") or os.getenv("REDIS_URL", "redis://localhost:6379/0")
         client = Redis.from_url(url)
         queue = RedisJobQueue(client)
     else:

--- a/src/svc_infra/jobs/easy.py
+++ b/src/svc_infra/jobs/easy.py
@@ -24,7 +24,7 @@ def easy_jobs(*, driver: str | None = None) -> tuple[JobQueue, InMemoryScheduler
     # Choose backend
     queue: JobQueue
     if cfg.driver == "redis":
-        url = os.getenv("JOBS_REDIS_URL") or os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        url: str = os.getenv("JOBS_REDIS_URL") or os.getenv("REDIS_URL") or "redis://localhost:6379/0"
         client = Redis.from_url(url)
         queue = RedisJobQueue(client)
     else:

--- a/tests/unit/auth/routers/test_oauth_helpers.py
+++ b/tests/unit/auth/routers/test_oauth_helpers.py
@@ -561,12 +561,9 @@ class TestValidateAndDecodeJwtToken:
         )
 
         with patch(
-            "svc_infra.api.fastapi.auth.routers.oauth_router.get_auth_settings"
-        ) as mock_settings:
-            mock_jwt = MagicMock()
-            mock_jwt.secret.get_secret_value.return_value = secret
-            mock_settings.return_value.jwt = mock_jwt
-
+            "svc_infra.api.fastapi.auth.routers.oauth_router.resolve_jwt_secret",
+            return_value=secret,
+        ):
             result = await _validate_and_decode_jwt_token(token)
 
         assert result == "user-123"
@@ -575,12 +572,9 @@ class TestValidateAndDecodeJwtToken:
     async def test_rejects_invalid_token(self) -> None:
         """Should raise for invalid token."""
         with patch(
-            "svc_infra.api.fastapi.auth.routers.oauth_router.get_auth_settings"
-        ) as mock_settings:
-            mock_jwt = MagicMock()
-            mock_jwt.secret.get_secret_value.return_value = "secret"
-            mock_settings.return_value.jwt = mock_jwt
-
+            "svc_infra.api.fastapi.auth.routers.oauth_router.resolve_jwt_secret",
+            return_value="secret",
+        ):
             with pytest.raises(HTTPException) as exc_info:
                 await _validate_and_decode_jwt_token("invalid-token")
 

--- a/tests/unit/auth/test_resolve_jwt_secret.py
+++ b/tests/unit/auth/test_resolve_jwt_secret.py
@@ -1,0 +1,110 @@
+"""Tests for resolve_jwt_secret env-var fallback behaviour."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from svc_infra.api.fastapi.auth.settings import resolve_jwt_secret
+from svc_infra.app.env import MissingSecretError
+
+
+class TestResolveJwtSecret:
+    """Verify the JWT secret resolution order."""
+
+    def test_uses_jwt_block_secret_when_present(self) -> None:
+        """AuthSettings.jwt.secret (AUTH_JWT__SECRET) takes priority."""
+        mock_jwt = MagicMock()
+        mock_jwt.secret.get_secret_value.return_value = "from-nested-settings"
+        mock_settings = MagicMock()
+        mock_settings.jwt = mock_jwt
+
+        with patch(
+            "svc_infra.api.fastapi.auth.settings.get_auth_settings",
+            return_value=mock_settings,
+        ):
+            assert resolve_jwt_secret() == "from-nested-settings"
+
+    def test_falls_back_to_auth_jwt_secret_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """AUTH_JWT_SECRET (single underscore) is honoured as fallback."""
+        mock_settings = MagicMock()
+        mock_settings.jwt = None
+
+        monkeypatch.setenv("AUTH_JWT_SECRET", "from-single-underscore")
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        monkeypatch.setenv("APP_ENV", "dev")
+
+        with patch(
+            "svc_infra.api.fastapi.auth.settings.get_auth_settings",
+            return_value=mock_settings,
+        ):
+            assert resolve_jwt_secret() == "from-single-underscore"
+
+    def test_falls_back_to_jwt_secret_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bare JWT_SECRET env var is honoured when AUTH_JWT_SECRET missing."""
+        mock_settings = MagicMock()
+        mock_settings.jwt = None
+
+        monkeypatch.delenv("AUTH_JWT_SECRET", raising=False)
+        monkeypatch.setenv("JWT_SECRET", "from-bare-env")
+        monkeypatch.setenv("APP_ENV", "dev")
+
+        with patch(
+            "svc_infra.api.fastapi.auth.settings.get_auth_settings",
+            return_value=mock_settings,
+        ):
+            assert resolve_jwt_secret() == "from-bare-env"
+
+    def test_auth_jwt_secret_takes_priority_over_jwt_secret(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AUTH_JWT_SECRET wins over JWT_SECRET."""
+        mock_settings = MagicMock()
+        mock_settings.jwt = None
+
+        monkeypatch.setenv("AUTH_JWT_SECRET", "winner")
+        monkeypatch.setenv("JWT_SECRET", "loser")
+        monkeypatch.setenv("APP_ENV", "dev")
+
+        with patch(
+            "svc_infra.api.fastapi.auth.settings.get_auth_settings",
+            return_value=mock_settings,
+        ):
+            assert resolve_jwt_secret() == "winner"
+
+    def test_returns_dev_default_when_no_secret_in_dev(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In dev, returns the dev_default when nothing is set."""
+        mock_settings = MagicMock()
+        mock_settings.jwt = None
+
+        monkeypatch.delenv("AUTH_JWT_SECRET", raising=False)
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        monkeypatch.setenv("APP_ENV", "dev")
+
+        with patch(
+            "svc_infra.api.fastapi.auth.settings.get_auth_settings",
+            return_value=mock_settings,
+        ):
+            result = resolve_jwt_secret(dev_default="my-dev-default")
+            assert result == "my-dev-default"
+
+    def test_raises_in_production_when_no_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """In production, raises MissingSecretError when nothing is set."""
+        mock_settings = MagicMock()
+        mock_settings.jwt = None
+
+        monkeypatch.delenv("AUTH_JWT_SECRET", raising=False)
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        monkeypatch.setenv("APP_ENV", "prod")
+
+        with (
+            patch(
+                "svc_infra.api.fastapi.auth.settings.get_auth_settings",
+                return_value=mock_settings,
+            ),
+            pytest.raises(MissingSecretError),
+        ):
+            resolve_jwt_secret()


### PR DESCRIPTION
## What

Extract `resolve_jwt_secret()` to centralise JWT secret resolution with env var fallbacks.

## Why

Pydantic `env_nested_delimiter='__'` requires `AUTH_JWT__SECRET` (double underscore) to populate nested `jwt.secret`, but users naturally set `AUTH_JWT_SECRET` (single underscore). This caused `MissingSecretError` in production even with the env var set.

## Resolution Order

1. `AuthSettings.jwt.secret` (`AUTH_JWT__SECRET` with double underscore)
2. `AUTH_JWT_SECRET` env var (single underscore — common user expectation)
3. `JWT_SECRET` env var (bare name)
4. `require_secret()` (raises in production, returns dev_default otherwise)

## Changes

- New `resolve_jwt_secret()` in `auth/settings.py` used by all 4 call sites
- Removed duplicated jwt-block-or-require_secret patterns from add.py, oauth_router.py, pre_auth.py, user- Removed duplicated jwt-block-or-require_secret patterns from add.py, oauth_router.py, pre_auth.py, user- Removed duplicated jwt-block-or-require_secret patternsgs in 2.76s
```