### PR TITLE
fix: let semantic-release version handle push and github release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,21 +64,19 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           # Bump version locally without pushing (we control the push)
-          # Note: do not parse stdout — the last line is not always the version
-          # (e.g. "No build command specified, skipping" appears after the version)
-          poetry run semantic-release version --no-push 2>&1
+          # Bump version, commit, tag, push, and create GitHub Release in one step.
+          # semantic-release version (without --no-push) handles all of this using
+          # GH_TOKEN for auth. upload_to_vcs_release=true (default) creates the
+          # GitHub Release automatically.
+          poetry run semantic-release version 2>&1
 
-          # Check if HEAD is now tagged (semantic-release creates the tag locally)
+          # Check if HEAD is now tagged by semantic-release
           TAG=$(git describe --exact-match HEAD 2>/dev/null || echo "")
           if [[ -n "$TAG" ]]; then
             echo "released=true" >> "$GITHUB_OUTPUT"
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-            # Push branch first, then tag separately for reliable event delivery
-            git push origin main
-            git push origin "$TAG"
-
-            # Create GitHub Release
+            # Upload built artifacts to the GitHub Release
             poetry run semantic-release publish
           else
             echo "released=false" >> "$GITHUB_OUTPUT"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5801,14 +5801,14 @@ files = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.5"
+version = "3.1.6"
 description = "The comprehensive WSGI web application library."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc"},
-    {file = "werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67"},
+    {file = "werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131"},
+    {file = "werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,7 @@ branch = "main"
 tag_format = "v{version}"
 changelog_file = "CHANGELOG.md"
 upload_to_pypi = false
-upload_to_release = false
+upload_to_vcs_release = true  # create GitHub Release and upload artifacts
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["feat", "fix", "perf", "refactor", "docs", "chore", "test", "build", "ci"]


### PR DESCRIPTION
fix: let semantic-release version handle push and github release creation