### PR TITLE
fix: include exception class name in catchall error detail when message is empty

### DIFF
--- a/src/svc_infra/api/fastapi/middleware/errors/catchall.py
+++ b/src/svc_infra/api/fastapi/middleware/errors/catchall.py
@@ -35,12 +35,13 @@ class CatchAllExceptionMiddleware:
                 except Exception:
                     pass
             else:
+                detail = str(exc) or f"{type(exc).__name__}: (no message)"
                 body = json.dumps(
                     {
                         "type": "about:blank",
                         "title": "Internal Server Error",
                         "status": 500,
-                        "detail": str(exc),
+                        "detail": detail,
                         "instance": scope.get("path", "/"),
                         "code": "INTERNAL_ERROR",
                     }


### PR DESCRIPTION
fix: include exception class name in catchall error detail when message is empty