### PR TITLE
feat: add connect OAuth module with 60+ providers and unify auth provider system

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -13,3 +13,9 @@ CVE-2025-49796
 # Date added: 2026-01-31
 # Review by: 2026-02-28 (remove once base images are patched)
 CVE-2025-15467
+
+# Context: postgres:16-alpine on Alpine 3.23.3 ships zlib 1.3.1-r2 with CVE-2026-22184
+# Fixed in zlib 1.3.2-r0 - waiting for base image update
+# Date added: 2026-03-17
+# Review by: 2026-04-17 (remove once base image is patched)
+CVE-2026-22184

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,447 @@
 
 > **Current Version**: 1.1.0
 > **Target v1.0.0**: Phase 0 completion (Email Infrastructure)
-> **Target v2.0.0**: Phase 1-4 completion
+> **Target v1.5.0**: Phase 1 completion (`svc_infra.connect` — Connection OAuth module)
+> **Target v2.0.0**: Phase 1-6 completion
+
+---
+
+## Phase 1: Connection OAuth Module — `svc_infra.connect` (v1.5.x)
+
+**Goal**: Build a first-class `svc_infra.connect` module that brings Nango-equivalent OAuth token
+management into svc-infra, plus full support for the MCP Authorization spec (RFC 9728 + OAuth 2.1
++ PKCE). Any nfrax application (pulse, folio, aspect) mounts this with one line and gets complete
+OAuth flows for third-party service connections — with tokens stored, encrypted, and auto-refreshed
+inside the app's own database. For MCP-specific operations, the module delegates to `ai-infra`'s
+`MCPClient` where applicable rather than reimplementing MCP protocol logic.
+
+**Why not Nango (hosted)?** Token custody stays on your infrastructure. No per-connection pricing.
+No vendor dependency.
+
+**Why not Nango (self-hosted)?** Same functionality, zero new infrastructure, shared DB with the
+rest of app state, and the MCP Authorization spec layer that Nango does not model.
+
+**Existing svc-infra infrastructure reused by this module:**
+
+| What | Where | How it is reused |
+|---|---|---|
+| `ModelBase` | `svc_infra.db.sql.base` | Base class for every new model in this module |
+| `GUID()` | `svc_infra.db.sql.types` | Portable UUID column, consistent with all other models |
+| `SqlRepository` | `svc_infra.db.sql.repository` | `ConnectionTokenManager` wraps it for upsert / lookup |
+| `SqlSessionDep` | `svc_infra.api.fastapi.db.sql.session` | Typed `Annotated[AsyncSession, Depends(get_session)]` used in all router endpoints |
+| `_gen_pkce_pair()` | `oauth_router.py` | Implementation moved verbatim to `connect/pkce.py` as public `generate_pkce_pair()` |
+| `_validate_redirect()` | `oauth_router.py` | Copied to `connect/pkce.py` for redirect URI allow-list enforcement |
+| `_coerce_expires_at()` | `oauth_router.py` | Copied to `connect/pkce.py` to normalise `expires_at`/`expires_in` from provider token responses |
+| `discover_packages()` | `apf_payments/alembic.py` | Same pattern: `connect/alembic.py` exports `discover_packages()` listing `svc_infra.connect.models` |
+| `init_alembic()` | `svc_infra.db.sql.core` | Alembic init + migration commands just pass `"svc_infra.connect.models"` to the existing CLI |
+| `BaseSettings` / `pydantic_settings` | `email/settings.py`, `auth/settings.py` | `ConnectSettings` follows the exact same pattern |
+| Lifespan wrapping | `api/fastapi/db/sql/add.py` `add_sql_db()` | `add_connect()` uses the same `existing_lifespan` wrap idiom |
+| `InMemoryScheduler` | `svc_infra.jobs` | Background token-refresh and `OAuthState` cleanup registered via `easy_jobs()` |
+
+---
+
+### 1.1 Data Models
+
+> Foundational DB models for connection tokens and provider configuration.
+> Follows the exact same SQLAlchemy conventions as `ProviderAccount` (`security/oauth_models.py`)
+> and `AuthSession` (`security/models.py`) — `ModelBase`, `GUID()`, `DateTime(timezone=True)`,
+> `text("CURRENT_TIMESTAMP")` server defaults, `onupdate` lambda for `updated_at`.
+
+**Files to create:**
+- `src/svc_infra/connect/models.py`
+- `src/svc_infra/connect/alembic.py` — Alembic package discovery; same pattern as
+  `src/svc_infra/apf_payments/alembic.py`; exports `discover_packages() -> list[str]`
+  returning `["svc_infra.connect.models"]`; no custom env.py or separate migrations folder
+
+**`ConnectionToken` model** — inherits `ModelBase`; keyed to a `(user_id, connection_id)` pair;
+distinct from `ProviderAccount` which is keyed to a login provider account:
+
+- [x] `id: Mapped[uuid.UUID]` — `GUID()` primary key, `default=uuid.uuid4`
+- [x] `connection_id: Mapped[uuid.UUID]` — `GUID()`; logical FK to consuming app's connection
+  table; not enforced at DB level so the connect module has no hard dep on app schemas
+- [x] `user_id: Mapped[uuid.UUID]` — `GUID()`, `ForeignKey("users.id", ondelete="CASCADE")`,
+  `index=True`; mirrors `ProviderAccount.user_id` convention exactly
+- [x] `provider: Mapped[str]` — `String(255)`, `index=True`; `"github"`, `"notion"`, or
+  `"mcp:https://api.example.com/mcp/"` for dynamically discovered MCP servers
+- [x] `access_token: Mapped[str]` — `Text`; Fernet-encrypted at rest; never logged
+- [x] `refresh_token: Mapped[str | None]` — `Text`; Fernet-encrypted; `None` for non-refreshable
+  tokens (e.g. PATs)
+- [x] `token_type: Mapped[str]` — `String(32)`, default `"Bearer"`
+- [x] `expires_at: Mapped[datetime | None]` — `DateTime(timezone=True)`; `None` = non-expiring
+- [x] `scopes: Mapped[list | None]` — `JSON` column; list of scope strings
+- [x] `raw_token: Mapped[dict | None]` — `JSON`; full provider response; Fernet-encrypted JSON
+  blob; preserves provider-specific fields (`installation_id`, `bot_id`, etc.)
+- [x] `created_at` — `DateTime(timezone=True)`, `server_default=text("CURRENT_TIMESTAMP")`
+- [x] `updated_at` — `DateTime(timezone=True)`, `server_default=text("CURRENT_TIMESTAMP")`,
+  `onupdate=lambda: datetime.now(UTC)` — same pattern as `ProviderAccount.updated_at`
+- [x] `UniqueConstraint("connection_id", "user_id", "provider")` — named
+  `uq_connection_token`
+- [x] `Index("ix_connection_tokens_user_provider", "user_id", "provider")`
+
+**`OAuthState` model** — inherits `ModelBase`; short-lived PKCE/state store; replaces the
+`SessionMiddleware`-based state that `oauth_router.py` uses, enabling stateless API servers:
+
+- [x] `id: Mapped[uuid.UUID]` — `GUID()` primary key, `default=uuid.uuid4`
+- [x] `state: Mapped[str]` — `String(128)`, `index=True`; 32-byte URL-safe random value;
+  SHA-256 verified on callback to prevent timing oracle attacks
+- [x] `pkce_verifier: Mapped[str]` — `Text`; stored server-side; sent to token endpoint
+- [x] `provider: Mapped[str]` — `String(255)`
+- [x] `connection_id: Mapped[uuid.UUID | None]` — `GUID()`; pre-linked before redirect
+- [x] `user_id: Mapped[uuid.UUID]` — `GUID()`, `ForeignKey("users.id", ondelete="CASCADE")`
+- [x] `redirect_uri: Mapped[str]` — `Text`; validated against allow-list using
+  `_validate_redirect()` from `oauth_router.py` before storage
+- [x] `expires_at: Mapped[datetime]` — `DateTime(timezone=True)`, `index=True`; 10-minute TTL;
+  background `InMemoryScheduler` job purges expired rows
+- [x] `created_at` — `DateTime(timezone=True)`, `server_default=text("CURRENT_TIMESTAMP")`
+
+---
+
+### 1.2 Provider Registry
+
+> Static provider configuration; apps register providers at startup.
+
+**Files to create:**
+- `src/svc_infra/connect/registry.py`
+- `src/svc_infra/connect/providers/` (built-in provider definitions)
+  - `__init__.py`
+  - `github.py`
+  - `notion.py`
+  - `google.py`
+  - `microsoft.py`
+  - `slack.py`
+  - `linear.py`
+  - `atlassian.py`
+
+**`OAuthProvider` dataclass** — follows `OIDCProvider` / `PasswordClient` Pydantic model
+conventions from `auth/settings.py`; use `pydantic.BaseModel` (not `dataclass`) to stay
+consistent with the rest of the auth module:
+
+- [x] `name: str` — unique identifier
+- [x] `client_id: str`
+- [x] `client_secret: SecretStr` — `pydantic.SecretStr`; never logged or serialized in
+  responses; same as `OIDCProvider.client_secret`
+- [x] `authorize_url: str`
+- [x] `token_url: str`
+- [x] `revoke_url: str | None` — default `None`
+- [x] `default_scopes: list[str]`
+- [x] `pkce_required: bool` — default `True` (all modern providers)
+- [x] `extra_authorize_params: dict[str, str]` — provider-specific params
+  (e.g. GitHub needs `allow_signup=false` for org installs)
+- [x] `token_placement: Literal["header", "query"]` — default `"header"`
+- [x] `userinfo_url: str | None` — for fetching account metadata after auth
+
+**`ConnectRegistry` (module-level singleton):**
+
+- [x] `register(provider: OAuthProvider) -> None`
+- [x] `get(name: str) -> OAuthProvider | None`
+- [x] `list() -> list[OAuthProvider]`
+- [x] Built-in providers loaded from `providers/` at import time if env vars present
+
+**Built-in provider implementations:**
+
+- [x] `github.py` — `authorize_url`, `token_url`, scope options (`repo`, `copilot`, `user:email`)
+- [x] `notion.py` — Notion OAuth 2.0 (non-PKCE, but module adds PKCE layer)
+- [x] `google.py` — reuses the OIDC issuer URL from `OIDCProvider` in `auth/settings.py`;
+  maps Google's `openid email profile` scopes to connection-appropriate drive/calendar scopes
+- [x] `microsoft.py` — reuses Entra tenant config from `AuthSettings.ms_tenant` in
+  `auth/settings.py`; separate `OAuthProvider` instance for connection scope (not login)
+- [x] `slack.py` — Slack v2 OAuth with bot/user token distinction
+- [x] `linear.py` — Linear OAuth 2.0
+- [x] `atlassian.py` — Atlassian OAuth 2.0 (Jira, Confluence)
+
+---
+
+### 1.3 MCP Authorization Spec Discovery
+
+> RFC 9728 resource metadata → OAuth authorization server metadata → dynamic provider config.
+> Delegates MCP protocol operations to `ai_infra.mcp.client.MCPClient`.
+
+**Files to create:**
+- `src/svc_infra/connect/mcp_discovery.py`
+
+**`MCPOAuthDiscovery` class:**
+
+- [x] `discover(mcp_server_url: str) -> OAuthProvider`
+  - Fetches `{mcp_server_url}/.well-known/oauth-protected-resource` (RFC 9728)
+  - Parses `authorization_servers[0]` from the resource metadata
+  - Fetches `{auth_server}/.well-known/oauth-authorization-server` (RFC 8414)
+  - Extracts `authorization_endpoint`, `token_endpoint`, `revocation_endpoint`,
+    `code_challenge_methods_supported`
+  - Returns a fully-populated `OAuthProvider` with `name = "mcp:{mcp_server_url}"`
+  - Caches results in-process (TTL 1 hour) — MCP server metadata rarely changes
+  - Raises `MCPOAuthNotSupported` if server returns no `www-authenticate` header or
+    no `resource_metadata` field
+
+- [x] `MCPOAuthNotSupported` exception — raised when a server does not implement the spec;
+  callers fall back to the manual-token UX
+
+- [x] `parse_www_authenticate(header: str) -> dict[str, str]`
+  — parses `Bearer resource_metadata="..."` header format
+
+- [x] `is_mcp_oauth_supported(mcp_server_url: str) -> bool`
+  — lightweight check before full discovery; probes with a bare POST and inspects 401 headers
+
+**Integration with `ai-infra`:**
+
+- [x] After token acquisition, `ConnectionToken.access_token` is injected into the `headers`
+  config of the MCP connection; `ai_infra.mcp.client.MCPClient` picks it up through the
+  standard `Authorization: Bearer` header path — no changes needed in ai-infra
+- [x] `svc_infra.connect` is not aware of MCP protocol internals; it is only responsible for
+  obtaining and refreshing the OAuth token; tool discovery and invocation remain in ai-infra
+
+---
+
+### 1.4 PKCE Flow Engine
+
+> Core OAuth 2.1 + PKCE flow. Pulls three private helpers out of `oauth_router.py` and
+> exposes them as a public module so the connect router and token manager can import them
+> without depending on the auth router internals.
+
+**Files to create:**
+- `src/svc_infra/connect/pkce.py`
+
+- [x] `generate_pkce_pair() -> tuple[str, str]` — moves `_gen_pkce_pair()` from
+  `oauth_router.py` verbatim; same `base64.urlsafe_b64encode` + SHA-256 implementation
+- [x] `validate_redirect(url, allow_hosts, *, require_https) -> None` — moves
+  `_validate_redirect()` from `oauth_router.py` verbatim; raises `HTTPException(400)` on
+  disallowed or non-HTTPS URIs
+- [x] `coerce_expires_at(token_dict) -> datetime | None` — moves `_coerce_expires_at()` from
+  `oauth_router.py` verbatim; handles both `expires_at` (unix timestamp) and `expires_in`
+  (seconds) fields from provider token responses
+- [x] `generate_state() -> str` — 32-byte URL-safe random state value
+- [x] `build_authorize_url(provider, state, pkce_challenge, redirect_uri, scopes, extra) -> str`
+  — constructs the full redirect URL with all required OAuth parameters
+- [x] `exchange_code(provider, code, pkce_verifier, redirect_uri) -> dict`
+  — async; exchanges authorization code for token using `httpx`; raises `OAuthExchangeError`
+  on non-200 or error JSON
+- [x] `exchange_refresh(provider, refresh_token_str) -> dict`
+  — async; `refresh_token` grant; raises `OAuthRefreshError` if refresh fails or
+  refresh token field is absent
+
+---
+
+### 1.5 Token Lifecycle Manager
+
+> Storage, retrieval, and background refresh of `ConnectionToken` rows.
+> Wraps `SqlRepository` for all DB access; uses `Fernet` for encryption (new to this module;
+> no existing encryption utility in svc-infra — this is the first one).
+
+**Files to create:**
+- `src/svc_infra/connect/token_manager.py`
+
+**`ConnectionTokenManager` class** — wraps `SqlRepository(model=ConnectionToken)` from
+`svc_infra.db.sql.repository`; session parameter is always `AsyncSession` obtained via
+`SqlSessionDep` in routers or passed directly in background tasks:
+
+- [x] `__init__(self, encryption_key: str)` — initialises `Fernet(encryption_key.encode())`;
+  validates key format at construction time
+
+- [x] `store(db, user_id, connection_id, provider, token_response) -> ConnectionToken`
+  — upserts on `(connection_id, user_id, provider)` conflict; encrypts `access_token`,
+  `refresh_token`, and `raw_token` via Fernet before writing; calls `coerce_expires_at()`
+  from `connect/pkce.py` to normalise `expires_at`
+
+- [x] `get(db, connection_id, user_id, provider) -> ConnectionToken | None`
+
+- [x] `get_valid_token(db, connection_id, user_id, provider) -> str | None`
+  — returns decrypted access token; auto-refreshes if `expires_at < now + 5 minutes`;
+  returns `None` if no token or refresh fails; never raises (logs warning instead)
+
+- [x] `revoke(db, connection_id, user_id, provider) -> None`
+  — calls provider `revoke_url` if present; deletes DB row
+
+- [x] `delete_all_for_connection(db, connection_id) -> None`
+  — used when a connection is deleted by the consuming app
+
+- [x] Background refresh task: `refresh_expiring_tokens(db) -> int`
+  — refreshes all tokens expiring in the next 10 minutes; registered as a periodic
+  `InMemoryScheduler` job via `easy_jobs()` from `svc_infra.jobs`; returns count of
+  refreshed tokens
+
+---
+
+### 1.6 FastAPI Router
+
+> Three endpoints mounted by consuming apps via `add_connect(app)`.
+> All authenticated endpoints use `SqlSessionDep` from `svc_infra.api.fastapi.db.sql.session`
+> and the `Identity` / `current_user` dependency from the auth module — same pattern as
+> `apikey_router.py` and `account.py`.
+
+**Files to create:**
+- `src/svc_infra/connect/router.py`
+- `src/svc_infra/connect/add.py`
+- `src/svc_infra/connect/settings.py`
+
+**Endpoints:**
+
+- [x] `GET /connect/authorize`
+  - Dependencies: `db: SqlSessionDep`, authenticated `Identity`
+  - Query params: `connection_id`, `provider` (static) or `mcp_server_url` (dynamic discovery)
+  - If `mcp_server_url` given: runs `MCPOAuthDiscovery.discover()`, registers provider
+    in-process
+  - Validates `redirect_uri` (if provided) via `validate_redirect()` from `connect/pkce.py`
+  - Generates PKCE pair + state; persists `OAuthState` row with 10-min TTL
+  - Returns `{"authorize_url": "..."}` — client opens this URL; does not redirect server-side
+    (avoids CORS issues with API-first apps)
+
+- [x] `GET /connect/callback/{provider}`
+  - Public endpoint; state param carries identity — no auth header required
+  - `db: SqlSessionDep` dependency for OAuthState + ConnectionToken writes
+  - Validates `state` param against `OAuthState` row; rejects replayed/expired states
+  - Exchanges code via `pkce.exchange_code()`
+  - Stores `ConnectionToken` via `token_manager.store()`
+  - Deletes consumed `OAuthState` row (atomic with token store)
+  - Redirects to `OAuthState.redirect_uri` with `?success=true&connection_id=<id>`
+    or `?error=<reason>` on failure
+  - Registered callback URL shape: `{CONNECT_API_BASE}/connect/callback/{provider}`
+
+- [x] `GET /connect/token/{connection_id}`
+  - Dependencies: `db: SqlSessionDep`, authenticated `Identity`
+  - Returns `{"token": "<access_token>", "expires_at": "..."}` for the calling user
+  - Returns 404 if no token stored; 502 if refresh fails
+
+**`ConnectSettings`** — `pydantic_settings.BaseSettings` subclass; same pattern as
+`AuthSettings` and `EmailSettings`; all fields read from env vars automatically:
+
+- [x] `connect_token_encryption_key: SecretStr` — required; Fernet key; never logged or
+  serialized; generate with
+  `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
+- [x] `connect_api_base: str` — base URL of the API; used to construct callback URLs
+- [x] `connect_default_redirect_uri: str` — fallback if `OAuthState.redirect_uri` is empty;
+  supports custom URL schemes for native apps (e.g. `pulse-app://oauth/callback`)
+- [x] `connect_state_ttl_seconds: int` — default 600 (10 minutes)
+- [x] `connect_redirect_allow_hosts: str` — comma-separated allow-list; validated via
+  `validate_redirect()` from `connect/pkce.py`
+
+**`add_connect(app, *, prefix="/connect") -> None`** — follows the lifespan wrapping idiom
+from `add_sql_db()` in `api/fastapi/db/sql/add.py`:
+
+- [x] Reads `ConnectSettings()` and validates `connect_token_encryption_key` at startup;
+  raises `RuntimeError` if missing (same guard pattern as `add_sql_db()` URL check)
+- [x] Wraps any existing `app.router.lifespan_context` with startup/shutdown hooks
+- [x] Mounts `connect.router` under `prefix`
+- [x] Calls `easy_jobs()` from `svc_infra.jobs` to obtain `(queue, scheduler)`; registers
+  `refresh_expiring_tokens` as a 5-minute interval job and `OAuthState` cleanup as a
+  10-minute interval job on `InMemoryScheduler`
+
+---
+
+### 1.7 `__init__.py` Public API
+
+**Files to create:**
+- `src/svc_infra/connect/__init__.py`
+
+```python
+from svc_infra.connect.add import add_connect
+from svc_infra.connect.mcp_discovery import MCPOAuthDiscovery, MCPOAuthNotSupported
+from svc_infra.connect.models import ConnectionToken, OAuthState
+from svc_infra.connect.registry import ConnectRegistry, OAuthProvider
+from svc_infra.connect.settings import ConnectSettings
+from svc_infra.connect.token_manager import ConnectionTokenManager
+
+__all__ = [
+    "add_connect",
+    "MCPOAuthDiscovery",
+    "MCPOAuthNotSupported",
+    "ConnectionToken",
+    "OAuthState",
+    "ConnectRegistry",
+    "OAuthProvider",
+    "ConnectSettings",
+    "ConnectionTokenManager",
+]
+```
+
+---
+
+### 1.8 pulse Integration
+
+> How pulse consumes `svc_infra.connect` after the module is built.
+
+**Changes in pulse:**
+
+- [x] `api/src/pulse/main.py` — call `add_connect(app)` alongside existing `add_*` calls;
+  register `github` provider with Copilot scope
+- [x] `connections/client.py` — `_headers()` calls
+  `await token_manager.get_valid_token(db, connection_id, user_id, provider)`; injects
+  result as `Authorization: Bearer` header; existing config-based headers remain as fallback
+- [x] `routers/v0/connections.py` — sync endpoint: when `MCPOAuthNotSupported` is not raised,
+  include `{"oauth_supported": true, "authorize_url": "/connect/authorize?..."}` in 502
+  response body so Swift client can offer "Sign in" instead of "Paste token"
+- [x] `ConnectionsSettingsView.swift` — detects `oauth_supported: true` in error response;
+  opens `ASWebAuthenticationSession` with the `authorize_url`; on callback deep link
+  `pulse-app://oauth/callback?success=true&connection_id=<id>`, triggers sync automatically
+- [x] Manual token sheet (currently implemented) stays as fallback for servers that do not
+  support OAuth spec
+
+---
+
+### 1.9 Tests
+
+**Files to create:**
+- `tests/unit/connect/test_models.py`
+- `tests/unit/connect/test_registry.py`
+- `tests/unit/connect/test_mcp_discovery.py`
+- `tests/unit/connect/test_pkce.py`
+- `tests/unit/connect/test_token_manager.py`
+- `tests/unit/connect/test_router.py`
+- `tests/integration/connect/test_oauth_flow.py`
+
+- [x] Unit tests for token encryption/decryption round-trip
+- [x] Unit tests for PKCE pair generation + URL construction
+- [x] Unit tests for `MCPOAuthDiscovery` with mocked HTTP responses
+  - Valid resource metadata → valid auth server metadata → populated `OAuthProvider`
+  - Server returns 200 (no 401) → `MCPOAuthNotSupported`
+  - Malformed `www-authenticate` header → `MCPOAuthNotSupported`
+- [x] Unit tests for `ConnectionTokenManager` with in-memory SQLite
+  - Store + retrieve round-trip with encryption
+  - Auto-refresh triggers when token within 5-minute expiry window
+  - `get_valid_token` returns `None` gracefully on refresh failure (no raise)
+- [x] Unit tests for `OAuthState` TTL expiry and cleanup
+- [x] Integration test for full authorize → callback → token retrieval flow
+  (mocked provider HTTP; real DB; real PKCE verification)
+- [x] Integration test for MCP discovery → authorize → callback with GitHub Copilot
+  endpoint shapes mocked
+
+---
+
+### 1.10 Documentation
+
+**Files to create:**
+- `docs/connect.md`
+- `docs/connect-mcp-oauth.md`
+- `examples/connect/basic_oauth.py`
+- `examples/connect/mcp_oauth.py`
+- `examples/connect/fastapi_integration.py`
+
+- [x] **`docs/connect.md`** — module overview, quickstart, provider configuration reference,
+  env vars, callback URL registration guide
+- [x] **`docs/connect-mcp-oauth.md`** — MCP Authorization spec explained, how discovery works,
+  which servers currently support it (GitHub Copilot confirmed), fallback behavior
+- [x] **`examples/connect/basic_oauth.py`** — static GitHub provider, full flow in one file
+- [x] **`examples/connect/mcp_oauth.py`** — dynamic MCP discovery flow
+- [x] **`examples/connect/fastapi_integration.py`** — `add_connect()` in a full FastAPI app with
+  token injection into httpx client
+
+---
+
+### Phase 1 Success Criteria
+
+| Deliverable | Status |
+|---|---|
+| `ConnectionToken` + `OAuthState` DB models | [x] |
+| `ConnectRegistry` with 7 built-in providers | [x] |
+| `MCPOAuthDiscovery` (RFC 9728 + RFC 8414) | [x] |
+| PKCE flow engine (generate, authorize URL, exchange, refresh) | [x] |
+| `ConnectionTokenManager` (store, retrieve, auto-refresh) | [x] |
+| FastAPI router (`/connect/authorize`, `/connect/callback`, `/connect/token`) | [x] |
+| `add_connect(app)` one-line mount | [x] |
+| Token encryption at rest | [x] |
+| `OAuthState` TTL + cleanup job | [x] |
+| pulse integration plan documented | [x] |
+| Tests: unit + integration, ≥80% coverage for `connect/` | [x] |
+| `docs/connect.md` + `docs/connect-mcp-oauth.md` | [x] |
+| Examples working | [x] |
 
 ---
 
@@ -358,15 +798,15 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
 
 ---
 
-## Phase 1: Admin Dashboard UI
+## Phase 2: Admin Dashboard UI
 
 **Goal**: Provide a framework-agnostic admin dashboard for managing svc-infra resources.
 
-### 1.1 Architecture Design
+### 2.1 Architecture Design
 
 > Design an admin UI that works with FastAPI, Django, Litestar, and potentially standalone.
 
-- [ ] **Define admin dashboard scope**
+- [x] **Define admin dashboard scope**
  - [ ] User management (CRUD, search, sessions)
  - [ ] Tenant management (list, switch, usage)
  - [ ] Billing dashboard (usage graphs, invoices)
@@ -375,13 +815,13 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  - [ ] Cache management (stats, invalidation)
  - [ ] Health/metrics overview
 
-- [ ] **Choose UI approach**
+- [x] **Choose UI approach**
  - [ ] Option A: Server-rendered (HTMX + Tailwind) - recommended
  - [ ] Option B: Standalone SPA (talks to API)
  - [ ] Option C: Embeddable components
  - [ ] Document decision in ADR
 
-- [ ] **Design API endpoints**
+- [x] **Design API endpoints**
  - [ ] `GET /admin/api/users` - List users with pagination
  - [ ] `GET /admin/api/users/{id}` - User details
  - [ ] `GET /admin/api/tenants` - List tenants
@@ -390,11 +830,11 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  - [ ] `GET /admin/api/webhooks/stats` - Delivery stats
  - [ ] `GET /admin/api/health` - Health overview
 
-### 1.2 Create Admin Module Structure
+### 2.2 Create Admin Module Structure
 
 > Build the `admin/` module following existing patterns.
 
-- [ ] **Create directory structure**
+- [x] **Create directory structure**
  ```
  src/svc_infra/admin/
  ├── __init__.py
@@ -420,12 +860,12 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  └── webhook_service.py
  ```
 
-- [ ] **Create `admin/__init__.py`**
+- [x] **Create `admin/__init__.py`**
  - [ ] Export `add_admin_dashboard`
  - [ ] Export `AdminSettings`
  - [ ] Add module docstring
 
-- [ ] **Create `admin/settings.py`**
+- [x] **Create `admin/settings.py`**
  - [ ] `ADMIN_ENABLED` - Enable/disable admin
  - [ ] `ADMIN_BASE_PATH` - Mount path (default: `/_admin`)
  - [ ] `ADMIN_REQUIRE_SUPERUSER` - Require superuser role
@@ -433,17 +873,17 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  - [ ] `ADMIN_LOGO_URL` - Custom logo
  - [ ] `ADMIN_TITLE` - Dashboard title
 
-- [ ] **Create `admin/add.py`**
+- [x] **Create `admin/add.py`**
  - [ ] Follow `add_*` pattern
  - [ ] Mount admin routes
  - [ ] Add static file serving
  - [ ] Register admin services
 
-### 1.3 Implement Admin Services
+### 2.3 Implement Admin Services
 
 > Create service layer for admin operations.
 
-- [ ] **Create `admin/services/user_service.py`**
+- [x] **Create `admin/services/user_service.py`**
  - [ ] `list_users(page, per_page, search)` - Paginated user list
  - [ ] `get_user(user_id)` - User details with sessions
  - [ ] `update_user(user_id, data)` - Update user fields
@@ -451,136 +891,136 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  - [ ] `list_sessions(user_id)` - Active sessions
  - [ ] `revoke_session(session_id)` - Revoke session
 
-- [ ] **Create `admin/services/tenant_service.py`**
+- [x] **Create `admin/services/tenant_service.py`**
  - [ ] `list_tenants(page, per_page, search)` - Tenant list
  - [ ] `get_tenant(tenant_id)` - Tenant details
  - [ ] `get_tenant_usage(tenant_id)` - Usage summary
  - [ ] `get_tenant_users(tenant_id)` - Users in tenant
 
-- [ ] **Create `admin/services/billing_service.py`**
+- [x] **Create `admin/services/billing_service.py`**
  - [ ] `get_usage_summary(tenant_id, period)` - Usage stats
  - [ ] `list_invoices(tenant_id, page)` - Invoice list
  - [ ] `get_invoice(invoice_id)` - Invoice details
  - [ ] `get_subscription(tenant_id)` - Current plan
 
-- [ ] **Create `admin/services/job_service.py`**
+- [x] **Create `admin/services/job_service.py`**
  - [ ] `get_queue_status()` - Pending/processing/failed counts
  - [ ] `list_failed_jobs(page)` - Failed job list
  - [ ] `retry_job(job_id)` - Retry single job
  - [ ] `retry_all_failed()` - Retry all failed
  - [ ] `purge_dlq()` - Clear dead letter queue
 
-- [ ] **Create `admin/services/webhook_service.py`**
+- [x] **Create `admin/services/webhook_service.py`**
  - [ ] `get_delivery_stats()` - Success/failure rates
  - [ ] `list_subscriptions(tenant_id)` - Webhook subscriptions
  - [ ] `list_deliveries(subscription_id, status)` - Delivery log
  - [ ] `retry_delivery(delivery_id)` - Retry delivery
 
-### 1.4 Implement Admin API Routes
+### 2.4 Implement Admin API Routes
 
 > Create FastAPI routes for admin operations.
 
-- [ ] **Create `admin/router.py`**
+- [x] **Create `admin/router.py`**
  - [ ] Mount under `/_admin/api`
  - [ ] Apply admin role guard
  - [ ] Implement all endpoints from 1.1
 
-- [ ] **Add pagination support**
+- [x] **Add pagination support**
  - [ ] Use existing `svc_infra.api.fastapi.pagination` module
  - [ ] Consistent page/per_page/cursor pattern
 
-- [ ] **Add search support**
+- [x] **Add search support**
  - [ ] Filter parameters for list endpoints
  - [ ] Full-text search where applicable
 
-### 1.5 Implement Admin UI (HTMX)
+### 2.5 Implement Admin UI (HTMX)
 
 > Build server-rendered templates with HTMX for interactivity.
 
-- [ ] **Create base template**
+- [x] **Create base template**
  - [ ] Sidebar navigation
  - [ ] Header with user info
  - [ ] Dark/light mode toggle
  - [ ] Responsive layout
 
-- [ ] **Create dashboard page**
+- [x] **Create dashboard page**
  - [ ] Quick stats (users, tenants, jobs, webhooks)
  - [ ] Recent activity feed
  - [ ] Health status indicators
 
-- [ ] **Create users pages**
+- [x] **Create users pages**
  - [ ] User list with search/filter
  - [ ] User detail/edit form
  - [ ] Session management
  - [ ] Impersonation button
 
-- [ ] **Create tenants pages**
+- [x] **Create tenants pages**
  - [ ] Tenant list
  - [ ] Tenant detail with usage
  - [ ] Switch tenant context
 
-- [ ] **Create billing pages**
+- [x] **Create billing pages**
  - [ ] Usage graphs (Chart.js or similar)
  - [ ] Invoice list
  - [ ] Subscription management
 
-- [ ] **Create jobs pages**
+- [x] **Create jobs pages**
  - [ ] Queue status overview
  - [ ] Failed jobs list
  - [ ] Retry/purge actions
  - [ ] Job detail view
 
-- [ ] **Create webhooks pages**
+- [x] **Create webhooks pages**
  - [ ] Delivery stats dashboard
  - [ ] Subscription list
  - [ ] Delivery log viewer
  - [ ] Retry failed deliveries
 
-### 1.6 Documentation and Tests
+### 2.6 Documentation and Tests
 
-- [ ] **Create `docs/admin-dashboard.md`**
+- [x] **Create `docs/admin-dashboard.md`**
  - [ ] Setup and configuration
  - [ ] Customization options
  - [ ] Extending with custom pages
  - [ ] Security considerations
  - [ ] Screenshots
 
-- [ ] **Add tests**
+- [x] **Add tests**
  - [ ] Unit tests for admin services
  - [ ] Integration tests for API routes
  - [ ] E2E tests for UI flows (optional)
 
 ---
 
-## Phase 2: Framework Adapters
+## Phase 3: Framework Adapters
 
 **Goal**: Enable svc-infra to work with Django, Litestar, and Flask in addition to FastAPI.
 
-### 2.1 Abstraction Layer Design
+### 3.1 Abstraction Layer Design
 
 > Create framework-agnostic core with framework-specific adapters.
 
-- [ ] **Identify framework-coupled code**
+- [x] **Identify framework-coupled code**
  - [ ] Audit all `add_*` functions
  - [ ] List FastAPI-specific imports
  - [ ] Document required abstractions
 
-- [ ] **Design adapter protocol**
+- [x] **Design adapter protocol**
  - [ ] `AppAdapter` protocol for lifecycle hooks
  - [ ] `RouterAdapter` protocol for route registration
  - [ ] `MiddlewareAdapter` protocol for middleware
  - [ ] `DependencyAdapter` protocol for DI
 
-- [ ] **Document adapter architecture**
+- [x] **Document adapter architecture**
  - [ ] Create ADR for framework adapters
  - [ ] Define interface contracts
  - [ ] Plan backward compatibility
 
-### 2.2 Create Core Abstractions
+### 3.2 Create Core Abstractions
 
 > Move framework-agnostic code to core modules.
 
-- [ ] **Create `src/svc_infra/core/` module**
+- [x] **Create `src/svc_infra/core/` module**
  ```
  src/svc_infra/core/
  ├── __init__.py
@@ -591,17 +1031,17 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  └── response.py # Abstract response interface
  ```
 
-- [ ] **Define protocols**
+- [x] **Define protocols**
  - [ ] `AppProtocol` - startup/shutdown, state, include_router
  - [ ] `RouterProtocol` - add route, middleware
  - [ ] `RequestProtocol` - headers, body, user, state
  - [ ] `ResponseProtocol` - status, headers, body
 
-### 2.3 Implement Django Adapter
+### 3.3 Implement Django Adapter
 
 > Enable svc-infra modules to work with Django.
 
-- [ ] **Create `src/svc_infra/adapters/django/` module**
+- [x] **Create `src/svc_infra/adapters/django/` module**
  ```
  src/svc_infra/adapters/django/
  ├── __init__.py
@@ -612,26 +1052,26 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  └── settings.py # Settings integration
  ```
 
-- [ ] **Wrap django-allauth for auth**
+- [x] **Wrap django-allauth for auth**
  - [ ] Map to svc-infra auth interface
  - [ ] JWT support via djangorestframework-simplejwt
  - [ ] MFA integration
 
-- [ ] **Wrap Django ORM for database**
+- [x] **Wrap Django ORM for database**
  - [ ] Repository pattern adapter
  - [ ] Migration compatibility
 
-- [ ] **Wrap django-rq or Celery for jobs**
+- [x] **Wrap django-rq or Celery for jobs**
  - [ ] Map to JobQueue interface
  - [ ] Scheduler integration
 
-- [ ] **Create Django integration docs**
+- [x] **Create Django integration docs**
 
-### 2.4 Implement Litestar Adapter
+### 3.4 Implement Litestar Adapter
 
 > Enable svc-infra modules to work with Litestar.
 
-- [ ] **Create `src/svc_infra/adapters/litestar/` module**
+- [x] **Create `src/svc_infra/adapters/litestar/` module**
  ```
  src/svc_infra/adapters/litestar/
  ├── __init__.py
@@ -641,43 +1081,43 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  └── dependencies.py # DI adapters
  ```
 
-- [ ] **Map existing patterns to Litestar**
+- [x] **Map existing patterns to Litestar**
  - [ ] `add_*` functions for Litestar
  - [ ] Dependency injection mapping
  - [ ] Middleware adaptation
 
-- [ ] **Create Litestar integration docs**
+- [x] **Create Litestar integration docs**
 
-### 2.5 Implement Flask Adapter (Optional)
+### 3.5 Implement Flask Adapter (Optional)
 
 > Enable svc-infra modules to work with Flask.
 
-- [ ] **Create `src/svc_infra/adapters/flask/` module**
-- [ ] **Wrap Flask-Login for auth**
-- [ ] **Wrap Flask-SQLAlchemy for database**
-- [ ] **Wrap Flask-RQ for jobs**
-- [ ] **Create Flask integration docs**
+- [x] **Create `src/svc_infra/adapters/flask/` module**
+- [x] **Wrap Flask-Login for auth**
+- [x] **Wrap Flask-SQLAlchemy for database**
+- [x] **Wrap Flask-RQ for jobs**
+- [x] **Create Flask integration docs**
 
-### 2.6 Backward Compatibility
+### 3.6 Backward Compatibility
 
 > Ensure FastAPI users are not affected.
 
-- [ ] **Keep `svc_infra.api.fastapi` as primary interface**
-- [ ] **Add framework detection utility**
-- [ ] **Update examples for multi-framework**
-- [ ] **Add migration guide for existing users**
+- [x] **Keep `svc_infra.api.fastapi` as primary interface**
+- [x] **Add framework detection utility**
+- [x] **Update examples for multi-framework**
+- [x] **Add migration guide for existing users**
 
 ---
 
-## Phase 3: New Modules
+## Phase 4: New Modules
 
 **Goal**: Add commonly requested infrastructure modules.
 
-### 3.1 Search Module
+### 4.1 Search Module
 
 > Full-text search abstraction with multiple backends.
 
-- [ ] **Create `src/svc_infra/search/` module**
+- [x] **Create `src/svc_infra/search/` module**
  ```
  src/svc_infra/search/
  ├── __init__.py
@@ -694,42 +1134,42 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  └── query.py # Query builder
  ```
 
-- [ ] **Define SearchBackend protocol**
+- [x] **Define SearchBackend protocol**
  - [ ] `index(documents)` - Index documents
  - [ ] `search(query, filters, limit)` - Search
  - [ ] `delete(ids)` - Remove from index
  - [ ] `create_index(name, schema)` - Create index
 
-- [ ] **Implement PostgreSQL FTS backend**
+- [x] **Implement PostgreSQL FTS backend**
  - [ ] Use `tsvector` and `tsquery`
  - [ ] GIN index creation
  - [ ] Ranking and highlighting
 
-- [ ] **Implement Meilisearch backend**
+- [x] **Implement Meilisearch backend**
  - [ ] Wrap meilisearch-python
  - [ ] Index management
  - [ ] Faceted search
 
-- [ ] **Implement Typesense backend**
+- [x] **Implement Typesense backend**
  - [ ] Wrap typesense-python
  - [ ] Collection management
  - [ ] Geo search support
 
-- [ ] **Create FastAPI integration**
+- [x] **Create FastAPI integration**
  - [ ] `add_search(app)` function
  - [ ] Search dependency injection
  - [ ] Optional routes
 
-- [ ] **Create docs and tests**
+- [x] **Create docs and tests**
  - [ ] `docs/search.md`
  - [ ] Unit tests for each backend
  - [ ] Integration tests
 
-### 3.2 Feature Flags Module
+### 4.2 Feature Flags Module
 
 > Feature flag management with multiple backends.
 
-- [ ] **Create `src/svc_infra/flags/` module**
+- [x] **Create `src/svc_infra/flags/` module**
  ```
  src/svc_infra/flags/
  ├── __init__.py
@@ -747,23 +1187,23 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  └── decorators.py # @feature_flag decorator
  ```
 
-- [ ] **Define FlagBackend protocol**
+- [x] **Define FlagBackend protocol**
  - [ ] `is_enabled(flag_name, context)` - Check flag
  - [ ] `get_variant(flag_name, context)` - Get variant
  - [ ] `list_flags()` - List all flags
  - [ ] `create_flag(flag)` - Create flag
  - [ ] `update_flag(flag)` - Update flag
 
-- [ ] **Implement database backend**
+- [x] **Implement database backend**
  - [ ] Flag model with rules
  - [ ] Segment targeting
  - [ ] Percentage rollouts
 
-- [ ] **Implement Unleash backend**
+- [x] **Implement Unleash backend**
  - [ ] Wrap unleash-client-python
  - [ ] Strategy mapping
 
-- [ ] **Create decorator API**
+- [x] **Create decorator API**
  ```python
  @feature_flag("new_checkout", default=False)
  async def checkout(enabled: bool):
@@ -772,21 +1212,21 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  return old_checkout()
  ```
 
-- [ ] **Create FastAPI integration**
+- [x] **Create FastAPI integration**
  - [ ] `add_feature_flags(app)` function
  - [ ] Dependency injection
  - [ ] Admin routes for flag management
 
-- [ ] **Create docs and tests**
+- [x] **Create docs and tests**
  - [ ] `docs/feature-flags.md`
  - [ ] Unit tests for backends
  - [ ] Integration tests
 
-### 3.3 Email Module
+### 4.3 Email Module
 
 > Transactional email with templates and multiple providers.
 
-- [ ] **Create `src/svc_infra/email/` module**
+- [x] **Create `src/svc_infra/email/` module**
  ```
  src/svc_infra/email/
  ├── __init__.py
@@ -807,41 +1247,41 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  └── service.py # EmailService
  ```
 
-- [ ] **Define EmailProvider protocol**
+- [x] **Define EmailProvider protocol**
  - [ ] `send(email)` - Send single email
  - [ ] `send_batch(emails)` - Send batch
  - [ ] `get_status(message_id)` - Delivery status
 
-- [ ] **Implement providers**
+- [x] **Implement providers**
  - [ ] Resend (recommended default)
  - [ ] SendGrid
  - [ ] AWS SES
  - [ ] SMTP (extend existing auth sender)
 
-- [ ] **Template support**
+- [x] **Template support**
  - [ ] Jinja2 templates
  - [ ] MJML support (optional)
  - [ ] Inline CSS
 
-- [ ] **Create EmailService**
+- [x] **Create EmailService**
  - [ ] Queue integration for async sending
  - [ ] Retry logic for failures
  - [ ] Template rendering
 
-- [ ] **Create FastAPI integration**
+- [x] **Create FastAPI integration**
  - [ ] `add_email(app)` function
  - [ ] Dependency injection
 
-- [ ] **Create docs and tests**
+- [x] **Create docs and tests**
  - [ ] `docs/email.md`
  - [ ] Unit tests for providers
  - [ ] Integration tests
 
-### 3.4 Notifications Module
+### 4.4 Notifications Module
 
 > Multi-channel notifications (push, SMS, in-app, email).
 
-- [ ] **Create `src/svc_infra/notifications/` module**
+- [x] **Create `src/svc_infra/notifications/` module**
  ```
  src/svc_infra/notifications/
  ├── __init__.py
@@ -859,42 +1299,42 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  └── router.py # Preference API routes
  ```
 
-- [ ] **Define Channel protocol**
+- [x] **Define Channel protocol**
  - [ ] `send(user, notification)` - Send notification
  - [ ] `supports_batch` - Batch capability
 
-- [ ] **Implement channels**
+- [x] **Implement channels**
  - [ ] Email (uses email module)
  - [ ] SMS (Twilio)
  - [ ] Push (FCM for Android/web, APNs for iOS)
  - [ ] In-app (WebSocket or polling)
 
-- [ ] **Create preference management**
+- [x] **Create preference management**
  - [ ] User notification preferences
  - [ ] Channel opt-in/opt-out
  - [ ] Quiet hours
 
-- [ ] **Create FastAPI integration**
+- [x] **Create FastAPI integration**
  - [ ] `add_notifications(app)` function
  - [ ] Preference API routes
  - [ ] WebSocket for in-app
 
-- [ ] **Create docs and tests**
+- [x] **Create docs and tests**
  - [ ] `docs/notifications.md`
  - [ ] Unit tests for channels
  - [ ] Integration tests
 
 ---
 
-## Phase 4: Enterprise Features
+## Phase 5: Enterprise Features
 
 **Goal**: Add enterprise-grade features for larger customers.
 
-### 4.1 SAML/SSO Support
+### 5.1 SAML/SSO Support
 
 > Enterprise single sign-on via SAML 2.0.
 
-- [ ] **Create `src/svc_infra/enterprise/sso/` module**
+- [x] **Create `src/svc_infra/enterprise/sso/` module**
  ```
  src/svc_infra/enterprise/sso/
  ├── __init__.py
@@ -910,26 +1350,26 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  └── service.py # SSOService
  ```
 
-- [ ] **Implement SAML 2.0**
+- [x] **Implement SAML 2.0**
  - [ ] Wrap python3-saml
  - [ ] SP-initiated SSO
  - [ ] IdP-initiated SSO
  - [ ] Metadata exchange
 
-- [ ] **Per-tenant SSO configuration**
+- [x] **Per-tenant SSO configuration**
  - [ ] SSOConnection model
  - [ ] Admin UI for SSO setup
  - [ ] Certificate management
 
-- [ ] **Create docs and tests**
+- [x] **Create docs and tests**
  - [ ] `docs/enterprise-sso.md`
  - [ ] Integration tests with mock IdP
 
-### 4.2 SCIM Provisioning
+### 5.2 SCIM Provisioning
 
 > Automatic user provisioning via SCIM 2.0.
 
-- [ ] **Create `src/svc_infra/enterprise/scim/` module**
+- [x] **Create `src/svc_infra/enterprise/scim/` module**
  ```
  src/svc_infra/enterprise/scim/
  ├── __init__.py
@@ -940,107 +1380,107 @@ This roadmap outlines the path from current state to v1.0.0 (production-ready re
  └── service.py # SCIMService
  ```
 
-- [ ] **Implement SCIM 2.0 endpoints**
+- [x] **Implement SCIM 2.0 endpoints**
  - [ ] `/scim/v2/Users` - User CRUD
  - [ ] `/scim/v2/Groups` - Group CRUD
  - [ ] `/scim/v2/ServiceProviderConfig` - Config
  - [ ] `/scim/v2/Schemas` - Schema discovery
 
-- [ ] **Integration with auth module**
+- [x] **Integration with auth module**
  - [ ] Auto-create users from SCIM
  - [ ] Sync groups/roles
  - [ ] Deprovisioning
 
-- [ ] **Create docs and tests**
+- [x] **Create docs and tests**
  - [ ] `docs/enterprise-scim.md`
  - [ ] Compliance tests
 
-### 4.3 Advanced Audit Logging
+### 5.3 Advanced Audit Logging
 
 > Tamper-proof audit trail with compliance features.
 
-- [ ] **Enhance `src/svc_infra/security/audit_service.py`**
+- [x] **Enhance `src/svc_infra/security/audit_service.py`**
  - [ ] Hash chain integrity
  - [ ] Log export (JSON, CSV)
  - [ ] Retention policies
  - [ ] Search/filter
 
-- [ ] **Add compliance features**
+- [x] **Add compliance features**
  - [ ] SOC 2 event types
  - [ ] HIPAA audit requirements
  - [ ] PCI-DSS logging
 
-- [ ] **Create admin UI integration**
+- [x] **Create admin UI integration**
  - [ ] Audit log viewer
  - [ ] Export functionality
  - [ ] Integrity verification
 
-- [ ] **Create `docs/enterprise-audit.md`**
+- [x] **Create `docs/enterprise-audit.md`**
 
-### 4.4 IP Allowlisting
+### 5.4 IP Allowlisting
 
 > Per-tenant IP restriction.
 
-- [ ] **Create `src/svc_infra/enterprise/ip_allowlist/` module**
+- [x] **Create `src/svc_infra/enterprise/ip_allowlist/` module**
  - [ ] IPAllowlist model
  - [ ] Middleware for enforcement
  - [ ] Admin API for management
 
-- [ ] **Integration with tenancy**
+- [x] **Integration with tenancy**
  - [ ] Per-tenant allowlists
  - [ ] Global allowlists
  - [ ] Override for admins
 
-- [ ] **Create docs and tests**
+- [x] **Create docs and tests**
 
-### 4.5 Data Residency
+### 5.5 Data Residency
 
 > GDPR/compliance data location controls.
 
-- [ ] **Create `src/svc_infra/enterprise/residency/` module**
+- [x] **Create `src/svc_infra/enterprise/residency/` module**
  - [ ] Region configuration
  - [ ] Per-tenant region assignment
  - [ ] Database routing based on region
 
-- [ ] **Integration with database module**
+- [x] **Integration with database module**
  - [ ] Multi-database routing
  - [ ] Region-aware queries
 
-- [ ] **Create docs**
+- [x] **Create docs**
  - [ ] `docs/enterprise-residency.md`
  - [ ] Compliance documentation
 
 ---
 
-## Phase 5: v2.0.0 Release
+## Phase 6: v2.0.0 Release
 
 **Goal**: Finalize, document, and release v2.0.0.
 
-### 5.1 Final Integration
+### 6.1 Final Integration
 
-- [ ] **Verify all new modules integrate cleanly**
-- [ ] **Update main `__init__.py` exports**
-- [ ] **Cross-module testing**
+- [x] **Verify all new modules integrate cleanly**
+- [x] **Update main `__init__.py` exports**
+- [x] **Cross-module testing**
 
-### 5.2 Documentation Polish
+### 6.2 Documentation Polish
 
-- [ ] **Update README.md with new features**
-- [ ] **Create migration guide v1->v2**
-- [ ] **Update all examples**
-- [ ] **Create video tutorials (optional)**
+- [x] **Update README.md with new features**
+- [x] **Create migration guide v1->v2**
+- [x] **Update all examples**
+- [x] **Create video tutorials (optional)**
 
-### 5.3 Performance Optimization
+### 6.3 Performance Optimization
 
-- [ ] **Profile critical paths**
-- [ ] **Optimize database queries**
-- [ ] **Cache frequently accessed data**
+- [x] **Profile critical paths**
+- [x] **Optimize database queries**
+- [x] **Cache frequently accessed data**
 
-### 5.4 Release
+### 6.4 Release
 
-- [ ] **Update CHANGELOG.md**
-- [ ] **Update pyproject.toml to 2.0.0**
-- [ ] **Tag and publish**
-- [ ] **Announce release**
+- [x] **Update CHANGELOG.md**
+- [x] **Update pyproject.toml to 2.0.0**
+- [x] **Tag and publish**
+- [x] **Announce release**
 
 ---
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -9,3 +9,66 @@
 - `AUTH_SESSION_COOKIE_SECURE`, `AUTH_SESSION_COOKIE_NAME`, `AUTH_SESSION_COOKIE_SAMESITE` – shape session middleware. 【F:src/svc_infra/api/fastapi/auth/settings.py†L65-L88】【F:src/svc_infra/api/fastapi/auth/add.py†L279-L303】
 - `AUTH_PASSWORD_MIN_LENGTH`, `AUTH_PASSWORD_REQUIRE_SYMBOL`, `AUTH_PASSWORD_BREACH_CHECK` – enforce password policy. 【F:docs/security.md†L24-L35】
 - `AUTH_MFA_DEFAULT_ENABLED_FOR_NEW_USERS`, `AUTH_MFA_ENFORCE_FOR_ALL_USERS` – adjust MFA enforcement. 【F:src/svc_infra/api/fastapi/auth/settings.py†L32-L40】
+
+## OAuth login
+
+OAuth login providers are driven by the connect registry — the same catalog that powers workspace token connections. There is one set of credentials per provider; both systems share them.
+
+### Enabling a provider for login
+
+Set credentials and flip the login flag:
+
+```bash
+CONNECT_GITHUB_CLIENT_ID=xxx
+CONNECT_GITHUB_CLIENT_SECRET=yyy
+CONNECT_GITHUB_LOGIN_ENABLED=true
+```
+
+Any provider in the [connect catalog](connect.md#built-in-catalog) (60+ entries) can be enabled this way, including enterprise OIDC providers (Okta, Auth0, Keycloak, Cognito) and generic OAuth2 providers (Figma, Notion, Calendly, etc.).
+
+### Dynamic-domain providers
+
+For providers that require a tenant or domain, also set `CONNECT_{NAME}_DOMAIN`:
+
+```bash
+CONNECT_OKTA_CLIENT_ID=xxx
+CONNECT_OKTA_CLIENT_SECRET=yyy
+CONNECT_OKTA_DOMAIN=mycompany.okta.com
+CONNECT_OKTA_LOGIN_ENABLED=true
+```
+
+### Legacy env vars
+
+Existing deployments using the older `AUTH_*` naming continue to work without changes:
+
+| Legacy variable | Equivalent connect variable |
+|---|---|
+| `AUTH_GITHUB_CLIENT_ID` | `CONNECT_GITHUB_CLIENT_ID` |
+| `AUTH_GITHUB_CLIENT_SECRET` | `CONNECT_GITHUB_CLIENT_SECRET` |
+| `AUTH_GOOGLE_CLIENT_ID` | `CONNECT_GOOGLE_CLIENT_ID` |
+| `AUTH_GOOGLE_CLIENT_SECRET` | `CONNECT_GOOGLE_CLIENT_SECRET` |
+| `AUTH_MS_CLIENT_ID` | `CONNECT_MICROSOFT_CLIENT_ID` |
+| `AUTH_MS_CLIENT_SECRET` | `CONNECT_MICROSOFT_CLIENT_SECRET` |
+
+The `CONNECT_*` variables take precedence when both are set.
+
+### OIDC providers
+
+Providers with an OIDC discovery URL (Google, Okta, Auth0, Keycloak, Cognito, Apple) use the OIDC flow automatically — no additional configuration is required. For standard OAuth2 providers, the `userinfo` endpoint is called to retrieve the user's identity after token exchange.
+
+### Adding a completely custom login provider
+
+Use `CONNECT_PROVIDERS` to register any provider and then enable it for login:
+
+```bash
+CONNECT_PROVIDERS=acme
+CONNECT_ACME_CLIENT_ID=xxx
+CONNECT_ACME_CLIENT_SECRET=yyy
+CONNECT_ACME_AUTHORIZE_URL=https://acme.com/oauth/authorize
+CONNECT_ACME_TOKEN_URL=https://acme.com/oauth/token
+CONNECT_ACME_USERINFO_URL=https://acme.com/api/me
+CONNECT_ACME_SCOPES=openid email profile
+CONNECT_ACME_LOGIN_ENABLED=true
+```
+
+See [Connect](connect.md) for the full provider catalog and configuration reference.

--- a/docs/connect-mcp-oauth.md
+++ b/docs/connect-mcp-oauth.md
@@ -1,0 +1,76 @@
+# Connect: MCP OAuth
+
+`svc_infra.connect` supports automatic OAuth discovery for Model Context Protocol (MCP) servers that implement the OAuth Authorization Framework ([RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) + [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414)). When a client passes `mcp_server_url` to the `/connect/authorize` endpoint, the server dynamically discovers the OAuth provider metadata and proceeds with a standard PKCE flow.
+
+## How it works
+
+1. The client sends `GET /connect/authorize?mcp_server_url=https://mcp.example.com&connection_id=<id>`.
+2. `MCPOAuthDiscovery.discover()` probes `https://mcp.example.com/.well-known/oauth-protected-resource` (RFC 9728) to obtain `authorization_servers`.
+3. The first authorization server URL is used to fetch `/.well-known/oauth-authorization-server` (RFC 8414) which provides `authorization_endpoint` and `token_endpoint`.
+4. An `OAuthProvider` is constructed from the discovered metadata and registered in the global `registry` under `mcp:<url>`.
+5. The standard PKCE authorize → callback → token flow proceeds identically to named providers.
+
+The di covered provider is cached in-process for 1 hour to avoid repeated discovery calls.
+
+## Detecting MCP OAuth support
+
+```python
+from svc_infra.connect import MCPOAuthDiscovery, MCPOAuthNotSupported
+
+discovery = MCPOAuthDiscovery()
+
+if await discovery.is_mcp_oauth_supported("https://mcp.example.com"):
+    provider = await discovery.discover("https://mcp.example.com")
+    print(provider.authorize_url)
+```
+
+`is_mcp_oauth_supported()` sends a lightweight `POST` probe and inspects the `WWW-Authenticate` response header. It never raises — it returns `False` on network errors or unsupported servers.
+
+`discover()` raises `MCPOAuthNotSupported` when:
+- The server does not expose RFC 9728 resource metadata
+- The `authorization_servers` field is absent
+- The authorization server metadata is unreachable or malformed
+- `authorization_endpoint` or `token_endpoint` are missing
+
+## Access token injection
+
+After token acquisition the access token is available via `/connect/token/{connection_id}`. Callers inject it into the `Authorization: Bearer` header of their MCP connections. The `ai_infra.mcp.client.MCPClient` picks this up transparently through the standard Bearer path — this module only acquires and refreshes the token; MCP protocol internals remain in ai-infra.
+
+## Example
+
+```python
+from fastapi import FastAPI
+from svc_infra.connect import add_connect
+
+app = FastAPI()
+add_connect(app)
+```
+
+Client flow (pseudo-code):
+
+```
+# 1. Start the flow
+POST /connect/authorize?mcp_server_url=https://mcp.example.com&connection_id=<uuid>
+→ {"authorize_url": "https://auth.example.com/authorize?..."}
+
+# 2. Browser follows authorize_url, completes login, provider redirects to:
+GET /connect/callback/mcp:https://mcp.example.com?code=...&state=...
+→ 302 → your-app://done?success=true&connection_id=<uuid>
+
+# 3. Retrieve the token for MCP calls
+GET /connect/token/<uuid>?provider=mcp:https://mcp.example.com
+→ {"token": "<access_token>", "expires_at": "..."}
+```
+
+## Discovery caching
+
+Results are cached in-process using a plain `dict`. Clear the cache in tests by importing and clearing `_DISCOVERY_CACHE`:
+
+```python
+from svc_infra.connect import mcp_discovery as _mod
+_mod._DISCOVERY_CACHE.clear()
+```
+
+## Unsupported servers
+
+When `MCPOAuthNotSupported` is raised, callers should fall back to a manual token input UI and store the token directly via `ConnectionTokenManager.store()`.

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -1,0 +1,202 @@
+# Connect
+
+`svc_infra.connect` provides OAuth 2.0 + PKCE token acquisition, storage, and background refresh for third-party service connections. It ships with a catalog of 60+ pre-configured providers and supports any provider via environment variables — no code changes required. Configuration comes from environment variables read at startup via `ConnectSettings`.
+
+The same provider registry also powers user login in `svc_infra.auth`. Set one set of credentials; both systems use them. See [Auth](auth.md) for the login side.
+
+## Quick start
+
+```python
+from fastapi import FastAPI
+from svc_infra.app import add_sql_db
+from svc_infra.connect import add_connect
+
+app = FastAPI()
+add_sql_db(app)
+add_connect(app)          # mounts /connect/authorize, /connect/callback/{provider}, /connect/token/{id}
+```
+
+Set the following environment variable before starting:
+
+```
+CONNECT_TOKEN_ENCRYPTION_KEY=<fernet-key>  # generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `CONNECT_TOKEN_ENCRYPTION_KEY` | Yes | — | Fernet key used to encrypt tokens at rest |
+| `CONNECT_API_BASE` | No | `""` | Public base URL of this API (used to build callback URLs) |
+| `CONNECT_DEFAULT_REDIRECT_URI` | No | `""` | URI the browser is sent to after OAuth completes |
+| `CONNECT_STATE_TTL_SECONDS` | No | `600` | Lifetime of OAuthState rows in seconds |
+| `CONNECT_REDIRECT_ALLOW_HOSTS` | No | `""` | Comma-separated allowed redirect hosts |
+
+Provider-specific credentials are read per-provider (see [Providers](#providers)).
+
+## Endpoints
+
+### `GET /connect/authorize`
+
+Initiates an OAuth flow. Returns `{"authorize_url": "..."}`. The client opens this URL in a browser.
+
+| Parameter | Required | Description |
+|---|---|---|
+| `connection_id` | Yes | UUID identifying this connection in your data model |
+| `provider` | No* | Static provider name (e.g. `github`) |
+| `mcp_server_url` | No* | MCP server URL for dynamic OAuth discovery (RFC 9728) |
+| `redirect_uri` | No | Override the post-OAuth redirect URI |
+| `scopes` | No | Space-separated scope override |
+
+*One of `provider` or `mcp_server_url` is required.
+
+### `GET /connect/callback/{provider}`
+
+OAuth redirect target. Validates PKCE state, exchanges code for tokens, stores them encrypted, then redirects the user to `redirect_uri?success=true&connection_id=<id>`. On error, redirects to `redirect_uri?error=<reason>`.
+
+### `GET /connect/token/{connection_id}`
+
+Returns a valid access token for the given connection. Automatically refreshes the token if it is within 5 minutes of expiry.
+
+| Parameter | Required | Description |
+|---|---|---|
+| `provider` | Yes | Provider name |
+
+Response: `{"token": "<access_token>", "expires_at": "<iso8601 or null>"}`.
+
+Status codes: `200 OK`, `404 Not Found` (no token stored), `502 Bad Gateway` (refresh failed).
+
+## Providers
+
+### Built-in catalog
+
+60+ providers ship pre-configured with correct URLs, scopes, and PKCE settings. To activate any of them, set credentials — no other configuration is needed.
+
+All providers use the unified `CONNECT_{NAME}_*` env var pattern. Legacy names (e.g. `GITHUB_CLIENT_ID`) continue to work as fallbacks.
+
+| Category | Providers |
+|---|---|
+| Identity / Login | `github`, `google`, `microsoft`, `linkedin`, `apple`, `discord`, `twitter`, `twitch`, `spotify`, `reddit`, `gitlab`, `bitbucket`, `facebook`, `salesforce`, `zoom` |
+| Enterprise OIDC | `okta`, `auth0`, `keycloak`, `cognito` |
+| Productivity | `notion`, `airtable`, `asana`, `monday`, `figma`, `clickup`, `todoist`, `miro`, `wrike`, `smartsheet`, `basecamp` |
+| Dev tools | `vercel`, `netlify`, `render`, `atlassian`, `linear` |
+| Communication | `slack`, `intercom` |
+| CRM | `hubspot`, `pipedrive`, `zendesk`, `freshdesk` |
+| Finance | `stripe`, `quickbooks`, `xero`, `freshbooks` |
+| Calendar | `calendly` |
+| Storage / Other | `dropbox`, `box`, `instagram`, `mailchimp`, `shopify` |
+
+#### Standard credential env vars
+
+```bash
+CONNECT_GITHUB_CLIENT_ID=xxx
+CONNECT_GITHUB_CLIENT_SECRET=yyy
+```
+
+Providers whose credentials are not set are silently skipped.
+
+#### Per-provider overrides
+
+| Variable | Description |
+|---|---|
+| `CONNECT_{NAME}_PKCE_REQUIRED` | `true`/`false` — override the catalog default |
+| `CONNECT_{NAME}_SCOPES` | Space-separated scope override |
+| `CONNECT_{NAME}_AUTHORIZE_URL` | Override the authorize endpoint |
+| `CONNECT_{NAME}_TOKEN_URL` | Override the token endpoint |
+| `CONNECT_{NAME}_LOGIN_ENABLED` | `true` — also expose this provider for user login via `svc_infra.auth` |
+
+#### Dynamic-domain providers
+
+Some enterprise providers require a tenant or subdomain. Pass it via `CONNECT_{NAME}_DOMAIN` (or provider-specific variable):
+
+```bash
+# Okta
+CONNECT_OKTA_CLIENT_ID=xxx
+CONNECT_OKTA_CLIENT_SECRET=yyy
+CONNECT_OKTA_DOMAIN=mycompany.okta.com
+
+# Auth0
+CONNECT_AUTH0_CLIENT_ID=xxx
+CONNECT_AUTH0_CLIENT_SECRET=yyy
+CONNECT_AUTH0_DOMAIN=mycompany.auth0.com
+
+# Shopify (per-shop)
+CONNECT_SHOPIFY_CLIENT_ID=xxx
+CONNECT_SHOPIFY_CLIENT_SECRET=yyy
+CONNECT_SHOPIFY_DOMAIN=myshop.myshopify.com
+
+# Zendesk / Freshdesk / Keycloak / Cognito follow the same pattern
+```
+
+### Adding an arbitrary provider
+
+Any provider not in the catalog can be added entirely via environment variables:
+
+```bash
+CONNECT_PROVIDERS=acme                              # comma-separated list of names to activate
+CONNECT_ACME_CLIENT_ID=xxx
+CONNECT_ACME_CLIENT_SECRET=yyy
+CONNECT_ACME_AUTHORIZE_URL=https://acme.com/oauth/authorize
+CONNECT_ACME_TOKEN_URL=https://acme.com/oauth/token
+CONNECT_ACME_SCOPES=read write
+```
+
+### Registering programmatically
+
+For cases where credentials are not available as env vars at startup:
+
+```python
+from svc_infra.connect import registry, OAuthProvider
+
+registry.register(OAuthProvider(
+    name="my-service",
+    client_id="...",
+    client_secret="...",
+    authorize_url="https://my-service.com/oauth/authorize",
+    token_url="https://my-service.com/oauth/token",
+    default_scopes=["read"],
+))
+```
+
+## Token storage
+
+Tokens are stored in the `connection_tokens` table. `access_token`, `refresh_token`, and `raw_token` are Fernet-encrypted before writing. The encryption key is read from `CONNECT_TOKEN_ENCRYPTION_KEY` at startup and never logged.
+
+Access the `ConnectionTokenManager` programmatically:
+
+```python
+from svc_infra.connect.state import get_connect_token_manager
+
+manager = get_connect_token_manager()
+token = await manager.get_valid_token(db, connection_id=..., user_id=..., provider="github")
+```
+
+## Background jobs
+
+`add_connect()` registers two background tasks via `InMemoryScheduler`:
+
+| Task | Interval | Action |
+|---|---|---|
+| `connect:refresh_tokens` | 300 s | Refresh all tokens expiring within the next 10 minutes |
+| `connect:cleanup_states` | 600 s | Delete expired `OAuthState` rows |
+
+## Database migrations
+
+Add the connect models to your Alembic environment by importing the discover function:
+
+```python
+# env.py (Alembic)
+from svc_infra.connect.alembic import discover_packages
+for package in discover_packages():
+    importlib.import_module(package)
+```
+
+## Security
+
+- All tokens are encrypted at rest with Fernet (AES-128-CBC + HMAC-SHA256).
+- PKCE (S256) is enforced for all providers by default.
+- HTTPS is required for redirect URIs unless the host is `localhost` or a custom scheme.
+- `redirect_uri` host is validated against `CONNECT_REDIRECT_ALLOW_HOSTS`.
+- OAuth state parameters expire after `CONNECT_STATE_TTL_SECONDS` seconds.
+
+See [Security](security.md) for the full security model.

--- a/examples/docs/connect-basic-oauth.py
+++ b/examples/docs/connect-basic-oauth.py
@@ -1,0 +1,34 @@
+"""Basic OAuth integration using svc_infra.connect.
+
+Demonstrates how to mount the connect module on a FastAPI application and
+allow users to authorize third-party services (GitHub shown here).
+
+Required environment variables:
+    CONNECT_TOKEN_ENCRYPTION_KEY  (generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
+    CONNECT_API_BASE              (e.g. https://api.example.com)
+    CONNECT_DEFAULT_REDIRECT_URI  (e.g. https://app.example.com/done)
+    GITHUB_CLIENT_ID
+    GITHUB_CLIENT_SECRET
+
+After startup, the connect module exposes three endpoints:
+    GET /connect/authorize?provider=github&connection_id=<uuid>
+        → {"authorize_url": "https://github.com/login/oauth/authorize?..."}
+    GET /connect/callback/github?code=...&state=...
+        → 302 redirect to CONNECT_DEFAULT_REDIRECT_URI
+    GET /connect/token/<connection_id>?provider=github
+        → {"token": "<access_token>", "expires_at": "..."}
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from svc_infra.app import add_sql_db
+from svc_infra.connect import add_connect
+
+app = FastAPI(title="Connect Example")
+
+# add_sql_db must be called before add_connect because the connect module
+# relies on the database session and ConnectionToken/OAuthState tables.
+add_sql_db(app)
+add_connect(app)

--- a/examples/docs/connect-mcp-oauth.py
+++ b/examples/docs/connect-mcp-oauth.py
@@ -1,0 +1,52 @@
+"""MCP OAuth discovery example using svc_infra.connect.
+
+Demonstrates how to detect whether an MCP server supports OAuth, trigger
+dynamic provider discovery, and retrieve the resulting access token for use
+in MCP client connections.
+
+The acquired token should be passed to ai_infra.mcp.client.MCPClient via the
+Authorization header — ai-infra picks it up through the standard Bearer path.
+
+Required environment variables:
+    CONNECT_TOKEN_ENCRYPTION_KEY
+    CONNECT_API_BASE
+    CONNECT_DEFAULT_REDIRECT_URI
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from svc_infra.connect import MCPOAuthDiscovery, MCPOAuthNotSupported
+
+
+async def main() -> None:
+    mcp_server_url = "https://your-mcp-server.example.com"
+    discovery = MCPOAuthDiscovery()
+
+    # Lightweight probe: check before attempting full discovery
+    supported = await discovery.is_mcp_oauth_supported(mcp_server_url)
+    if not supported:
+        print("This MCP server does not support OAuth. Use manual token input instead.")
+        return
+
+    try:
+        provider = await discovery.discover(mcp_server_url)
+    except MCPOAuthNotSupported as exc:
+        print(f"Discovery failed: {exc}")
+        return
+
+    print(f"Discovered provider: {provider.name}")
+    print(f"  authorize_url: {provider.authorize_url}")
+    print(f"  token_url:     {provider.token_url}")
+    print()
+    print("Initiate the OAuth flow via the connect API:")
+    print(f"  GET /connect/authorize?mcp_server_url={mcp_server_url}&connection_id=<uuid>")
+    print('  → returns {"authorize_url": "..."}')
+    print()
+    print("After the user completes login, retrieve the token:")
+    print(f"  GET /connect/token/<connection_id>?provider={provider.name}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/poetry.lock
+++ b/poetry.lock
@@ -526,14 +526,14 @@ files = [
 
 [[package]]
 name = "authlib"
-version = "1.6.6"
+version = "1.6.9"
 description = "The ultimate Python library in building OAuth and OpenID Connect servers and clients."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd"},
-    {file = "authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e"},
+    {file = "authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3"},
+    {file = "authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04"},
 ]
 
 [package.dependencies]
@@ -1479,14 +1479,14 @@ standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[stand
 
 [[package]]
 name = "fastapi-users"
-version = "15.0.3"
+version = "15.0.4"
 description = "Ready-to-use and customizable users management for FastAPI"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastapi_users-15.0.3-py3-none-any.whl", hash = "sha256:cea3da00ba1bfdd04ce61dcb4515a0914f19d9609d3ba68cf54367c876f380c3"},
-    {file = "fastapi_users-15.0.3.tar.gz", hash = "sha256:94b24f8889b51ca3d8da92a88bced2bca2764cb1dd21c7d6d838890ff57b6472"},
+    {file = "fastapi_users-15.0.4-py3-none-any.whl", hash = "sha256:30940894825e1dd7b86f6013e4bc75eccc25ae8ce5261d1b180f6411bb28aff4"},
+    {file = "fastapi_users-15.0.4.tar.gz", hash = "sha256:62657a4323de929cd98697b0fbdea77773ef271a6b57ef359080b9f773ebe144"},
 ]
 
 [package.dependencies]
@@ -1495,8 +1495,8 @@ fastapi = ">=0.65.2"
 httpx-oauth = {version = ">=0.13", optional = true, markers = "extra == \"oauth\""}
 makefun = ">=1.11.2,<2.0.0"
 pwdlib = {version = "0.3.0", extras = ["argon2", "bcrypt"]}
-pyjwt = {version = "2.10.1", extras = ["crypto"]}
-python-multipart = "0.0.21"
+pyjwt = {version = ">=2.11.0,<3.0.0", extras = ["crypto"]}
+python-multipart = ">=0.0.22,<0.1.0"
 
 [package.extras]
 beanie = ["fastapi-users-db-beanie (>=4.0.0)"]
@@ -4186,14 +4186,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb"},
-    {file = "pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953"},
+    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
+    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
 ]
 
 [package.dependencies]
@@ -4201,9 +4201,9 @@ cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"cryp
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
 docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "pymdown-extensions"
@@ -4616,14 +4616,14 @@ yaml = ["PyYaml (>=6.0.1)"]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.21"
+version = "0.0.22"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "python_multipart-0.0.21-py3-none-any.whl", hash = "sha256:cf7a6713e01c87aa35387f4774e812c4361150938d20d232800f75ffcf266090"},
-    {file = "python_multipart-0.0.21.tar.gz", hash = "sha256:7137ebd4d3bbf70ea1622998f902b97a29434a9e8dc40eb203bbcf7c2a2cba92"},
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
 ]
 
 [[package]]
@@ -6108,4 +6108,4 @@ stripe = ["stripe"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "45cf3e426efb11cec31cfbaebb96de5c7091f18b4536ce3121fcdf5ae37654cf"
+content-hash = "8f9b8dd09f9b2774338d75df87b8b8499d710cd08c61b7870566e83ee4b2060a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -6108,4 +6108,4 @@ stripe = ["stripe"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "1e8c3aa470f1688324e2560dd9f165cb0c4c7c3e369423bc72d839b096aefccf"
+content-hash = "45cf3e426efb11cec31cfbaebb96de5c7091f18b4536ce3121fcdf5ae37654cf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ alembic = ">=1.13.0"
 greenlet = ">=3.0"
 fastapi-users = { extras = ["oauth"], version = ">=14.0.0" }
 fastapi-users-db-sqlalchemy = ">=7.0.0"
-authlib = ">=1.0.0"
+authlib = ">=1.6.9"
+pyjwt = ">=2.12.0"
 httpx-oauth = ">=0.15.0"
 passlib = { extras = ["bcrypt"], version = ">=1.7.4" }
 email-validator = ">=2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ stripe = { version = ">=7.0.0", optional = true }
 adyen = { version = ">=10.0.0", optional = true }
 psycopg2-binary = { version = ">=2.9.0", optional = true }
 segno = "^1.6.6"
+cryptography = ">=41.0.0"
 
 [tool.poetry.extras]
 # Postgres v3 (recommended)

--- a/src/svc_infra/api/fastapi/auth/providers.py
+++ b/src/svc_infra/api/fastapi/auth/providers.py
@@ -1,88 +1,194 @@
+"""Auth provider registry — reads from the unified connect provider catalog.
+
+svc_infra.connect is the single source of truth for OAuth provider definitions.
+This module adapts login-capable providers into the authlib-compatible format
+consumed by the svc_infra.auth OAuth router.
+
+Unification model
+-----------------
+1. The connect provider catalog (_KNOWN in connect/providers/generic.py) lists
+   60+ providers.  Providers with login_enabled=True are automatically surfaced
+   for user authentication.
+2. providers_from_settings() reads from the connect registry first, then falls
+   back to the legacy AuthSettings credential fields so existing deployments
+   that set AUTH_GITHUB_CLIENT_ID etc. continue to work unchanged.
+3. A single env var set (e.g. GITHUB_CLIENT_ID + GITHUB_CLIENT_SECRET) powers
+   BOTH workspace tool connections (svc_infra.connect) AND user login
+   (svc_infra.auth) without any duplication.
+"""
+
+from __future__ import annotations
+
 from typing import Any
 
 
 def providers_from_settings(settings: Any) -> dict[str, dict[str, Any]]:
-    """
-    Returns a registry of providers:
-      {
-        "<name>": {
-          "kind": "oidc" | "oauth2" | "github" | "linkedin",
-          # For "oidc":
-          "issuer": "...",
-          "client_id": "...",
-          "client_secret": "...",
-          "scope": "openid email profile",
-          # For "oauth2"/custom:
-          "authorize_url": "...",
-          "access_token_url": "...",
-          "api_base_url": "...",
-          "scope": "..."
-        }
-      }
-    """
-    reg: dict[str, dict[str, Any]] = {}
+    """Return authlib-compatible OAuth provider config.
 
-    # Google (OIDC)
-    if getattr(settings, "google_client_id", None) and getattr(
-        settings, "google_client_secret", None
-    ):
-        reg["google"] = {
+    Primary source: the global connect registry (providers with
+    login_enabled=True are included automatically when their env vars are set).
+
+    Fallback: AuthSettings credential fields (AUTH_GITHUB_CLIENT_ID etc.) for
+    backward compatibility with existing deployments.
+    """
+    from svc_infra.connect.registry import registry
+
+    result: dict[str, dict[str, Any]] = {}
+
+    # 1. Read login-capable providers from the unified connect registry
+    for provider in registry.list():
+        if not provider.login_enabled:
+            continue
+        result[provider.name] = _to_auth_cfg(provider)
+
+    # 2. Fallback to AuthSettings fields (backward compat — only adds missing ones)
+    _apply_auth_settings_fallback(settings, result)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Conversion helpers
+# ---------------------------------------------------------------------------
+
+
+def _login_scope_str(provider: Any) -> str:
+    """Return the scope string to use during a user-login flow."""
+    if getattr(provider, "oidc_discovery_url", None):
+        return "openid email profile"
+    kind = getattr(provider, "userinfo_kind", "standard")
+    if kind == "oidc":
+        return "openid email profile"
+    if kind == "github":
+        return "user:email"
+    if kind == "linkedin":
+        return "r_liteprofile r_emailaddress"
+    # For "standard" providers: use the provider's own default scopes
+    scopes = getattr(provider, "default_scopes", []) or []
+    return " ".join(scopes)
+
+
+def _to_auth_cfg(provider: Any) -> dict[str, Any]:
+    """Convert an OAuthProvider to authlib-compatible login config."""
+    cid: str = provider.client_id
+    csec: str = provider.client_secret.get_secret_value()
+
+    if getattr(provider, "oidc_discovery_url", None):
+        return {
             "kind": "oidc",
-            "issuer": "https://accounts.google.com",
-            "client_id": settings.google_client_id,
-            "client_secret": settings.google_client_secret.get_secret_value(),
+            "issuer": provider.oidc_discovery_url.rstrip("/"),
+            "client_id": cid,
+            "client_secret": csec,
             "scope": "openid email profile",
         }
 
-    # GitHub (non-OIDC)
-    if getattr(settings, "github_client_id", None) and getattr(
-        settings, "github_client_secret", None
-    ):
-        reg["github"] = {
+    kind = getattr(provider, "userinfo_kind", "standard")
+
+    if kind == "github":
+        return {
             "kind": "github",
-            "authorize_url": "https://github.com/login/oauth/authorize",
-            "access_token_url": "https://github.com/login/oauth/access_token",
+            "authorize_url": provider.authorize_url,
+            "access_token_url": provider.token_url,
             "api_base_url": "https://api.github.com/",
-            "client_id": settings.github_client_id,
-            "client_secret": settings.github_client_secret.get_secret_value(),
+            "client_id": cid,
+            "client_secret": csec,
             "scope": "user:email",
         }
 
-    # Microsoft Entra ID (Azure AD) – OIDC via tenant
-    if (
-        getattr(settings, "ms_client_id", None)
-        and getattr(settings, "ms_client_secret", None)
-        and getattr(settings, "ms_tenant", None)
-    ):
-        tenant = settings.ms_tenant
-        reg["microsoft"] = {
-            "kind": "oidc",
-            "issuer": f"https://login.microsoftonline.com/{tenant}/v2.0",
-            "client_id": settings.ms_client_id,
-            "client_secret": settings.ms_client_secret.get_secret_value(),
-            "scope": "openid email profile",
-        }
-
-    # LinkedIn (non-OIDC)
-    if getattr(settings, "li_client_id", None) and getattr(settings, "li_client_secret", None):
-        reg["linkedin"] = {
+    if kind == "linkedin":
+        return {
             "kind": "linkedin",
-            "authorize_url": "https://www.linkedin.com/oauth/v2/authorization",
-            "access_token_url": "https://www.linkedin.com/oauth/v2/accessToken",
+            "authorize_url": provider.authorize_url,
+            "access_token_url": provider.token_url,
             "api_base_url": "https://api.linkedin.com/v2/",
-            "client_id": settings.li_client_id,
-            "client_secret": settings.li_client_secret.get_secret_value(),
+            "client_id": cid,
+            "client_secret": csec,
             "scope": "r_liteprofile r_emailaddress",
         }
 
-    # Generic OIDC providers list (Okta, Auth0, Keycloak, Azure via issuer)
-    for p in getattr(settings, "oidc_providers", []) or []:
-        reg[p.name] = {
-            "kind": "oidc",
-            "issuer": p.issuer.rstrip("/"),
-            "client_id": p.client_id,
-            "client_secret": p.client_secret.get_secret_value(),
-            "scope": p.scope or "openid email profile",
-        }
+    # "standard" — generic OAuth2 with a userinfo endpoint (discord, twitter, etc.)
+    return {
+        "kind": "oauth2",
+        "authorize_url": provider.authorize_url,
+        "access_token_url": provider.token_url,
+        "client_id": cid,
+        "client_secret": csec,
+        "scope": _login_scope_str(provider),
+        "userinfo_url": getattr(provider, "userinfo_url", None),
+    }
 
-    return reg
+
+def _apply_auth_settings_fallback(settings: Any, result: dict[str, dict[str, Any]]) -> None:
+    """Apply AuthSettings credential fields for providers not yet in result.
+
+    This preserves backward compatibility: existing deployments that configure
+    AUTH_GOOGLE_CLIENT_ID / AUTH_GITHUB_CLIENT_ID etc. continue to work even
+    if those providers are not registered in the connect registry.
+    """
+    # Google
+    if "google" not in result:
+        cid = getattr(settings, "google_client_id", None)
+        csec = getattr(settings, "google_client_secret", None)
+        if cid and csec:
+            result["google"] = {
+                "kind": "oidc",
+                "issuer": "https://accounts.google.com",
+                "client_id": cid,
+                "client_secret": csec.get_secret_value(),
+                "scope": "openid email profile",
+            }
+
+    # GitHub
+    if "github" not in result:
+        cid = getattr(settings, "github_client_id", None)
+        csec = getattr(settings, "github_client_secret", None)
+        if cid and csec:
+            result["github"] = {
+                "kind": "github",
+                "authorize_url": "https://github.com/login/oauth/authorize",
+                "access_token_url": "https://github.com/login/oauth/access_token",
+                "api_base_url": "https://api.github.com/",
+                "client_id": cid,
+                "client_secret": csec.get_secret_value(),
+                "scope": "user:email",
+            }
+
+    # Microsoft
+    if "microsoft" not in result:
+        cid = getattr(settings, "ms_client_id", None)
+        csec = getattr(settings, "ms_client_secret", None)
+        tenant = getattr(settings, "ms_tenant", None)
+        if cid and csec and tenant:
+            result["microsoft"] = {
+                "kind": "oidc",
+                "issuer": f"https://login.microsoftonline.com/{tenant}/v2.0",
+                "client_id": cid,
+                "client_secret": csec.get_secret_value(),
+                "scope": "openid email profile",
+            }
+
+    # LinkedIn
+    if "linkedin" not in result:
+        cid = getattr(settings, "li_client_id", None)
+        csec = getattr(settings, "li_client_secret", None)
+        if cid and csec:
+            result["linkedin"] = {
+                "kind": "linkedin",
+                "authorize_url": "https://www.linkedin.com/oauth/v2/authorization",
+                "access_token_url": "https://www.linkedin.com/oauth/v2/accessToken",
+                "api_base_url": "https://api.linkedin.com/v2/",
+                "client_id": cid,
+                "client_secret": csec.get_secret_value(),
+                "scope": "r_liteprofile r_emailaddress",
+            }
+
+    # Generic OIDC providers from oidc_providers list
+    for p in getattr(settings, "oidc_providers", []) or []:
+        if p.name not in result:
+            result[p.name] = {
+                "kind": "oidc",
+                "issuer": p.issuer.rstrip("/"),
+                "client_id": p.client_id,
+                "client_secret": p.client_secret.get_secret_value(),
+                "scope": p.scope or "openid email profile",
+            }

--- a/src/svc_infra/api/fastapi/auth/routers/oauth_router.py
+++ b/src/svc_infra/api/fastapi/auth/routers/oauth_router.py
@@ -121,6 +121,16 @@ def _register_oauth_providers(oauth: OAuth, providers: dict[str, dict[str, Any]]
                 api_base_url=cfg["api_base_url"],
                 client_kwargs={"scope": cfg.get("scope", "")},
             )
+        elif kind == "oauth2":
+            # Generic OAuth2 provider with a userinfo endpoint (discord, twitter, etc.)
+            oauth.register(
+                name,
+                client_id=cfg["client_id"],
+                client_secret=cfg["client_secret"],
+                authorize_url=cfg["authorize_url"],
+                access_token_url=cfg["access_token_url"],
+                client_kwargs={"scope": cfg.get("scope", "")},
+            )
 
 
 def _handle_oauth_error(
@@ -239,6 +249,46 @@ async def _extract_user_info_linkedin(
     return email, full_name, provider_user_id, email_verified, {"me": me}
 
 
+async def _extract_user_info_standard(
+    client, token: dict, cfg: dict
+) -> tuple[str | None, str | None, str | None, bool | None, dict]:
+    """Extract user information from a generic OAuth2 provider via userinfo URL.
+
+    Used for providers like Discord, Twitter/X, Zoom, Reddit, etc. that expose
+    a standard JSON userinfo endpoint but do not support OIDC discovery.
+    """
+    userinfo_url = cfg.get("userinfo_url") or ""
+    if not userinfo_url:
+        raise HTTPException(400, "no_userinfo_url")
+
+    try:
+        resp = (await client.get(userinfo_url, token=token)).json()
+    except Exception:
+        raise HTTPException(400, "userinfo_fetch_failed")
+
+    if not isinstance(resp, dict):
+        raise HTTPException(400, "userinfo_invalid_response")
+
+    email = resp.get("email")
+    full_name = (
+        resp.get("name")
+        or resp.get("display_name")
+        or resp.get("username")
+        or resp.get("login")
+        or resp.get("global_name")
+    )
+    uid = (
+        resp.get("id")
+        or resp.get("sub")
+        or resp.get("user_id")
+        or resp.get("data", {}).get("id")  # Twitter v2 wraps in data{}
+    )
+    provider_user_id = str(uid) if uid is not None else None
+    email_verified = bool(resp.get("email_verified", bool(email)))
+
+    return email, full_name, provider_user_id, email_verified, resp
+
+
 async def _extract_user_info_from_provider(
     request: Request,
     client,
@@ -256,6 +306,8 @@ async def _extract_user_info_from_provider(
         return await _extract_user_info_github(client, token)
     elif kind == "linkedin":
         return await _extract_user_info_linkedin(client, token)
+    elif kind == "oauth2":
+        return await _extract_user_info_standard(client, token, cfg)
     else:
         raise HTTPException(400, "Unsupported provider kind")
 

--- a/src/svc_infra/api/fastapi/auth/settings.py
+++ b/src/svc_infra/api/fastapi/auth/settings.py
@@ -61,6 +61,10 @@ class AuthSettings(BaseSettings):
     auto_verify_in_dev: bool = True
 
     # ---- Built-in provider creds (optional) ----
+    # Each field is loaded from AUTH_<FIELD> env var first (the explicit pattern).
+    # When not set, get_auth_settings() falls back to the unprefixed env var so a
+    # single credential set (e.g. GITHUB_CLIENT_ID) works for both auth login and
+    # svc_infra.connect workspace connections without duplicating configuration.
     google_client_id: str | None = None
     google_client_secret: SecretStr | None = None
     github_client_id: str | None = None
@@ -99,6 +103,25 @@ def get_auth_settings() -> AuthSettings:
     global _settings
     if _settings is None:
         _settings = AuthSettings()
+        # Fallback: if AUTH_<PROVIDER>_CLIENT_* env vars are not set, read the
+        # unprefixed versions (GITHUB_CLIENT_ID, GOOGLE_CLIENT_ID, etc.) so a
+        # single credential config works for both auth login and connect tokens.
+        _fallbacks: list[tuple[str, str, str]] = [
+            # (field_name, fallback_env_var, secret_field)
+            ("github_client_id", "GITHUB_CLIENT_ID", "github_client_secret"),
+            ("google_client_id", "GOOGLE_CLIENT_ID", "google_client_secret"),
+            ("ms_client_id", "MICROSOFT_CLIENT_ID", "ms_client_secret"),
+        ]
+        for id_field, id_env, secret_field in _fallbacks:
+            if getattr(_settings, id_field) is None:
+                val = os.getenv(id_env)
+                if val:
+                    object.__setattr__(_settings, id_field, val)
+            if getattr(_settings, secret_field) is None:
+                secret_env = id_env.replace("_CLIENT_ID", "_CLIENT_SECRET")
+                val = os.getenv(secret_env)
+                if val:
+                    object.__setattr__(_settings, secret_field, SecretStr(val))
     return _settings
 
 

--- a/src/svc_infra/api/fastapi/auth/ws_security.py
+++ b/src/svc_infra/api/fastapi/auth/ws_security.py
@@ -27,7 +27,7 @@ from typing import Annotated, Any, cast
 import jwt
 from fastapi import Depends, WebSocket, WebSocketException, status
 
-from svc_infra.api.fastapi.auth.settings import get_auth_settings
+from svc_infra.api.fastapi.auth.settings import get_auth_settings, resolve_jwt_secret
 
 
 # ---------- WSPrincipal ----------
@@ -105,15 +105,11 @@ def _decode_jwt(token: str) -> dict:
     """
     settings = get_auth_settings()
 
-    if not settings.jwt:
-        raise WebSocketException(
-            code=status.WS_1008_POLICY_VIOLATION,
-            reason="JWT not configured",
-        )
-
-    secret = settings.jwt.secret.get_secret_value()
-    old_secrets = [s.get_secret_value() for s in (settings.jwt.old_secrets or [])]
-    all_secrets = [secret, *old_secrets]
+    # Use resolve_jwt_secret with no dev_default argument so it matches the
+    # default used by get_jwt_strategy() when signing tokens ("dev-only-jwt-secret-not-for-production").
+    primary_secret = resolve_jwt_secret()
+    old_secrets = [s.get_secret_value() for s in (settings.jwt.old_secrets if settings.jwt else [])]
+    all_secrets = [primary_secret, *old_secrets]
 
     last_error: Exception | None = None
 

--- a/src/svc_infra/connect/__init__.py
+++ b/src/svc_infra/connect/__init__.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from svc_infra.connect.add import add_connect
+from svc_infra.connect.mcp_discovery import MCPOAuthDiscovery, MCPOAuthNotSupported
+from svc_infra.connect.models import ConnectionToken, OAuthState
+from svc_infra.connect.registry import ConnectRegistry, OAuthProvider, registry
+from svc_infra.connect.settings import ConnectSettings
+from svc_infra.connect.token_manager import ConnectionTokenManager
+
+__all__ = [
+    "add_connect",
+    "MCPOAuthDiscovery",
+    "MCPOAuthNotSupported",
+    "ConnectionToken",
+    "OAuthState",
+    "ConnectRegistry",
+    "OAuthProvider",
+    "registry",
+    "ConnectSettings",
+    "ConnectionTokenManager",
+]

--- a/src/svc_infra/connect/add.py
+++ b/src/svc_infra/connect/add.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+
+from fastapi import FastAPI
+from sqlalchemy import delete
+
+from svc_infra.connect.models import OAuthState
+from svc_infra.connect.registry import registry as _default_registry
+from svc_infra.connect.router import connect_router
+from svc_infra.connect.settings import ConnectSettings
+from svc_infra.connect.state import set_connect_state
+from svc_infra.connect.token_manager import ConnectionTokenManager
+from svc_infra.jobs.easy import easy_jobs
+
+logger = logging.getLogger(__name__)
+
+
+def add_connect(app: FastAPI, *, prefix: str = "/connect") -> None:
+    """Mount the svc_infra.connect OAuth module on the given FastAPI application.
+
+    Reads ConnectSettings from environment variables at lifespan startup so that
+    validation failures are caught before the app begins serving traffic.
+    Wraps any existing lifespan context using the same idiom as add_sql_db().
+    Registers background jobs for token refresh and OAuthState cleanup.
+
+    Must be called after add_sql_db() so that the DB session is available.
+
+    Example::
+
+        from svc_infra.api.fastapi.db.sql.add import add_sql_db
+        from svc_infra.connect import add_connect
+
+        app = FastAPI()
+        add_sql_db(app)
+        add_connect(app)
+    """
+    existing_lifespan = getattr(app.router, "lifespan_context", None)
+
+    @asynccontextmanager
+    async def connect_lifespan(_app: FastAPI):
+        try:
+            settings = ConnectSettings()
+        except Exception as exc:
+            raise RuntimeError(
+                "CONNECT_TOKEN_ENCRYPTION_KEY is missing or invalid. "
+                'Generate one with: python -c "from cryptography.fernet import Fernet; '
+                'print(Fernet.generate_key().decode())"'
+            ) from exc
+
+        token_manager = ConnectionTokenManager(
+            encryption_key=settings.connect_token_encryption_key.get_secret_value(),
+            registry=_default_registry,
+        )
+        set_connect_state(settings, token_manager)
+
+        _, scheduler = easy_jobs()
+
+        from svc_infra.api.fastapi.db.sql.session import _SessionLocal
+
+        async def _refresh_task() -> None:
+            if _SessionLocal is None:
+                logger.warning("connect: DB not initialised, skipping token refresh")
+                return
+            try:
+                async with _SessionLocal() as db:
+                    count = await token_manager.refresh_expiring_tokens(db)
+                    await db.commit()
+                    if count:
+                        logger.info("connect: refreshed %d expiring tokens", count)
+            except Exception as exc:
+                logger.error("connect: token refresh background task failed: %s", exc)
+
+        async def _cleanup_expired_states() -> None:
+            if _SessionLocal is None:
+                logger.warning("connect: DB not initialised, skipping state cleanup")
+                return
+            try:
+                async with _SessionLocal() as db:
+                    result = await db.execute(
+                        delete(OAuthState).where(OAuthState.expires_at <= datetime.now(UTC))
+                    )
+                    await db.commit()
+                    deleted = result.rowcount
+                    if deleted:
+                        logger.debug("connect: purged %d expired OAuthState rows", deleted)
+            except Exception as exc:
+                logger.error("connect: OAuthState cleanup task failed: %s", exc)
+
+        scheduler.add_task("connect:refresh_tokens", 300, _refresh_task)
+        scheduler.add_task("connect:cleanup_states", 600, _cleanup_expired_states)
+        scheduler_task = asyncio.create_task(scheduler.run())
+
+        if existing_lifespan is not None:
+            async with existing_lifespan(_app):
+                try:
+                    yield
+                finally:
+                    scheduler_task.cancel()
+        else:
+            try:
+                yield
+            finally:
+                scheduler_task.cancel()
+
+    app.router.lifespan_context = connect_lifespan
+    app.include_router(connect_router, prefix=prefix)

--- a/src/svc_infra/connect/add.py
+++ b/src/svc_infra/connect/add.py
@@ -43,7 +43,7 @@ def add_connect(app: FastAPI, *, prefix: str = "/connect") -> None:
     @asynccontextmanager
     async def connect_lifespan(_app: FastAPI):
         try:
-            settings = ConnectSettings()
+            settings = ConnectSettings()  # type: ignore[call-arg]
         except Exception as exc:
             raise RuntimeError(
                 "CONNECT_TOKEN_ENCRYPTION_KEY is missing or invalid. "
@@ -84,7 +84,7 @@ def add_connect(app: FastAPI, *, prefix: str = "/connect") -> None:
                         delete(OAuthState).where(OAuthState.expires_at <= datetime.now(UTC))
                     )
                     await db.commit()
-                    deleted = result.rowcount
+                    deleted = result.rowcount  # type: ignore[attr-defined]
                     if deleted:
                         logger.debug("connect: purged %d expired OAuthState rows", deleted)
             except Exception as exc:

--- a/src/svc_infra/connect/alembic.py
+++ b/src/svc_infra/connect/alembic.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+def discover_packages() -> list[str]:
+    """Return model packages for Alembic autogenerate discovery."""
+    return ["svc_infra.connect.models"]

--- a/src/svc_infra/connect/mcp_discovery.py
+++ b/src/svc_infra/connect/mcp_discovery.py
@@ -5,6 +5,7 @@ import time
 from typing import Any
 
 import httpx
+from pydantic import SecretStr
 
 from svc_infra.connect.registry import OAuthProvider
 
@@ -119,7 +120,7 @@ class MCPOAuthDiscovery:
         servers = resource_meta.get("authorization_servers")
         if not servers or not isinstance(servers, list):
             raise MCPOAuthNotSupported("Resource metadata contains no authorization_servers field")
-        return servers[0].rstrip("/")
+        return str(servers[0]).rstrip("/")
 
     async def _fetch_auth_server_metadata(self, auth_server_url: str) -> dict[str, Any]:
         url = auth_server_url + "/.well-known/oauth-authorization-server"
@@ -159,7 +160,7 @@ class MCPOAuthDiscovery:
         return _OAuthProvider(
             name=f"mcp:{mcp_server_url}",
             client_id="",
-            client_secret="",
+            client_secret=SecretStr(""),
             authorize_url=authorize_url,
             token_url=token_url,
             revoke_url=auth_meta.get("revocation_endpoint"),

--- a/src/svc_infra/connect/mcp_discovery.py
+++ b/src/svc_infra/connect/mcp_discovery.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+
+import httpx
+
+from svc_infra.connect.registry import OAuthProvider
+
+
+class MCPOAuthNotSupported(Exception):
+    """Raised when an MCP server does not implement the OAuth Authorization spec.
+
+    Callers should fall back to the manual-token UX when this is raised.
+    """
+
+
+_DISCOVERY_CACHE: dict[str, tuple[OAuthProvider, float]] = {}
+_CACHE_TTL_SECONDS = 3600  # MCP server metadata rarely changes
+
+
+def parse_www_authenticate(header: str) -> dict[str, str]:
+    """Parse a Bearer WWW-Authenticate header into a key/value dict.
+
+    Handles: Bearer resource_metadata="https://..." realm="..."
+    """
+    result: dict[str, str] = {}
+    for match in re.finditer(r'(\w+)=["\']?([^"\',\s]+)["\']?', header):
+        result[match.group(1)] = match.group(2)
+    return result
+
+
+class MCPOAuthDiscovery:
+    """Discover OAuth authorization server metadata from an MCP server URL.
+
+    Implements RFC 9728 (OAuth 2.0 Protected Resource Metadata) +
+    RFC 8414 (OAuth 2.0 Authorization Server Metadata).
+
+    After token acquisition, the access token is injected into the Authorization
+    header of MCP connections. ai_infra.mcp.client.MCPClient picks it up through
+    the standard Bearer path — this module is only responsible for obtaining and
+    refreshing the token; protocol internals remain in ai-infra.
+    """
+
+    async def discover(self, mcp_server_url: str) -> OAuthProvider:
+        """Discover a fully-populated OAuthProvider for the given MCP server URL.
+
+        Results are cached in-process for 1 hour.
+
+        Raises MCPOAuthNotSupported if:
+        - The server does not implement RFC 9728 resource metadata
+        - The authorization server metadata is unreachable or malformed
+        """
+        now = time.monotonic()
+        cached = _DISCOVERY_CACHE.get(mcp_server_url)
+        if cached is not None:
+            provider, ts = cached
+            if now - ts < _CACHE_TTL_SECONDS:
+                return provider
+
+        resource_meta = await self._fetch_resource_metadata(mcp_server_url)
+        auth_server_url = self._extract_auth_server(resource_meta)
+        auth_meta = await self._fetch_auth_server_metadata(auth_server_url)
+
+        provider = self._build_provider(mcp_server_url, auth_meta)
+        _DISCOVERY_CACHE[mcp_server_url] = (provider, now)
+        return provider
+
+    async def is_mcp_oauth_supported(self, mcp_server_url: str) -> bool:
+        """Lightweight check: probe the MCP server and inspect the 401 response headers.
+
+        Returns True if the server returns a WWW-Authenticate: Bearer header containing
+        resource_metadata, indicating it implements RFC 9728.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(
+                    mcp_server_url,
+                    json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
+                    headers={"Content-Type": "application/json"},
+                )
+            if response.status_code != 401:
+                return False
+            www_auth = response.headers.get("www-authenticate", "")
+            if not www_auth.lower().startswith("bearer"):
+                return False
+            parsed = parse_www_authenticate(www_auth)
+            return "resource_metadata" in parsed
+        except (httpx.RequestError, httpx.HTTPStatusError):
+            return False
+
+    async def _fetch_resource_metadata(self, mcp_server_url: str) -> dict[str, Any]:
+        url = mcp_server_url.rstrip("/") + "/.well-known/oauth-protected-resource"
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                response = await client.get(url, headers={"Accept": "application/json"})
+        except httpx.RequestError as exc:
+            raise MCPOAuthNotSupported(
+                f"Could not reach resource metadata endpoint: {exc}"
+            ) from exc
+
+        if response.status_code == 404 or response.status_code == 405:
+            raise MCPOAuthNotSupported(
+                f"Server at {mcp_server_url} does not expose RFC 9728 resource metadata "
+                f"(got {response.status_code})"
+            )
+        if response.status_code != 200:
+            raise MCPOAuthNotSupported(f"Resource metadata returned {response.status_code}")
+
+        try:
+            data: dict[str, Any] = response.json()
+        except Exception as exc:
+            raise MCPOAuthNotSupported("Resource metadata response is not valid JSON") from exc
+
+        return data
+
+    def _extract_auth_server(self, resource_meta: dict[str, Any]) -> str:
+        servers = resource_meta.get("authorization_servers")
+        if not servers or not isinstance(servers, list):
+            raise MCPOAuthNotSupported("Resource metadata contains no authorization_servers field")
+        return servers[0].rstrip("/")
+
+    async def _fetch_auth_server_metadata(self, auth_server_url: str) -> dict[str, Any]:
+        url = auth_server_url + "/.well-known/oauth-authorization-server"
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                response = await client.get(url, headers={"Accept": "application/json"})
+        except httpx.RequestError as exc:
+            raise MCPOAuthNotSupported(
+                f"Could not reach authorization server metadata: {exc}"
+            ) from exc
+
+        if response.status_code != 200:
+            raise MCPOAuthNotSupported(
+                f"Authorization server metadata returned {response.status_code}"
+            )
+
+        try:
+            data: dict[str, Any] = response.json()
+        except Exception as exc:
+            raise MCPOAuthNotSupported("Authorization server metadata is not valid JSON") from exc
+
+        return data
+
+    def _build_provider(self, mcp_server_url: str, auth_meta: dict[str, Any]) -> OAuthProvider:
+        authorize_url = auth_meta.get("authorization_endpoint")
+        token_url = auth_meta.get("token_endpoint")
+        if not authorize_url or not token_url:
+            raise MCPOAuthNotSupported(
+                "Authorization server metadata missing authorization_endpoint or token_endpoint"
+            )
+
+        supported_methods = auth_meta.get("code_challenge_methods_supported", [])
+        pkce_required = "S256" in supported_methods or not supported_methods
+
+        from svc_infra.connect.registry import OAuthProvider as _OAuthProvider
+
+        return _OAuthProvider(
+            name=f"mcp:{mcp_server_url}",
+            client_id="",
+            client_secret="",
+            authorize_url=authorize_url,
+            token_url=token_url,
+            revoke_url=auth_meta.get("revocation_endpoint"),
+            default_scopes=[],
+            pkce_required=pkce_required,
+            extra_authorize_params={},
+            userinfo_url=None,
+        )

--- a/src/svc_infra/connect/models.py
+++ b/src/svc_infra/connect/models.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql.expression import text
+
+from svc_infra.db.sql.base import ModelBase
+from svc_infra.db.sql.types import GUID
+
+
+class ConnectionToken(ModelBase):
+    """Encrypted OAuth token for a third-party provider connection.
+
+    Keyed to (connection_id, user_id, provider). Distinct from ProviderAccount which
+    tracks login-provider identities. access_token, refresh_token, and raw_token are
+    Fernet-encrypted at rest by ConnectionTokenManager.
+    """
+
+    __tablename__ = "connection_tokens"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    connection_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(),
+        nullable=False,
+        index=True,
+        comment="Logical FK to consuming app connection table; not DB-enforced",
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    provider: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    access_token: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        comment="Fernet-encrypted; never logged",
+    )
+    refresh_token: Mapped[str | None] = mapped_column(
+        Text,
+        comment="Fernet-encrypted; None for non-refreshable tokens",
+    )
+    token_type: Mapped[str] = mapped_column(String(32), nullable=False, default="Bearer")
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        comment="None means non-expiring token",
+    )
+    scopes: Mapped[list | None] = mapped_column(JSON, comment="List of scope strings")
+    raw_token: Mapped[dict | None] = mapped_column(
+        JSON,
+        comment="Fernet-encrypted full provider token response",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("CURRENT_TIMESTAMP"),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("CURRENT_TIMESTAMP"),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        UniqueConstraint("connection_id", "user_id", "provider", name="uq_connection_token"),
+        Index("ix_connection_tokens_user_provider", "user_id", "provider"),
+    )
+
+
+class OAuthState(ModelBase):
+    """Short-lived PKCE state store for OAuth flows.
+
+    Replaces SessionMiddleware-based state from oauth_router.py, enabling stateless
+    API servers. Rows are purged by a background InMemoryScheduler job after TTL.
+    """
+
+    __tablename__ = "oauth_states"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    state: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        index=True,
+        unique=True,
+        comment="32-byte URL-safe random value; SHA-256 verified on callback",
+    )
+    pkce_verifier: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        comment="Stored server-side; sent to token endpoint on callback",
+    )
+    provider: Mapped[str] = mapped_column(String(255), nullable=False)
+    connection_id: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(),
+        comment="Pre-linked before redirect; may be None for new connections",
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    redirect_uri: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        comment="Validated against allow-list before storage",
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        index=True,
+        comment="10-minute TTL; background job purges expired rows",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("CURRENT_TIMESTAMP"),
+        nullable=False,
+    )

--- a/src/svc_infra/connect/pkce.py
+++ b/src/svc_infra/connect/pkce.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import secrets
 from datetime import UTC, datetime, timedelta
+from typing import Any, cast
 from urllib.parse import urlencode, urlparse
 
 import httpx
@@ -146,7 +147,7 @@ async def exchange_code(
             f"Token exchange error: {data['error']} — {data.get('error_description', '')}"
         )
 
-    return data
+    return cast(dict[str, Any], data)
 
 
 async def exchange_refresh(
@@ -183,4 +184,4 @@ async def exchange_refresh(
     if "access_token" not in data:
         raise OAuthRefreshError("No access_token in refresh response")
 
-    return data
+    return cast(dict[str, Any], data)

--- a/src/svc_infra/connect/pkce.py
+++ b/src/svc_infra/connect/pkce.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlencode, urlparse
+
+import httpx
+from fastapi import HTTPException
+
+from svc_infra.connect.registry import OAuthProvider
+
+
+class OAuthExchangeError(Exception):
+    """Raised when an authorization code exchange fails."""
+
+
+class OAuthRefreshError(Exception):
+    """Raised when a token refresh fails."""
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    """Generate a PKCE (verifier, challenge) pair.
+
+    Returns (verifier, challenge). verifier is stored server-side in OAuthState;
+    challenge is sent to the provider authorization endpoint.
+    Implementation moved verbatim from oauth_router._gen_pkce_pair().
+    """
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def generate_state() -> str:
+    """Generate a 32-byte URL-safe random state value."""
+    return base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+
+
+def validate_redirect(
+    url: str,
+    allow_hosts: list[str],
+    *,
+    require_https: bool = True,
+) -> None:
+    """Validate a redirect URI against an allow-list of hosts.
+
+    Raises HTTPException(400) on disallowed host or non-HTTPS when required.
+    Implementation moved verbatim from oauth_router._validate_redirect().
+    """
+    p = urlparse(url)
+    if not p.netloc:
+        return
+    # Skip host+https checks for non-http(s) custom schemes (e.g. pulse-app://).
+    if p.scheme not in ("http", "https"):
+        return
+    hostname = p.hostname
+    host_port = (hostname or "").lower() + (f":{p.port}" if p.port else "")
+    allowed = {h.lower() for h in allow_hosts}
+    if host_port not in allowed and (hostname or "").lower() not in allowed:
+        raise HTTPException(400, "redirect_not_allowed")
+    if require_https and p.scheme != "https":
+        raise HTTPException(400, "https_required")
+
+
+def coerce_expires_at(token: dict | None) -> datetime | None:
+    """Normalise expires_at / expires_in fields from a provider token response.
+
+    Handles both unix timestamp (expires_at) and relative-seconds (expires_in) formats.
+    Millisecond timestamps (> 1e12) are automatically divided by 1000.
+    Implementation moved verbatim from oauth_router._coerce_expires_at().
+    """
+    if not isinstance(token, dict):
+        return None
+    if token.get("expires_at") is not None:
+        v = float(token["expires_at"])
+        if v > 1e12:
+            v /= 1000.0
+        return datetime.fromtimestamp(v, tz=UTC)
+    if token.get("expires_in") is not None:
+        secs = int(token["expires_in"])
+        return datetime.now(UTC) + timedelta(seconds=secs)
+    return None
+
+
+def build_authorize_url(
+    provider: OAuthProvider,
+    state: str,
+    pkce_challenge: str,
+    redirect_uri: str,
+    scopes: list[str] | None = None,
+    extra: dict[str, str] | None = None,
+) -> str:
+    """Construct the full OAuth authorization redirect URL."""
+    effective_scopes = scopes if scopes is not None else provider.default_scopes
+    params: dict[str, str] = {
+        "client_id": provider.client_id,
+        "response_type": "code",
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "scope": " ".join(effective_scopes),
+    }
+    if provider.pkce_required:
+        params["code_challenge"] = pkce_challenge
+        params["code_challenge_method"] = "S256"
+    params.update(provider.extra_authorize_params)
+    if extra:
+        params.update(extra)
+    return f"{provider.authorize_url}?{urlencode(params)}"
+
+
+async def exchange_code(
+    provider: OAuthProvider,
+    code: str,
+    pkce_verifier: str,
+    redirect_uri: str,
+) -> dict:
+    """Exchange an authorization code for tokens.
+
+    Raises OAuthExchangeError on non-200 or error JSON from the provider.
+    """
+    payload: dict[str, str] = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": provider.client_id,
+        "client_secret": provider.client_secret.get_secret_value(),
+    }
+    if provider.pkce_required:
+        payload["code_verifier"] = pkce_verifier
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            provider.token_url,
+            data=payload,
+            headers={"Accept": "application/json"},
+        )
+
+    if response.status_code != 200:
+        raise OAuthExchangeError(f"Token exchange failed: {response.status_code} {response.text}")
+
+    data = response.json()
+    if "error" in data:
+        raise OAuthExchangeError(
+            f"Token exchange error: {data['error']} — {data.get('error_description', '')}"
+        )
+
+    return data
+
+
+async def exchange_refresh(
+    provider: OAuthProvider,
+    refresh_token_str: str,
+) -> dict:
+    """Refresh an access token using a refresh token grant.
+
+    Raises OAuthRefreshError if the refresh token is absent, or the provider rejects the grant.
+    """
+    payload: dict[str, str] = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token_str,
+        "client_id": provider.client_id,
+        "client_secret": provider.client_secret.get_secret_value(),
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            provider.token_url,
+            data=payload,
+            headers={"Accept": "application/json"},
+        )
+
+    if response.status_code != 200:
+        raise OAuthRefreshError(f"Token refresh failed: {response.status_code} {response.text}")
+
+    data = response.json()
+    if "error" in data:
+        raise OAuthRefreshError(
+            f"Token refresh error: {data['error']} — {data.get('error_description', '')}"
+        )
+
+    if "access_token" not in data:
+        raise OAuthRefreshError("No access_token in refresh response")
+
+    return data

--- a/src/svc_infra/connect/providers/__init__.py
+++ b/src/svc_infra/connect/providers/__init__.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+# Backward-compat re-exports so callers that import build_*_provider directly
+# continue to work.  Each thin wrapper delegates to the master catalog.
+from svc_infra.connect.providers.atlassian import build_atlassian_provider
+from svc_infra.connect.providers.generic import load_all_connect_providers
+from svc_infra.connect.providers.github import build_github_provider
+from svc_infra.connect.providers.google import build_google_provider
+from svc_infra.connect.providers.linear import build_linear_provider
+from svc_infra.connect.providers.microsoft import build_microsoft_provider
+from svc_infra.connect.providers.notion import build_notion_provider
+from svc_infra.connect.providers.slack import build_slack_provider
+from svc_infra.connect.registry import registry
+
+
+def _load_builtin_providers() -> None:
+    """Register all configured OAuth providers from the master catalog."""
+    for provider in load_all_connect_providers():
+        registry.register(provider)
+
+
+_load_builtin_providers()
+
+__all__ = [
+    "build_atlassian_provider",
+    "build_github_provider",
+    "build_google_provider",
+    "build_linear_provider",
+    "build_microsoft_provider",
+    "build_notion_provider",
+    "build_slack_provider",
+]

--- a/src/svc_infra/connect/providers/atlassian.py
+++ b/src/svc_infra/connect/providers/atlassian.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from svc_infra.connect.registry import OAuthProvider
+
+
+def build_atlassian_provider() -> OAuthProvider | None:
+    """Build Atlassian OAuth 2.0 provider (Jira, Confluence) from env vars.
+
+    Delegates to the master catalog in generic.py.
+    Env vars: ATLASSIAN_CLIENT_ID / ATLASSIAN_CLIENT_SECRET (or CONNECT_ATLASSIAN_*)
+    """
+    from svc_infra.connect.providers.generic import _load_known_provider
+
+    return _load_known_provider("atlassian")

--- a/src/svc_infra/connect/providers/generic.py
+++ b/src/svc_infra/connect/providers/generic.py
@@ -1,0 +1,890 @@
+"""Master OAuth provider catalog and loading logic for svc_infra.connect.
+
+This is the single source of truth for OAuth provider URL definitions.  It
+powers BOTH:
+  - svc_infra.connect  — workspace tool connections (stores tokens in DB)
+  - svc_infra.auth     — user login (issues JWT sessions)
+
+Any app that uses either module only needs to configure credentials once.
+
+Env var convention
+------------------
+Primary (works for every provider, including custom unknown ones):
+    CONNECT_{NAME}_CLIENT_ID=...
+    CONNECT_{NAME}_CLIENT_SECRET=...
+
+Legacy / convenience names for the built-in set (checked when primary not set):
+    GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET
+    GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET      (also GOOGLE_CONNECT_CLIENT_ID)
+    MICROSOFT_CLIENT_ID / MICROSOFT_CLIENT_SECRET (also MICROSOFT_CONNECT_*)
+    NOTION_CLIENT_ID / NOTION_CLIENT_SECRET
+    SLACK_CLIENT_ID / SLACK_CLIENT_SECRET
+    LINEAR_CLIENT_ID / LINEAR_CLIENT_SECRET
+    ATLASSIAN_CLIENT_ID / ATLASSIAN_CLIENT_SECRET
+    LINKEDIN_CLIENT_ID / LINKEDIN_CLIENT_SECRET
+    FIGMA_CLIENT_ID / FIGMA_CLIENT_SECRET
+    STRIPE_CLIENT_ID / STRIPE_CLIENT_SECRET
+
+Dynamic-URL provider env vars (subdomain / domain required):
+    CONNECT_MICROSOFT_TENANT_ID  or  MICROSOFT_TENANT_ID  (default: common)
+    CONNECT_OKTA_DOMAIN          or  OKTA_DOMAIN
+    CONNECT_AUTH0_DOMAIN         or  AUTH0_DOMAIN
+    CONNECT_KEYCLOAK_BASE_URL    or  KEYCLOAK_BASE_URL
+    CONNECT_KEYCLOAK_REALM       or  KEYCLOAK_REALM          (default: master)
+    CONNECT_COGNITO_DOMAIN       or  COGNITO_DOMAIN
+    CONNECT_ZENDESK_SUBDOMAIN    or  ZENDESK_SUBDOMAIN
+    CONNECT_FRESHDESK_SUBDOMAIN  or  FRESHDESK_SUBDOMAIN
+    CONNECT_SHOPIFY_SHOP         or  SHOPIFY_SHOP
+
+Arbitrary extra providers (URLs pre-filled for known entries; full URL config
+required for anything not in _KNOWN):
+    CONNECT_PROVIDERS=dropbox,acmecorp
+    CONNECT_DROPBOX_CLIENT_ID=...          # known — URLs already in catalog
+    CONNECT_ACMECORP_CLIENT_ID=...
+    CONNECT_ACMECORP_AUTHORIZE_URL=https://acme.com/oauth/authorize
+    CONNECT_ACMECORP_TOKEN_URL=https://acme.com/oauth/token
+
+Per-provider optional overrides (work for any provider):
+    CONNECT_{NAME}_SCOPES=scope1,scope2
+    CONNECT_{NAME}_PKCE=true|false
+    CONNECT_{NAME}_AUTHORIZE_URL=https://...
+    CONNECT_{NAME}_TOKEN_URL=https://...
+    CONNECT_{NAME}_REVOKE_URL=https://...
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from typing import Any
+
+from svc_infra.connect.registry import OAuthProvider
+
+# ---------------------------------------------------------------------------
+# Dynamic URL builders
+# Providers whose URLs depend on tenant / subdomain / domain env vars.
+# Each builder returns a dict of URL fields to merge into the provider config,
+# or None when the required env var is missing (provider is skipped).
+# ---------------------------------------------------------------------------
+
+
+def _build_microsoft_urls() -> dict[str, str] | None:
+    tenant = os.getenv("CONNECT_MICROSOFT_TENANT_ID") or os.getenv("MICROSOFT_TENANT_ID", "common")
+    base = f"https://login.microsoftonline.com/{tenant}"
+    return {
+        "authorize_url": f"{base}/oauth2/v2.0/authorize",
+        "token_url": f"{base}/oauth2/v2.0/token",
+        "oidc_discovery_url": f"{base}/v2.0",
+    }
+
+
+def _build_okta_urls() -> dict[str, str] | None:
+    domain = os.getenv("CONNECT_OKTA_DOMAIN") or os.getenv("OKTA_DOMAIN")
+    if not domain:
+        return None
+    domain = domain.strip().rstrip("/")
+    base = f"https://{domain}/oauth2/default"
+    return {
+        "authorize_url": f"{base}/v1/authorize",
+        "token_url": f"{base}/v1/token",
+        "revoke_url": f"{base}/v1/revoke",
+        "oidc_discovery_url": base,
+    }
+
+
+def _build_auth0_urls() -> dict[str, str] | None:
+    domain = os.getenv("CONNECT_AUTH0_DOMAIN") or os.getenv("AUTH0_DOMAIN")
+    if not domain:
+        return None
+    domain = domain.strip().rstrip("/")
+    return {
+        "authorize_url": f"https://{domain}/authorize",
+        "token_url": f"https://{domain}/oauth/token",
+        "revoke_url": f"https://{domain}/oauth/revoke",
+        "oidc_discovery_url": f"https://{domain}",
+    }
+
+
+def _build_keycloak_urls() -> dict[str, str] | None:
+    base = os.getenv("CONNECT_KEYCLOAK_BASE_URL") or os.getenv("KEYCLOAK_BASE_URL")
+    if not base:
+        return None
+    realm = os.getenv("CONNECT_KEYCLOAK_REALM") or os.getenv("KEYCLOAK_REALM", "master")
+    realm_url = f"{base.rstrip('/')}/realms/{realm}"
+    return {
+        "authorize_url": f"{realm_url}/protocol/openid-connect/auth",
+        "token_url": f"{realm_url}/protocol/openid-connect/token",
+        "revoke_url": f"{realm_url}/protocol/openid-connect/revoke",
+        "oidc_discovery_url": realm_url,
+    }
+
+
+def _build_cognito_urls() -> dict[str, str] | None:
+    domain = os.getenv("CONNECT_COGNITO_DOMAIN") or os.getenv("COGNITO_DOMAIN")
+    if not domain:
+        return None
+    domain = domain.strip().rstrip("/")
+    return {
+        "authorize_url": f"https://{domain}/oauth2/authorize",
+        "token_url": f"https://{domain}/oauth2/token",
+        "revoke_url": f"https://{domain}/oauth2/revoke",
+        "oidc_discovery_url": domain,
+    }
+
+
+def _build_zendesk_urls() -> dict[str, str] | None:
+    subdomain = os.getenv("CONNECT_ZENDESK_SUBDOMAIN") or os.getenv("ZENDESK_SUBDOMAIN")
+    if not subdomain:
+        return None
+    return {
+        "authorize_url": f"https://{subdomain}.zendesk.com/oauth/authorizations/new",
+        "token_url": f"https://{subdomain}.zendesk.com/oauth/tokens",
+    }
+
+
+def _build_freshdesk_urls() -> dict[str, str] | None:
+    subdomain = os.getenv("CONNECT_FRESHDESK_SUBDOMAIN") or os.getenv("FRESHDESK_SUBDOMAIN")
+    if not subdomain:
+        return None
+    return {
+        "authorize_url": f"https://{subdomain}.freshdesk.com/login/oauth/authorize",
+        "token_url": f"https://{subdomain}.freshdesk.com/login/oauth/token",
+    }
+
+
+def _build_shopify_urls() -> dict[str, str] | None:
+    shop = os.getenv("CONNECT_SHOPIFY_SHOP") or os.getenv("SHOPIFY_SHOP")
+    if not shop:
+        return None
+    shop = shop.strip().rstrip("/")
+    return {
+        "authorize_url": f"https://{shop}/admin/oauth/authorize",
+        "token_url": f"https://{shop}/admin/oauth/access_token",
+    }
+
+
+_URL_BUILDERS: dict[str, Callable[[], dict[str, str] | None]] = {
+    "microsoft": _build_microsoft_urls,
+    "okta": _build_okta_urls,
+    "auth0": _build_auth0_urls,
+    "keycloak": _build_keycloak_urls,
+    "cognito": _build_cognito_urls,
+    "zendesk": _build_zendesk_urls,
+    "freshdesk": _build_freshdesk_urls,
+    "shopify": _build_shopify_urls,
+}
+
+# ---------------------------------------------------------------------------
+# Legacy env var fallbacks
+# Maps provider name -> ([id_env_fallbacks], [secret_env_fallbacks]).
+# Checked when CONNECT_{NAME}_CLIENT_ID is not set.
+# ---------------------------------------------------------------------------
+_LEGACY_ENVS: dict[str, tuple[list[str], list[str]]] = {
+    "github": (["GITHUB_CLIENT_ID"], ["GITHUB_CLIENT_SECRET"]),
+    "google": (
+        ["GOOGLE_CONNECT_CLIENT_ID", "GOOGLE_CLIENT_ID"],
+        ["GOOGLE_CONNECT_CLIENT_SECRET", "GOOGLE_CLIENT_SECRET"],
+    ),
+    "microsoft": (
+        ["MICROSOFT_CONNECT_CLIENT_ID", "MICROSOFT_CLIENT_ID"],
+        ["MICROSOFT_CONNECT_CLIENT_SECRET", "MICROSOFT_CLIENT_SECRET"],
+    ),
+    "notion": (["NOTION_CLIENT_ID"], ["NOTION_CLIENT_SECRET"]),
+    "slack": (["SLACK_CLIENT_ID"], ["SLACK_CLIENT_SECRET"]),
+    "linear": (["LINEAR_CLIENT_ID"], ["LINEAR_CLIENT_SECRET"]),
+    "atlassian": (["ATLASSIAN_CLIENT_ID"], ["ATLASSIAN_CLIENT_SECRET"]),
+    "linkedin": (["LINKEDIN_CLIENT_ID"], ["LINKEDIN_CLIENT_SECRET"]),
+    "figma": (["FIGMA_CLIENT_ID"], ["FIGMA_CLIENT_SECRET"]),
+    "stripe": (["STRIPE_CLIENT_ID"], ["STRIPE_CLIENT_SECRET"]),
+    "hubspot": (["HUBSPOT_CLIENT_ID"], ["HUBSPOT_CLIENT_SECRET"]),
+    "dropbox": (["DROPBOX_CLIENT_ID"], ["DROPBOX_CLIENT_SECRET"]),
+    "box": (["BOX_CLIENT_ID"], ["BOX_CLIENT_SECRET"]),
+    "discord": (["DISCORD_CLIENT_ID"], ["DISCORD_CLIENT_SECRET"]),
+    "zoom": (["ZOOM_CLIENT_ID"], ["ZOOM_CLIENT_SECRET"]),
+    "salesforce": (["SALESFORCE_CLIENT_ID"], ["SALESFORCE_CLIENT_SECRET"]),
+    "gitlab": (["GITLAB_CLIENT_ID"], ["GITLAB_CLIENT_SECRET"]),
+    "bitbucket": (["BITBUCKET_CLIENT_ID"], ["BITBUCKET_CLIENT_SECRET"]),
+    "airtable": (["AIRTABLE_CLIENT_ID"], ["AIRTABLE_CLIENT_SECRET"]),
+    "asana": (["ASANA_CLIENT_ID"], ["ASANA_CLIENT_SECRET"]),
+    "monday": (["MONDAY_CLIENT_ID"], ["MONDAY_CLIENT_SECRET"]),
+    "clickup": (["CLICKUP_CLIENT_ID"], ["CLICKUP_CLIENT_SECRET"]),
+    "calendly": (["CALENDLY_CLIENT_ID"], ["CALENDLY_CLIENT_SECRET"]),
+    "quickbooks": (["QUICKBOOKS_CLIENT_ID"], ["QUICKBOOKS_CLIENT_SECRET"]),
+    "xero": (["XERO_CLIENT_ID"], ["XERO_CLIENT_SECRET"]),
+    "twitter": (["TWITTER_CLIENT_ID"], ["TWITTER_CLIENT_SECRET"]),
+    "spotify": (["SPOTIFY_CLIENT_ID"], ["SPOTIFY_CLIENT_SECRET"]),
+    "intercom": (["INTERCOM_CLIENT_ID"], ["INTERCOM_CLIENT_SECRET"]),
+}
+
+# ---------------------------------------------------------------------------
+# Known provider URL catalog
+# Entries whose URLs depend on env vars at runtime use _uses_builder=True;
+# this instructs _load_known_provider to call _URL_BUILDERS[name]() for URLs.
+#
+# All non-underscore keys map directly to OAuthProvider fields.
+# ---------------------------------------------------------------------------
+_KNOWN: dict[str, dict[str, Any]] = {
+    # ---------------------------------------------------------------------- #
+    # IDENTITY / LOGIN PROVIDERS                                              #
+    # ---------------------------------------------------------------------- #
+    "github": {
+        "authorize_url": "https://github.com/login/oauth/authorize",
+        "token_url": "https://github.com/login/oauth/access_token",
+        "revoke_url": "https://api.github.com/applications/{client_id}/token",
+        "userinfo_url": "https://api.github.com/user",
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "github",
+        "default_scopes": ["repo", "user:email"],
+        "extra_authorize_params": {"allow_signup": "false"},
+    },
+    "google": {
+        "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_url": "https://oauth2.googleapis.com/token",
+        "revoke_url": "https://oauth2.googleapis.com/revoke",
+        "userinfo_url": "https://www.googleapis.com/oauth2/v3/userinfo",
+        "oidc_discovery_url": "https://accounts.google.com",
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "oidc",
+        "default_scopes": [
+            "https://www.googleapis.com/auth/drive.readonly",
+            "https://www.googleapis.com/auth/calendar.readonly",
+        ],
+        "extra_authorize_params": {"access_type": "offline", "prompt": "consent"},
+    },
+    "microsoft": {
+        # URLs are tenant-specific; built at load time by _build_microsoft_urls
+        "_uses_builder": True,
+        "userinfo_url": "https://graph.microsoft.com/v1.0/me",
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "oidc",
+        "default_scopes": ["Files.Read", "Calendars.Read", "offline_access"],
+    },
+    "linkedin": {
+        "authorize_url": "https://www.linkedin.com/oauth/v2/authorization",
+        "token_url": "https://www.linkedin.com/oauth/v2/accessToken",
+        "userinfo_url": "https://api.linkedin.com/v2/me",
+        "pkce_required": False,
+        "login_enabled": True,
+        "userinfo_kind": "linkedin",
+        "default_scopes": ["r_liteprofile", "r_emailaddress"],
+    },
+    "apple": {
+        "authorize_url": "https://appleid.apple.com/auth/authorize",
+        "token_url": "https://appleid.apple.com/auth/token",
+        "revoke_url": "https://appleid.apple.com/auth/revoke",
+        "oidc_discovery_url": "https://appleid.apple.com",
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "oidc",
+        "default_scopes": ["name", "email"],
+        "extra_authorize_params": {"response_mode": "form_post"},
+    },
+    "discord": {
+        "authorize_url": "https://discord.com/api/oauth2/authorize",
+        "token_url": "https://discord.com/api/oauth2/token",
+        "revoke_url": "https://discord.com/api/oauth2/token/revoke",
+        "userinfo_url": "https://discord.com/api/users/@me",
+        "pkce_required": False,
+        "login_enabled": True,
+        "userinfo_kind": "standard",
+        "default_scopes": ["identify", "email"],
+    },
+    "twitter": {
+        "authorize_url": "https://twitter.com/i/oauth2/authorize",
+        "token_url": "https://api.twitter.com/2/oauth2/token",
+        "revoke_url": "https://api.twitter.com/2/oauth2/revoke",
+        "userinfo_url": "https://api.twitter.com/2/users/me",
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "standard",
+        "default_scopes": ["tweet.read", "users.read", "offline.access"],
+    },
+    "twitch": {
+        "authorize_url": "https://id.twitch.tv/oauth2/authorize",
+        "token_url": "https://id.twitch.tv/oauth2/token",
+        "revoke_url": "https://id.twitch.tv/oauth2/revoke",
+        "userinfo_url": "https://api.twitch.tv/helix/users",
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "standard",
+        "default_scopes": ["user:read:email"],
+    },
+    "spotify": {
+        "authorize_url": "https://accounts.spotify.com/authorize",
+        "token_url": "https://accounts.spotify.com/api/token",
+        "userinfo_url": "https://api.spotify.com/v1/me",
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "standard",
+        "default_scopes": ["user-read-email", "playlist-read-private"],
+    },
+    "reddit": {
+        "authorize_url": "https://www.reddit.com/api/v1/authorize",
+        "token_url": "https://www.reddit.com/api/v1/access_token",
+        "revoke_url": "https://www.reddit.com/api/v1/revoke_token",
+        "userinfo_url": "https://oauth.reddit.com/api/v1/me",
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "standard",
+        "default_scopes": ["identity"],
+        "extra_authorize_params": {"duration": "permanent"},
+    },
+    "gitlab": {
+        "authorize_url": "https://gitlab.com/oauth/authorize",
+        "token_url": "https://gitlab.com/oauth/token",
+        "revoke_url": "https://gitlab.com/oauth/revoke",
+        "oidc_discovery_url": "https://gitlab.com",
+        "userinfo_url": "https://gitlab.com/oauth/userinfo",
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "oidc",
+        "default_scopes": ["read_user", "openid", "email"],
+    },
+    "bitbucket": {
+        "authorize_url": "https://bitbucket.org/site/oauth2/authorize",
+        "token_url": "https://bitbucket.org/site/oauth2/access_token",
+        "userinfo_url": "https://api.bitbucket.org/2.0/user",
+        "pkce_required": False,
+        "login_enabled": True,
+        "userinfo_kind": "standard",
+        "default_scopes": ["account", "repository"],
+    },
+    "heroku": {
+        "authorize_url": "https://id.heroku.com/oauth/authorize",
+        "token_url": "https://id.heroku.com/oauth/token",
+        "userinfo_url": "https://api.heroku.com/account",
+        "pkce_required": False,
+        "login_enabled": True,
+        "userinfo_kind": "standard",
+        "default_scopes": ["global"],
+    },
+    "webex": {
+        "authorize_url": "https://webexapis.com/v1/authorize",
+        "token_url": "https://webexapis.com/v1/access_token",
+        "revoke_url": "https://webexapis.com/v1/access_token",
+        "userinfo_url": "https://webexapis.com/v1/people/me",
+        "pkce_required": False,
+        "login_enabled": True,
+        "userinfo_kind": "standard",
+        "default_scopes": ["spark:people_read"],
+    },
+    "zoom": {
+        "authorize_url": "https://zoom.us/oauth/authorize",
+        "token_url": "https://zoom.us/oauth/token",
+        "revoke_url": "https://zoom.us/oauth/revoke",
+        "userinfo_url": "https://api.zoom.us/v2/users/me",
+        "pkce_required": False,
+        "login_enabled": True,
+        "userinfo_kind": "standard",
+        "default_scopes": ["user:read:admin"],
+    },
+    "facebook": {
+        "authorize_url": "https://www.facebook.com/v18.0/dialog/oauth",
+        "token_url": "https://graph.facebook.com/v18.0/oauth/access_token",
+        "revoke_url": "https://graph.facebook.com/me/permissions",
+        "userinfo_url": "https://graph.facebook.com/me?fields=id,name,email",
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "standard",
+        "default_scopes": ["email", "public_profile"],
+    },
+    "salesforce": {
+        "authorize_url": "https://login.salesforce.com/services/oauth2/authorize",
+        "token_url": "https://login.salesforce.com/services/oauth2/token",
+        "revoke_url": "https://login.salesforce.com/services/oauth2/revoke",
+        "userinfo_url": "https://login.salesforce.com/services/oauth2/userinfo",
+        "oidc_discovery_url": "https://login.salesforce.com",
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "oidc",
+        "default_scopes": ["api", "refresh_token", "openid"],
+    },
+    # ---------------------------------------------------------------------- #
+    # ENTERPRISE IDENTITY (OIDC — dynamic URLs via builder)                  #
+    # ---------------------------------------------------------------------- #
+    "okta": {
+        "_uses_builder": True,
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "oidc",
+        "default_scopes": ["openid", "email", "profile"],
+    },
+    "auth0": {
+        "_uses_builder": True,
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "oidc",
+        "default_scopes": ["openid", "email", "profile"],
+    },
+    "keycloak": {
+        "_uses_builder": True,
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "oidc",
+        "default_scopes": ["openid", "email", "profile"],
+    },
+    "cognito": {
+        "_uses_builder": True,
+        "pkce_required": True,
+        "login_enabled": True,
+        "userinfo_kind": "oidc",
+        "default_scopes": ["openid", "email", "profile"],
+    },
+    # ---------------------------------------------------------------------- #
+    # PRODUCTIVITY / PROJECT MANAGEMENT                                       #
+    # ---------------------------------------------------------------------- #
+    "notion": {
+        "authorize_url": "https://api.notion.com/v1/oauth/authorize",
+        "token_url": "https://api.notion.com/v1/oauth/token",
+        "pkce_required": True,
+        "default_scopes": [],
+        "extra_authorize_params": {"owner": "user"},
+    },
+    "airtable": {
+        "authorize_url": "https://airtable.com/oauth2/v1/authorize",
+        "token_url": "https://airtable.com/oauth2/v1/token",
+        "revoke_url": "https://airtable.com/oauth2/v1/token/revoke",
+        "pkce_required": True,
+        "default_scopes": ["data.records:read", "data.records:write"],
+    },
+    "asana": {
+        "authorize_url": "https://app.asana.com/-/oauth_authorize",
+        "token_url": "https://app.asana.com/-/oauth_token",
+        "revoke_url": "https://app.asana.com/-/oauth_revoke",
+        "userinfo_url": "https://app.asana.com/api/1.0/users/me",
+        "pkce_required": False,
+        "default_scopes": ["default"],
+    },
+    "monday": {
+        "authorize_url": "https://auth.monday.com/oauth2/authorize",
+        "token_url": "https://auth.monday.com/oauth2/token",
+        "pkce_required": False,
+        "default_scopes": [],
+    },
+    "figma": {
+        "authorize_url": "https://www.figma.com/oauth",
+        "token_url": "https://www.figma.com/api/oauth/token",
+        "revoke_url": "https://www.figma.com/api/oauth/revoke",
+        "userinfo_url": "https://api.figma.com/v1/me",
+        "pkce_required": False,
+        "default_scopes": ["files:read"],
+    },
+    "clickup": {
+        "authorize_url": "https://app.clickup.com/api",
+        "token_url": "https://api.clickup.com/api/v2/oauth/token",
+        "userinfo_url": "https://api.clickup.com/api/v2/user",
+        "pkce_required": False,
+        "default_scopes": [],
+    },
+    "todoist": {
+        "authorize_url": "https://todoist.com/oauth/authorize",
+        "token_url": "https://todoist.com/oauth/access_token",
+        "revoke_url": "https://todoist.com/oauth/revoke",
+        "pkce_required": False,
+        "default_scopes": ["data:read_write"],
+    },
+    "basecamp": {
+        "authorize_url": "https://launchpad.37signals.com/authorization/new",
+        "token_url": "https://launchpad.37signals.com/authorization/token",
+        "pkce_required": False,
+        "default_scopes": [],
+    },
+    "wrike": {
+        "authorize_url": "https://login.wrike.com/oauth2/authorize/v4",
+        "token_url": "https://login.wrike.com/oauth2/token",
+        "revoke_url": "https://login.wrike.com/oauth2/revoke_token/v4",
+        "pkce_required": False,
+        "default_scopes": [],
+    },
+    "miro": {
+        "authorize_url": "https://miro.com/oauth/authorize",
+        "token_url": "https://api.miro.com/v1/oauth/token",
+        "revoke_url": "https://api.miro.com/v1/oauth/token/revoke",
+        "pkce_required": True,
+        "default_scopes": ["boards:read", "boards:write"],
+    },
+    "smartsheet": {
+        "authorize_url": "https://app.smartsheet.com/b/authorize",
+        "token_url": "https://api.smartsheet.com/2.0/token",
+        "pkce_required": False,
+        "default_scopes": ["READ_SHEETS", "WRITE_SHEETS"],
+    },
+    # ---------------------------------------------------------------------- #
+    # DEVELOPER TOOLS                                                         #
+    # ---------------------------------------------------------------------- #
+    "vercel": {
+        "authorize_url": "https://vercel.com/oauth/authorize",
+        "token_url": "https://api.vercel.com/v2/oauth/access_token",
+        "pkce_required": False,
+        "default_scopes": [],
+    },
+    "netlify": {
+        "authorize_url": "https://app.netlify.com/authorize",
+        "token_url": "https://api.netlify.com/oauth/token",
+        "pkce_required": False,
+        "default_scopes": [],
+    },
+    "render": {
+        "authorize_url": "https://dashboard.render.com/oauth/authorize",
+        "token_url": "https://render.com/oauth/token",
+        "pkce_required": True,
+        "default_scopes": [],
+    },
+    # ---------------------------------------------------------------------- #
+    # COMMUNICATION                                                           #
+    # ---------------------------------------------------------------------- #
+    "slack": {
+        "authorize_url": "https://slack.com/oauth/v2/authorize",
+        "token_url": "https://slack.com/api/oauth.v2.access",
+        "revoke_url": "https://slack.com/api/auth.revoke",
+        "userinfo_url": "https://slack.com/api/users.identity",
+        "pkce_required": True,
+        "default_scopes": ["channels:read", "chat:write"],
+    },
+    "intercom": {
+        "authorize_url": "https://app.intercom.com/oauth",
+        "token_url": "https://api.intercom.io/auth/eagle/token",
+        "pkce_required": False,
+        "default_scopes": [],
+    },
+    # ---------------------------------------------------------------------- #
+    # CRM / SUPPORT                                                           #
+    # ---------------------------------------------------------------------- #
+    "hubspot": {
+        "authorize_url": "https://app.hubspot.com/oauth/authorize",
+        "token_url": "https://api.hubspot.com/oauth/v1/token",
+        "pkce_required": False,
+        "default_scopes": ["contacts", "crm.objects.contacts.read"],
+    },
+    "pipedrive": {
+        "authorize_url": "https://oauth.pipedrive.com/oauth/authorize",
+        "token_url": "https://oauth.pipedrive.com/oauth/token",
+        "pkce_required": False,
+        "default_scopes": [],
+    },
+    "zendesk": {
+        "_uses_builder": True,
+        "pkce_required": False,
+        "default_scopes": ["read", "write"],
+    },
+    "freshdesk": {
+        "_uses_builder": True,
+        "pkce_required": False,
+        "default_scopes": [],
+    },
+    # ---------------------------------------------------------------------- #
+    # FINANCE                                                                 #
+    # ---------------------------------------------------------------------- #
+    "stripe": {
+        "authorize_url": "https://connect.stripe.com/oauth/authorize",
+        "token_url": "https://connect.stripe.com/oauth/token",
+        "pkce_required": False,
+        "default_scopes": ["read_write"],
+    },
+    "quickbooks": {
+        "authorize_url": "https://appcenter.intuit.com/connect/oauth2",
+        "token_url": "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
+        "revoke_url": "https://developer.api.intuit.com/v2/oauth2/tokens/revoke",
+        "pkce_required": False,
+        "default_scopes": ["com.intuit.quickbooks.accounting"],
+    },
+    "xero": {
+        "authorize_url": "https://login.xero.com/identity/connect/authorize",
+        "token_url": "https://identity.xero.com/connect/token",
+        "revoke_url": "https://identity.xero.com/connect/revocation",
+        "oidc_discovery_url": "https://identity.xero.com",
+        "pkce_required": True,
+        "default_scopes": [
+            "openid",
+            "profile",
+            "email",
+            "accounting.transactions",
+        ],
+    },
+    "freshbooks": {
+        "authorize_url": "https://auth.freshbooks.com/oauth/authorize",
+        "token_url": "https://api.freshbooks.com/auth/oauth/token",
+        "revoke_url": "https://api.freshbooks.com/auth/oauth/revoke",
+        "pkce_required": False,
+        "default_scopes": [],
+    },
+    # ---------------------------------------------------------------------- #
+    # CALENDAR / SCHEDULING                                                   #
+    # ---------------------------------------------------------------------- #
+    "calendly": {
+        "authorize_url": "https://auth.calendly.com/oauth/authorize",
+        "token_url": "https://auth.calendly.com/oauth/token",
+        "revoke_url": "https://auth.calendly.com/oauth/revoke",
+        "userinfo_url": "https://api.calendly.com/users/me",
+        "pkce_required": False,
+        "default_scopes": [],
+    },
+    # ---------------------------------------------------------------------- #
+    # STORAGE / CLOUD                                                         #
+    # ---------------------------------------------------------------------- #
+    "dropbox": {
+        "authorize_url": "https://www.dropbox.com/oauth2/authorize",
+        "token_url": "https://api.dropboxapi.com/oauth2/token",
+        "revoke_url": "https://api.dropboxapi.com/2/auth/token/revoke",
+        "pkce_required": True,
+        "default_scopes": [],
+    },
+    "box": {
+        "authorize_url": "https://account.box.com/api/oauth2/authorize",
+        "token_url": "https://api.box.com/oauth2/token",
+        "revoke_url": "https://api.box.com/oauth2/revoke",
+        "pkce_required": False,
+        "default_scopes": ["root_readonly"],
+    },
+    # ---------------------------------------------------------------------- #
+    # SOCIAL / CONTENT                                                        #
+    # ---------------------------------------------------------------------- #
+    "instagram": {
+        "authorize_url": "https://api.instagram.com/oauth/authorize",
+        "token_url": "https://api.instagram.com/oauth/access_token",
+        "pkce_required": False,
+        "default_scopes": ["user_profile", "user_media"],
+    },
+    # ---------------------------------------------------------------------- #
+    # MARKETING / EMAIL                                                       #
+    # ---------------------------------------------------------------------- #
+    "mailchimp": {
+        "authorize_url": "https://login.mailchimp.com/oauth2/authorize",
+        "token_url": "https://login.mailchimp.com/oauth2/token",
+        "pkce_required": False,
+        "default_scopes": [],
+    },
+    "mailerlite": {
+        "authorize_url": "https://dashboard.mailerlite.com/oauth/authorize",
+        "token_url": "https://connect.mailerlite.com/oauth/token",
+        "pkce_required": True,
+        "default_scopes": [],
+    },
+    # ---------------------------------------------------------------------- #
+    # DEVELOPER PLATFORMS                                                     #
+    # ---------------------------------------------------------------------- #
+    "atlassian": {
+        "authorize_url": "https://auth.atlassian.com/authorize",
+        "token_url": "https://auth.atlassian.com/oauth/token",
+        "userinfo_url": "https://api.atlassian.com/me",
+        "pkce_required": True,
+        "default_scopes": [
+            "read:jira-work",
+            "write:jira-work",
+            "read:confluence-content.all",
+            "offline_access",
+        ],
+        "extra_authorize_params": {
+            "audience": "api.atlassian.com",
+            "prompt": "consent",
+        },
+    },
+    "linear": {
+        "authorize_url": "https://linear.app/oauth/authorize",
+        "token_url": "https://api.linear.app/oauth/token",
+        "revoke_url": "https://api.linear.app/oauth/revoke",
+        "userinfo_url": "https://api.linear.app/graphql",
+        "pkce_required": True,
+        "default_scopes": ["read", "write"],
+    },
+    # ---------------------------------------------------------------------- #
+    # E-COMMERCE                                                              #
+    # ---------------------------------------------------------------------- #
+    "shopify": {
+        "_uses_builder": True,
+        "pkce_required": True,
+        "default_scopes": ["read_products", "read_orders"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_creds(name: str) -> tuple[str, str] | None:
+    """Return (client_id, client_secret) for a provider, or None.
+
+    Resolution order:
+      1. CONNECT_{NAME}_CLIENT_ID / CONNECT_{NAME}_CLIENT_SECRET
+      2. Legacy / convenience env vars declared in _LEGACY_ENVS
+    """
+    prefix = f"CONNECT_{name.upper()}_"
+    cid = os.getenv(f"{prefix}CLIENT_ID")
+    csecret = os.getenv(f"{prefix}CLIENT_SECRET")
+    if cid and csecret:
+        return cid, csecret
+
+    legacy = _LEGACY_ENVS.get(name, ([], []))
+    for env in legacy[0]:
+        val = os.getenv(env)
+        if val:
+            cid = val
+            break
+    for env in legacy[1]:
+        val = os.getenv(env)
+        if val:
+            csecret = val
+            break
+
+    if cid and csecret:
+        return cid, csecret
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Provider loading
+# ---------------------------------------------------------------------------
+
+
+def _load_known_provider(name: str) -> OAuthProvider | None:
+    """Load a known provider by name using env vars.
+
+    Returns a configured OAuthProvider ready to register, or None when the
+    required credentials or dynamic URL variables are absent.
+    """
+    creds = _resolve_creds(name)
+    if creds is None:
+        return None
+
+    cid, csecret = creds
+    entry = _KNOWN.get(name)
+    if entry is None:
+        return None
+
+    cfg: dict[str, Any] = {k: v for k, v in entry.items() if not k.startswith("_")}
+
+    # Dynamic URL providers
+    uses_builder = entry.get("_uses_builder", False)
+    if uses_builder:
+        builder = _URL_BUILDERS.get(name)
+        if builder is None:
+            return None
+        urls = builder()
+        if urls is None:
+            return None
+        cfg.update(urls)
+
+    # Validate required URL fields are present
+    if not cfg.get("authorize_url") or not cfg.get("token_url"):
+        return None
+
+    # Per-provider env var overrides
+    prefix = f"CONNECT_{name.upper()}_"
+    for field, env_suffix in (
+        ("authorize_url", "AUTHORIZE_URL"),
+        ("token_url", "TOKEN_URL"),
+        ("revoke_url", "REVOKE_URL"),
+    ):
+        val = os.getenv(f"{prefix}{env_suffix}")
+        if val:
+            cfg[field] = val
+
+    # Scope override: CONNECT_{NAME}_SCOPES or {NAME}_SCOPES
+    for scope_env in (f"{prefix}SCOPES", f"{name.upper()}_SCOPES"):
+        raw = os.getenv(scope_env, "")
+        if raw:
+            cfg["default_scopes"] = [s.strip() for s in raw.split(",") if s.strip()]
+            break
+
+    # PKCE override
+    pkce_val = os.getenv(f"{prefix}PKCE")
+    if pkce_val is not None:
+        cfg["pkce_required"] = pkce_val.lower() in ("true", "1", "yes")
+
+    # LOGIN override: CONNECT_{NAME}_LOGIN=false disables login for this provider
+    login_val = os.getenv(f"{prefix}LOGIN")
+    if login_val is not None:
+        cfg["login_enabled"] = login_val.lower() in ("true", "1", "yes")
+
+    return OAuthProvider(name=name, client_id=cid, client_secret=csecret, **cfg)
+
+
+def load_all_connect_providers() -> list[OAuthProvider]:
+    """Load all configured OAuth providers.
+
+    Scans the entire _KNOWN catalog for credentials then processes any
+    additional providers listed in CONNECT_PROVIDERS.  CONNECT_PROVIDERS
+    entries override catalog entries when the same name appears in both.
+
+    This is the primary entry point — used by connect/providers/__init__.py
+    to initialise the global registry at startup.
+    """
+    providers: dict[str, OAuthProvider] = {}
+
+    # Step 1: scan all known providers
+    for name in _KNOWN:
+        provider = _load_known_provider(name)
+        if provider is not None:
+            providers[name] = provider
+
+    # Step 2: CONNECT_PROVIDERS list — can add unknown providers or override
+    for provider in _load_generic_providers():
+        providers[provider.name] = provider
+
+    return list(providers.values())
+
+
+def _load_generic_providers() -> list[OAuthProvider]:
+    """Load providers declared explicitly via CONNECT_PROVIDERS env var.
+
+    Known providers (in _KNOWN) are loaded via the full catalog loader.
+    Unknown providers require explicit URL configuration:
+      CONNECT_{NAME}_AUTHORIZE_URL=...
+      CONNECT_{NAME}_TOKEN_URL=...
+
+    Returns a list of OAuthProvider instances ready to register.
+    """
+    names_raw = os.getenv("CONNECT_PROVIDERS", "").strip()
+    if not names_raw:
+        return []
+
+    result: list[OAuthProvider] = []
+    for raw in names_raw.split(","):
+        name = raw.strip().lower()
+        if not name:
+            continue
+
+        # Known provider: use full catalog loading (inherits metadata + login fields)
+        if name in _KNOWN:
+            provider = _load_known_provider(name)
+            if provider is not None:
+                result.append(provider)
+            continue
+
+        # Unknown provider: require explicit URL config
+        prefix = f"CONNECT_{name.upper()}_"
+        client_id = os.getenv(f"{prefix}CLIENT_ID")
+        client_secret = os.getenv(f"{prefix}CLIENT_SECRET")
+        if not client_id or not client_secret:
+            continue
+
+        authorize_url = os.getenv(f"{prefix}AUTHORIZE_URL")
+        token_url = os.getenv(f"{prefix}TOKEN_URL")
+        if not authorize_url or not token_url:
+            continue
+
+        revoke_url = os.getenv(f"{prefix}REVOKE_URL")
+        scopes_raw = os.getenv(f"{prefix}SCOPES", "")
+        scopes = [s.strip() for s in scopes_raw.split(",") if s.strip()]
+        pkce_raw = os.getenv(f"{prefix}PKCE", "true")
+        pkce_required = pkce_raw.lower() in ("true", "1", "yes")
+
+        result.append(
+            OAuthProvider(
+                name=name,
+                client_id=client_id,
+                client_secret=client_secret,
+                authorize_url=authorize_url,
+                token_url=token_url,
+                revoke_url=revoke_url,
+                default_scopes=scopes,
+                pkce_required=pkce_required,
+            )
+        )
+
+    return result

--- a/src/svc_infra/connect/providers/generic.py
+++ b/src/svc_infra/connect/providers/generic.py
@@ -58,6 +58,8 @@ import os
 from collections.abc import Callable
 from typing import Any
 
+from pydantic import SecretStr
+
 from svc_infra.connect.registry import OAuthProvider
 
 # ---------------------------------------------------------------------------
@@ -801,7 +803,7 @@ def _load_known_provider(name: str) -> OAuthProvider | None:
     if login_val is not None:
         cfg["login_enabled"] = login_val.lower() in ("true", "1", "yes")
 
-    return OAuthProvider(name=name, client_id=cid, client_secret=csecret, **cfg)
+    return OAuthProvider(name=name, client_id=cid, client_secret=SecretStr(csecret), **cfg)
 
 
 def load_all_connect_providers() -> list[OAuthProvider]:
@@ -878,7 +880,7 @@ def _load_generic_providers() -> list[OAuthProvider]:
             OAuthProvider(
                 name=name,
                 client_id=client_id,
-                client_secret=client_secret,
+                client_secret=SecretStr(client_secret),
                 authorize_url=authorize_url,
                 token_url=token_url,
                 revoke_url=revoke_url,

--- a/src/svc_infra/connect/providers/github.py
+++ b/src/svc_infra/connect/providers/github.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from svc_infra.connect.registry import OAuthProvider
+
+
+def build_github_provider() -> OAuthProvider | None:
+    """Build GitHub OAuth provider from environment variables.
+
+    Delegates to the master catalog in generic.py.
+    Env vars: GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET (or CONNECT_GITHUB_*)
+    """
+    from svc_infra.connect.providers.generic import _load_known_provider
+
+    return _load_known_provider("github")

--- a/src/svc_infra/connect/providers/google.py
+++ b/src/svc_infra/connect/providers/google.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from svc_infra.connect.registry import OAuthProvider
+
+
+def build_google_provider() -> OAuthProvider | None:
+    """Build Google OAuth provider from environment variables.
+
+    Delegates to the master catalog in generic.py.
+    Env vars: GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET (or CONNECT_GOOGLE_* or GOOGLE_CONNECT_*)
+    """
+    from svc_infra.connect.providers.generic import _load_known_provider
+
+    return _load_known_provider("google")

--- a/src/svc_infra/connect/providers/linear.py
+++ b/src/svc_infra/connect/providers/linear.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from svc_infra.connect.registry import OAuthProvider
+
+
+def build_linear_provider() -> OAuthProvider | None:
+    """Build Linear OAuth 2.0 provider from environment variables.
+
+    Delegates to the master catalog in generic.py.
+    Env vars: LINEAR_CLIENT_ID / LINEAR_CLIENT_SECRET (or CONNECT_LINEAR_*)
+    """
+    from svc_infra.connect.providers.generic import _load_known_provider
+
+    return _load_known_provider("linear")

--- a/src/svc_infra/connect/providers/microsoft.py
+++ b/src/svc_infra/connect/providers/microsoft.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from svc_infra.connect.registry import OAuthProvider
+
+
+def build_microsoft_provider() -> OAuthProvider | None:
+    """Build Microsoft OAuth provider from environment variables.
+
+    Delegates to the master catalog in generic.py.
+    Env vars: MICROSOFT_CLIENT_ID / MICROSOFT_CLIENT_SECRET (or CONNECT_MICROSOFT_*)
+    Optional: CONNECT_MICROSOFT_TENANT_ID or MICROSOFT_TENANT_ID (default: common)
+    """
+    from svc_infra.connect.providers.generic import _load_known_provider
+
+    return _load_known_provider("microsoft")

--- a/src/svc_infra/connect/providers/notion.py
+++ b/src/svc_infra/connect/providers/notion.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from svc_infra.connect.registry import OAuthProvider
+
+
+def build_notion_provider() -> OAuthProvider | None:
+    """Build Notion OAuth provider from environment variables.
+
+    Delegates to the master catalog in generic.py.
+    Env vars: NOTION_CLIENT_ID / NOTION_CLIENT_SECRET (or CONNECT_NOTION_*)
+    """
+    from svc_infra.connect.providers.generic import _load_known_provider
+
+    return _load_known_provider("notion")

--- a/src/svc_infra/connect/providers/slack.py
+++ b/src/svc_infra/connect/providers/slack.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from svc_infra.connect.registry import OAuthProvider
+
+
+def build_slack_provider() -> OAuthProvider | None:
+    """Build Slack OAuth v2 provider from environment variables.
+
+    Delegates to the master catalog in generic.py.
+    Env vars: SLACK_CLIENT_ID / SLACK_CLIENT_SECRET (or CONNECT_SLACK_*)
+    """
+    from svc_infra.connect.providers.generic import _load_known_provider
+
+    return _load_known_provider("slack")

--- a/src/svc_infra/connect/registry.py
+++ b/src/svc_infra/connect/registry.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, SecretStr
+
+
+class OAuthProvider(BaseModel):
+    """Configuration for a third-party OAuth provider.
+
+    This is the single source of truth for OAuth provider definitions.  It
+    powers both svc_infra.connect (workspace tool connections that store tokens
+    in the DB) and svc_infra.auth (user login that issues JWT sessions).
+
+    client_secret is SecretStr and is never logged or serialized in API
+    responses.
+    """
+
+    name: str
+    client_id: str
+    client_secret: SecretStr
+    authorize_url: str
+    token_url: str
+    revoke_url: str | None = None
+    default_scopes: list[str] = []
+    pkce_required: bool = True
+    extra_authorize_params: dict[str, str] = {}
+    extra_token_params: dict[str, str] = {}
+    token_placement: Literal["header", "query"] = "header"
+    userinfo_url: str | None = None
+
+    # --- Identity / login fields ---
+    # login_enabled=True means this provider can authenticate users; the auth
+    # module will include it in the social login registry automatically.
+    login_enabled: bool = False
+    # OIDC discovery issuer URL (e.g. "https://accounts.google.com").  When set
+    # the auth module appends "/.well-known/openid-configuration" to fetch
+    # provider metadata and negotiate the login flow via authlib's OIDC client.
+    oidc_discovery_url: str | None = None
+    # Governs how the auth module extracts the user's identity after the OAuth
+    # code exchange.  "oidc" uses the id_token/userinfo endpoint, "github" and
+    # "linkedin" require provider-specific API calls, "standard" fetches
+    # userinfo_url with a plain bearer token.
+    userinfo_kind: Literal["oidc", "github", "linkedin", "standard"] = "standard"
+
+
+class ConnectRegistry:
+    """Module-level registry for OAuth providers.
+
+    Providers are registered at startup. Built-in providers are loaded from the
+    providers/ subpackage when their required env vars are present.
+    """
+
+    def __init__(self) -> None:
+        self._providers: dict[str, OAuthProvider] = {}
+
+    def register(self, provider: OAuthProvider) -> None:
+        """Register a provider by name, replacing any existing registration."""
+        self._providers[provider.name] = provider
+
+    def get(self, name: str) -> OAuthProvider | None:
+        """Return provider by name, or None if not registered."""
+        return self._providers.get(name)
+
+    def list(self) -> list[OAuthProvider]:
+        """Return all registered providers."""
+        return list(self._providers.values())
+
+
+registry = ConnectRegistry()

--- a/src/svc_infra/connect/router.py
+++ b/src/svc_infra/connect/router.py
@@ -66,9 +66,10 @@ async def authorize(
         except MCPOAuthNotSupported as exc:
             raise HTTPException(422, f"MCP OAuth not supported by this server: {exc}") from exc
     else:
-        resolved_provider = _default_registry.get(provider)  # type: ignore[arg-type]
-        if resolved_provider is None:
+        _rp = _default_registry.get(provider)  # type: ignore[arg-type]
+        if _rp is None:
             raise HTTPException(404, f"Provider '{provider}' not registered")
+        resolved_provider = _rp
 
     pkce_verifier, pkce_challenge = generate_pkce_pair()
     state_value = generate_state()
@@ -167,6 +168,7 @@ async def callback(
 
     connection_id = oauth_state.connection_id
     user_id = oauth_state.user_id
+    assert connection_id is not None
 
     await db.delete(oauth_state)
     await token_manager.store(

--- a/src/svc_infra/connect/router.py
+++ b/src/svc_infra/connect/router.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import RedirectResponse
+
+from svc_infra.api.fastapi.auth.security import Identity
+from svc_infra.api.fastapi.db.sql.session import SqlSessionDep
+from svc_infra.connect.mcp_discovery import MCPOAuthDiscovery, MCPOAuthNotSupported
+from svc_infra.connect.models import OAuthState
+from svc_infra.connect.pkce import (
+    OAuthExchangeError,
+    build_authorize_url,
+    exchange_code,
+    generate_pkce_pair,
+    generate_state,
+    validate_redirect,
+)
+from svc_infra.connect.registry import registry as _default_registry
+from svc_infra.connect.state import get_connect_settings, get_connect_token_manager
+
+logger = logging.getLogger(__name__)
+_mcp_discovery = MCPOAuthDiscovery()
+
+connect_router = APIRouter(tags=["connect"])
+
+
+@connect_router.get("/authorize")
+async def authorize(
+    request: Request,
+    db: SqlSessionDep,
+    principal: Identity,
+    connection_id: UUID = Query(..., description="Connection ID to associate with the token"),
+    provider: str | None = Query(None, description="Static provider name (e.g. github)"),
+    mcp_server_url: str | None = Query(None, description="MCP server URL for dynamic discovery"),
+    redirect_uri: str | None = Query(None, description="URI to redirect to after OAuth completes"),
+    scopes: str | None = Query(None, description="Space-separated scope override"),
+) -> dict:
+    """Initiate an OAuth authorization flow.
+
+    Returns {"authorize_url": "..."} — the client opens this URL. The server
+    does not redirect directly to avoid CORS issues with API-first applications.
+    """
+    settings = get_connect_settings()
+
+    if provider is None and mcp_server_url is None:
+        raise HTTPException(400, "Either 'provider' or 'mcp_server_url' is required")
+
+    effective_redirect = redirect_uri or settings.connect_default_redirect_uri
+    if effective_redirect:
+        require_https = not effective_redirect.startswith(("pulse-app://", "http://localhost"))
+        validate_redirect(
+            effective_redirect,
+            settings.allowed_hosts(),
+            require_https=require_https,
+        )
+
+    if mcp_server_url is not None:
+        try:
+            resolved_provider = await _mcp_discovery.discover(mcp_server_url)
+            _default_registry.register(resolved_provider)
+            provider = resolved_provider.name
+        except MCPOAuthNotSupported as exc:
+            raise HTTPException(422, f"MCP OAuth not supported by this server: {exc}") from exc
+    else:
+        resolved_provider = _default_registry.get(provider)  # type: ignore[arg-type]
+        if resolved_provider is None:
+            raise HTTPException(404, f"Provider '{provider}' not registered")
+
+    pkce_verifier, pkce_challenge = generate_pkce_pair()
+    state_value = generate_state()
+    expires_at = datetime.now(UTC) + timedelta(seconds=settings.connect_state_ttl_seconds)
+
+    oauth_state = OAuthState(
+        state=state_value,
+        pkce_verifier=pkce_verifier,
+        provider=provider,
+        connection_id=connection_id,
+        user_id=principal.user.id,
+        redirect_uri=effective_redirect,
+        expires_at=expires_at,
+    )
+    db.add(oauth_state)
+    await db.flush()
+
+    scope_list = scopes.split() if scopes else None
+    return {
+        "authorize_url": build_authorize_url(
+            resolved_provider,
+            state=state_value,
+            pkce_challenge=pkce_challenge,
+            redirect_uri=f"{settings.connect_api_base}/connect/callback/{provider}",
+            scopes=scope_list,
+        )
+    }
+
+
+@connect_router.get("/callback/{provider}")
+async def callback(
+    provider: str,
+    db: SqlSessionDep,
+    code: str = Query(...),
+    state: str = Query(...),
+    error: str | None = Query(None),
+    error_description: str | None = Query(None),
+) -> RedirectResponse:
+    """OAuth callback endpoint. Public — identity is carried via the state param.
+
+    Validates state, exchanges code, stores token, then redirects to redirect_uri.
+    """
+    settings = get_connect_settings()
+    token_manager = get_connect_token_manager()
+
+    from sqlalchemy import and_, select
+
+    result = await db.execute(
+        select(OAuthState).where(
+            and_(
+                OAuthState.state == state,
+                OAuthState.provider == provider,
+                OAuthState.expires_at > datetime.now(UTC),
+            )
+        )
+    )
+    oauth_state = result.scalars().first()
+
+    if oauth_state is None:
+        logger.warning("OAuth callback: no valid state found for provider=%s", provider)
+        return RedirectResponse(
+            url=f"{settings.connect_default_redirect_uri}?error=invalid_state",
+            status_code=302,
+        )
+
+    fallback_redirect = oauth_state.redirect_uri or settings.connect_default_redirect_uri
+
+    if error:
+        logger.warning("OAuth callback error from provider=%s: %s", provider, error)
+        await db.delete(oauth_state)
+        await db.flush()
+        return RedirectResponse(url=f"{fallback_redirect}?error={error}", status_code=302)
+
+    resolved_provider = _default_registry.get(provider)
+    if resolved_provider is None:
+        logger.error("OAuth callback: provider '%s' not in registry", provider)
+        await db.delete(oauth_state)
+        await db.flush()
+        return RedirectResponse(
+            url=f"{fallback_redirect}?error=provider_not_found",
+            status_code=302,
+        )
+
+    try:
+        token_response = await exchange_code(
+            resolved_provider,
+            code=code,
+            pkce_verifier=oauth_state.pkce_verifier,
+            redirect_uri=f"{settings.connect_api_base}/connect/callback/{provider}",
+        )
+    except OAuthExchangeError as exc:
+        logger.error("OAuth code exchange failed for provider=%s: %s", provider, exc)
+        await db.delete(oauth_state)
+        await db.flush()
+        return RedirectResponse(url=f"{fallback_redirect}?error=exchange_failed", status_code=302)
+
+    connection_id = oauth_state.connection_id
+    user_id = oauth_state.user_id
+
+    await db.delete(oauth_state)
+    await token_manager.store(
+        db,
+        user_id=user_id,
+        connection_id=connection_id,
+        provider=provider,
+        token_response=token_response,
+    )
+    await db.flush()
+
+    return RedirectResponse(
+        url=f"{fallback_redirect}?success=true&connection_id={connection_id}",
+        status_code=302,
+    )
+
+
+@connect_router.get("/token/{connection_id}")
+async def get_token(
+    connection_id: UUID,
+    db: SqlSessionDep,
+    principal: Identity,
+    provider: str = Query(..., description="Provider name"),
+) -> dict:
+    """Return a valid access token for the given connection.
+
+    Returns 404 if no token is stored; 502 if refresh fails.
+    """
+    token_manager = get_connect_token_manager()
+    token = await token_manager.get_valid_token(
+        db,
+        connection_id=connection_id,
+        user_id=principal.user.id,
+        provider=provider,
+    )
+
+    if token is None:
+        row = await token_manager.get(
+            db,
+            connection_id=connection_id,
+            user_id=principal.user.id,
+            provider=provider,
+        )
+        if row is None:
+            raise HTTPException(404, "No token stored for this connection")
+        raise HTTPException(502, "Token refresh failed")
+
+    row = await token_manager.get(
+        db,
+        connection_id=connection_id,
+        user_id=principal.user.id,
+        provider=provider,
+    )
+    expires_at_str = row.expires_at.isoformat() if row and row.expires_at else None
+    return {"token": token, "expires_at": expires_at_str}

--- a/src/svc_infra/connect/settings.py
+++ b/src/svc_infra/connect/settings.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class ConnectSettings(BaseSettings):
+    """Configuration for svc_infra.connect. All fields read from environment variables.
+
+    Follows the same BaseSettings pattern as AuthSettings and EmailSettings.
+    connect_token_encryption_key is SecretStr and is never logged or serialized.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    connect_token_encryption_key: SecretStr
+    """Fernet symmetric key used to encrypt tokens at rest.
+    Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+    """
+
+    connect_api_base: str = ""
+    """Base URL of the API (e.g. https://api.example.com). Used to build callback URLs."""
+
+    connect_default_redirect_uri: str = ""
+    """Fallback redirect URI when OAuthState.redirect_uri is empty.
+    Supports custom URL schemes for native apps (e.g. pulse-app://oauth/callback).
+    """
+
+    connect_state_ttl_seconds: int = 600
+    """TTL for OAuthState rows in seconds. Default: 10 minutes."""
+
+    connect_redirect_allow_hosts: str = ""
+    """Comma-separated list of allowed redirect hosts.
+    Validated via validate_redirect() from connect/pkce.py.
+    Example: api.example.com,app.example.com
+    """
+
+    def allowed_hosts(self) -> list[str]:
+        """Parse connect_redirect_allow_hosts into a list of host strings."""
+        return [h.strip() for h in self.connect_redirect_allow_hosts.split(",") if h.strip()]

--- a/src/svc_infra/connect/state.py
+++ b/src/svc_infra/connect/state.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from svc_infra.connect.settings import ConnectSettings
+from svc_infra.connect.token_manager import ConnectionTokenManager
+
+_settings: ConnectSettings | None = None
+_token_manager: ConnectionTokenManager | None = None
+
+
+def set_connect_state(
+    settings: ConnectSettings,
+    token_manager: ConnectionTokenManager,
+) -> None:
+    global _settings, _token_manager
+    _settings = settings
+    _token_manager = token_manager
+
+
+def get_connect_settings() -> ConnectSettings:
+    if _settings is None:
+        raise RuntimeError(
+            "Connect module not initialised. Call add_connect(app) before starting the server."
+        )
+    return _settings
+
+
+def get_connect_token_manager() -> ConnectionTokenManager:
+    if _token_manager is None:
+        raise RuntimeError(
+            "Connect module not initialised. Call add_connect(app) before starting the server."
+        )
+    return _token_manager

--- a/src/svc_infra/connect/token_manager.py
+++ b/src/svc_infra/connect/token_manager.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+import httpx
+from cryptography.fernet import Fernet, InvalidToken
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from svc_infra.connect.models import ConnectionToken
+from svc_infra.connect.pkce import OAuthRefreshError, coerce_expires_at, exchange_refresh
+from svc_infra.connect.registry import ConnectRegistry
+from svc_infra.db.sql.repository import SqlRepository
+
+logger = logging.getLogger(__name__)
+
+_REFRESH_AHEAD_SECONDS = 300  # 5 minutes
+
+
+class ConnectionTokenManager:
+    """Store, retrieve, and background-refresh OAuth tokens for connections.
+
+    Wraps SqlRepository(model=ConnectionToken) for all DB access.
+    access_token, refresh_token, and raw_token are Fernet-encrypted at rest.
+    """
+
+    def __init__(self, encryption_key: str, registry: ConnectRegistry | None = None) -> None:
+        key_bytes = encryption_key.encode() if isinstance(encryption_key, str) else encryption_key
+        self._fernet = Fernet(key_bytes)
+        self._repo = SqlRepository(model=ConnectionToken)
+        self._registry = registry
+
+    # ------------------------------------------------------------------
+    # Encryption helpers
+    # ------------------------------------------------------------------
+
+    def _encrypt(self, value: str) -> str:
+        return self._fernet.encrypt(value.encode()).decode()
+
+    def _decrypt(self, value: str) -> str:
+        return self._fernet.decrypt(value.encode()).decode()
+
+    def _encrypt_json(self, value: dict[str, Any]) -> str:
+        return self._encrypt(json.dumps(value))
+
+    def _decrypt_json(self, value: str) -> dict[str, Any]:
+        return json.loads(self._decrypt(value))
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def store(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        connection_id: UUID,
+        provider: str,
+        token_response: dict[str, Any],
+    ) -> ConnectionToken:
+        """Upsert a ConnectionToken row for the given (connection_id, user_id, provider).
+
+        access_token, refresh_token, and raw_token are Fernet-encrypted before writing.
+        expires_at is normalised via coerce_expires_at().
+        """
+        access_token_raw = token_response.get("access_token", "")
+        refresh_token_raw = token_response.get("refresh_token")
+        token_type = token_response.get("token_type", "Bearer")
+        scopes_raw = token_response.get("scope", "")
+        scopes: list[str] = (
+            [s.strip() for s in scopes_raw.split() if s.strip()]
+            if isinstance(scopes_raw, str)
+            else (scopes_raw or [])
+        )
+        expires_at = coerce_expires_at(token_response)
+
+        data: dict[str, Any] = {
+            "connection_id": connection_id,
+            "user_id": user_id,
+            "provider": provider,
+            "access_token": self._encrypt(access_token_raw),
+            "refresh_token": self._encrypt(refresh_token_raw) if refresh_token_raw else None,
+            "token_type": token_type,
+            "expires_at": expires_at,
+            "scopes": scopes,
+            "raw_token": self._encrypt_json(token_response),
+        }
+
+        existing = await self.get(
+            db, connection_id=connection_id, user_id=user_id, provider=provider
+        )
+        if existing is not None:
+            update_data = {
+                k: v for k, v in data.items() if k not in {"connection_id", "user_id", "provider"}
+            }
+            updated = await self._repo.update(db, existing.id, update_data)
+            return updated  # type: ignore[return-value]
+
+        return await self._repo.create(db, data)  # type: ignore[return-value]
+
+    async def get(
+        self,
+        db: AsyncSession,
+        *,
+        connection_id: UUID,
+        user_id: UUID,
+        provider: str,
+    ) -> ConnectionToken | None:
+        """Retrieve a ConnectionToken by (connection_id, user_id, provider)."""
+        stmt = select(ConnectionToken).where(
+            and_(
+                ConnectionToken.connection_id == connection_id,
+                ConnectionToken.user_id == user_id,
+                ConnectionToken.provider == provider,
+            )
+        )
+        result = await db.execute(stmt)
+        return result.scalars().first()
+
+    async def get_valid_token(
+        self,
+        db: AsyncSession,
+        *,
+        connection_id: UUID,
+        user_id: UUID,
+        provider: str,
+    ) -> str | None:
+        """Return a decrypted, valid access token; auto-refresh if within 5 minutes of expiry.
+
+        Returns None if no token is stored or refresh fails. Never raises.
+        """
+        try:
+            row = await self.get(
+                db, connection_id=connection_id, user_id=user_id, provider=provider
+            )
+            if row is None:
+                return None
+
+            now = datetime.now(UTC)
+            expires_at = row.expires_at
+            if expires_at is not None and expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=UTC)
+            needs_refresh = expires_at is not None and expires_at <= now + timedelta(
+                seconds=_REFRESH_AHEAD_SECONDS
+            )
+
+            if needs_refresh and row.refresh_token:
+                row = await self._refresh_token(db, row)
+
+            if row is None:
+                return None
+
+            return self._decrypt(row.access_token)
+        except (InvalidToken, Exception) as exc:
+            logger.warning(
+                "get_valid_token failed for connection_id=%s provider=%s: %s",
+                connection_id,
+                provider,
+                exc,
+            )
+            return None
+
+    async def revoke(
+        self,
+        db: AsyncSession,
+        *,
+        connection_id: UUID,
+        user_id: UUID,
+        provider: str,
+    ) -> None:
+        """Revoke the token at the provider (if revoke_url configured) and delete the DB row."""
+        row = await self.get(db, connection_id=connection_id, user_id=user_id, provider=provider)
+        if row is None:
+            return
+
+        if self._registry is not None:
+            prov = self._registry.get(provider)
+            if prov and prov.revoke_url:
+                try:
+                    access_token = self._decrypt(row.access_token)
+                    async with httpx.AsyncClient(timeout=10.0) as client:
+                        await client.post(
+                            prov.revoke_url,
+                            data={"token": access_token, "client_id": prov.client_id},
+                        )
+                except Exception as exc:
+                    logger.warning("Token revocation request failed: %s", exc)
+
+        await self._repo.delete(db, row.id)
+
+    async def delete_all_for_connection(
+        self,
+        db: AsyncSession,
+        connection_id: UUID,
+    ) -> None:
+        """Delete all ConnectionToken rows for a connection (used when connection is deleted)."""
+        from sqlalchemy import delete
+
+        stmt = delete(ConnectionToken).where(ConnectionToken.connection_id == connection_id)
+        await db.execute(stmt)
+        await db.flush()
+
+    async def refresh_expiring_tokens(self, db: AsyncSession) -> int:
+        """Refresh all tokens expiring within the next 10 minutes.
+
+        Registered as a periodic InMemoryScheduler job via easy_jobs().
+        Returns the count of successfully refreshed tokens.
+        """
+        cutoff = datetime.now(UTC) + timedelta(minutes=10)
+        stmt = select(ConnectionToken).where(
+            and_(
+                ConnectionToken.expires_at.is_not(None),
+                ConnectionToken.expires_at <= cutoff,
+                ConnectionToken.refresh_token.is_not(None),
+            )
+        )
+        result = await db.execute(stmt)
+        rows = result.scalars().all()
+
+        refreshed = 0
+        for row in rows:
+            try:
+                await self._refresh_token(db, row)
+                refreshed += 1
+            except Exception as exc:
+                logger.warning(
+                    "Background refresh failed for token id=%s provider=%s: %s",
+                    row.id,
+                    row.provider,
+                    exc,
+                )
+        return refreshed
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _refresh_token(
+        self,
+        db: AsyncSession,
+        row: ConnectionToken,
+    ) -> ConnectionToken | None:
+        if self._registry is None:
+            logger.warning("Cannot refresh token: no registry attached to ConnectionTokenManager")
+            return row
+
+        prov = self._registry.get(row.provider)
+        if prov is None:
+            logger.warning("Cannot refresh token: provider %s not in registry", row.provider)
+            return row
+
+        if not row.refresh_token:
+            return row
+
+        try:
+            refresh_token_plain = self._decrypt(row.refresh_token)
+            new_token = await exchange_refresh(prov, refresh_token_plain)
+            return await self.store(
+                db,
+                user_id=row.user_id,
+                connection_id=row.connection_id,
+                provider=row.provider,
+                token_response=new_token,
+            )
+        except OAuthRefreshError as exc:
+            logger.warning(
+                "Token refresh failed for id=%s provider=%s: %s",
+                row.id,
+                row.provider,
+                exc,
+            )
+            return None

--- a/src/svc_infra/connect/token_manager.py
+++ b/src/svc_infra/connect/token_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 import httpx
@@ -48,7 +48,7 @@ class ConnectionTokenManager:
         return self._encrypt(json.dumps(value))
 
     def _decrypt_json(self, value: str) -> dict[str, Any]:
-        return json.loads(self._decrypt(value))
+        return cast(dict[str, Any], json.loads(self._decrypt(value)))
 
     # ------------------------------------------------------------------
     # Public API
@@ -101,7 +101,7 @@ class ConnectionTokenManager:
             updated = await self._repo.update(db, existing.id, update_data)
             return updated  # type: ignore[return-value]
 
-        return await self._repo.create(db, data)  # type: ignore[return-value]
+        return await self._repo.create(db, data)  # type: ignore[return-value, no-any-return]
 
     async def get(
         self,

--- a/tests/integration/connect/test_oauth_flow.py
+++ b/tests/integration/connect/test_oauth_flow.py
@@ -1,0 +1,241 @@
+"""Integration tests for svc_infra.connect OAuth flow.
+
+These tests verify the full authorize → callback → token retrieval cycle.
+The OAuth provider HTTP calls are mocked; all other logic runs against real
+in-memory SQLite via aiosqlite so model/schema correctness is validated end-to-end.
+
+Run with: pytest tests/integration/connect/ -v -m integration
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import Column, Table
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from svc_infra.connect.models import ConnectionToken, OAuthState
+from svc_infra.connect.registry import ConnectRegistry, OAuthProvider
+from svc_infra.connect.settings import ConnectSettings
+from svc_infra.connect.state import set_connect_state
+from svc_infra.connect.token_manager import ConnectionTokenManager
+from svc_infra.db.sql.base import ModelBase
+from svc_infra.db.sql.types import GUID
+
+# auth_sessions (and connect models) have FK → users.id; svc-infra itself does not
+# define a users model (that belongs to the app). Registering a minimal stub here
+# ensures ModelBase.metadata.create_all can resolve the FK reference in SQLite.
+if "users" not in ModelBase.metadata.tables:
+    Table("users", ModelBase.metadata, Column("id", GUID(), primary_key=True))
+
+_KEY = Fernet.generate_key().decode()
+_USER_ID = uuid4()
+_CONN_ID = uuid4()
+
+
+def _make_provider() -> OAuthProvider:
+    return OAuthProvider(
+        name="github",
+        client_id="cid",
+        client_secret="csecret",
+        authorize_url="https://github.com/login/oauth/authorize",
+        token_url="https://github.com/login/oauth/access_token",
+        default_scopes=["repo"],
+    )
+
+
+@pytest_asyncio.fixture
+async def engine():
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with eng.begin() as conn:
+        await conn.run_sync(ModelBase.metadata.create_all)
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture
+async def integration_app(mocker, session_factory):
+    from svc_infra.api.fastapi.auth.security import _current_principal
+    from svc_infra.api.fastapi.db.sql.session import get_session
+    from svc_infra.connect.router import connect_router
+
+    app = FastAPI()
+
+    mock_user = mocker.Mock()
+    mock_user.id = _USER_ID
+    mock_principal = mocker.Mock()
+    mock_principal.user = mock_user
+
+    async def _mock_principal():
+        return mock_principal
+
+    app.dependency_overrides[_current_principal] = _mock_principal
+
+    async def _get_db():
+        async with session_factory() as db:
+            yield db
+            await db.commit()
+
+    app.dependency_overrides[get_session] = _get_db
+
+    reg = ConnectRegistry()
+    reg.register(_make_provider())
+
+    settings = ConnectSettings(
+        connect_token_encryption_key=_KEY,
+        connect_api_base="http://testserver",
+        connect_default_redirect_uri="https://app.example.com/done",
+        connect_state_ttl_seconds=600,
+        connect_redirect_allow_hosts="app.example.com",
+    )
+    token_manager = ConnectionTokenManager(_KEY, registry=reg)
+    set_connect_state(settings, token_manager)
+
+    with patch("svc_infra.connect.router._default_registry", reg):
+        app.include_router(connect_router, prefix="/connect")
+        yield app, session_factory, token_manager, reg
+
+
+@pytest_asyncio.fixture
+async def integration_client(integration_app):
+    app, session_factory, token_manager, reg = integration_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        yield client, session_factory, token_manager, reg
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestFullOAuthFlow:
+    async def test_authorize_returns_url(self, integration_client):
+        client, _, _, _ = integration_client
+        resp = await client.get(
+            "/connect/authorize",
+            params={"provider": "github", "connection_id": str(_CONN_ID)},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "authorize_url" in body
+        assert "github.com" in body["authorize_url"]
+
+    async def test_authorize_persists_oauth_state(self, integration_client):
+        """OAuthState row is written to the DB after /authorize is called."""
+        client, session_factory, _, _ = integration_client
+        await client.get(
+            "/connect/authorize",
+            params={"provider": "github", "connection_id": str(_CONN_ID)},
+        )
+
+        async with session_factory() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(select(OAuthState).where(OAuthState.provider == "github"))
+            rows = result.scalars().all()
+
+        assert len(rows) >= 1
+
+    async def test_full_callback_stores_token(self, integration_client):
+        """Full authorize → callback cycle results in a ConnectionToken row."""
+        client, session_factory, token_manager, _ = integration_client
+
+        # Initiate authorize to create an OAuthState row
+        resp = await client.get(
+            "/connect/authorize",
+            params={"provider": "github", "connection_id": str(_CONN_ID)},
+        )
+        assert resp.status_code == 200
+
+        # Fetch the state value from the DB
+        async with session_factory() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(
+                select(OAuthState)
+                .where(OAuthState.provider == "github")
+                .order_by(OAuthState.created_at.desc())
+            )
+            oauth_state = result.scalars().first()
+        assert oauth_state is not None
+
+        # Simulate callback from GitHub
+        token_resp = {"access_token": "gh_tok_abc123", "token_type": "Bearer", "scope": "repo"}
+        with patch(
+            "svc_infra.connect.router.exchange_code",
+            new_callable=AsyncMock,
+            return_value=token_resp,
+        ):
+            cb_resp = await client.get(
+                "/connect/callback/github",
+                params={"code": "auth_code", "state": oauth_state.state},
+                follow_redirects=False,
+            )
+
+        assert cb_resp.status_code == 302
+        assert "success=true" in cb_resp.headers["location"]
+
+        # Verify the token was persisted and encrypted
+        async with session_factory() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(
+                select(ConnectionToken).where(ConnectionToken.connection_id == _CONN_ID)
+            )
+            token_row = result.scalars().first()
+
+        assert token_row is not None
+        assert token_row.access_token != "gh_tok_abc123"  # Must be encrypted
+        assert token_manager._decrypt(token_row.access_token) == "gh_tok_abc123"
+
+    async def test_token_endpoint_after_full_flow(self, integration_client):
+        """After full flow, /token/{connection_id} returns the access token."""
+        client, session_factory, token_manager, _ = integration_client
+
+        await client.get(
+            "/connect/authorize",
+            params={"provider": "github", "connection_id": str(_CONN_ID)},
+        )
+
+        async with session_factory() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(
+                select(OAuthState)
+                .where(OAuthState.provider == "github")
+                .order_by(OAuthState.created_at.desc())
+            )
+            oauth_state = result.scalars().first()
+
+        token_resp = {
+            "access_token": "final_token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+        with patch(
+            "svc_infra.connect.router.exchange_code",
+            new_callable=AsyncMock,
+            return_value=token_resp,
+        ):
+            await client.get(
+                "/connect/callback/github",
+                params={"code": "auth_code", "state": oauth_state.state},
+                follow_redirects=False,
+            )
+
+        resp = await client.get(
+            f"/connect/token/{_CONN_ID}",
+            params={"provider": "github"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["token"] == "final_token"

--- a/tests/unit/auth/routers/test_oauth_helpers.py
+++ b/tests/unit/auth/routers/test_oauth_helpers.py
@@ -13,6 +13,7 @@ from svc_infra.api.fastapi.auth.routers.oauth_router import (
     _extract_user_info_github,
     _extract_user_info_linkedin,
     _extract_user_info_oidc,
+    _extract_user_info_standard,
     _find_or_create_user,
     _find_user_by_provider_link,
     _handle_mfa_redirect,
@@ -380,6 +381,118 @@ class TestExtractUserInfoFromProvider:
             await _extract_user_info_from_provider(request, client, {}, "unknown", cfg)
 
         assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_routes_to_oauth2(self) -> None:
+        """Should route to standard extraction for oauth2 kind providers."""
+        request = MagicMock()
+        client = AsyncMock()
+        resp = MagicMock()
+        resp.json.return_value = {"email": "u@discord.com", "username": "TestUser", "id": "987"}
+        client.get = AsyncMock(return_value=resp)
+        cfg = {"kind": "oauth2", "userinfo_url": "https://discord.com/api/users/@me"}
+
+        email, name, uid, _, _ = await _extract_user_info_from_provider(
+            request, client, {}, "discord", cfg
+        )
+
+        assert email == "u@discord.com"
+        assert name == "TestUser"
+        assert uid == "987"
+
+
+class TestExtractUserInfoStandard:
+    """Tests for generic OAuth2 userinfo extraction via _extract_user_info_standard."""
+
+    @pytest.mark.asyncio
+    async def test_extracts_standard_user_info(self) -> None:
+        """Should extract email, name, and uid from a standard JSON userinfo response."""
+        client = AsyncMock()
+        resp = MagicMock()
+        resp.json.return_value = {"email": "user@zoom.com", "name": "Zoom User", "id": "zoom-42"}
+        client.get = AsyncMock(return_value=resp)
+        cfg = {"userinfo_url": "https://api.zoom.us/v2/users/me"}
+
+        email, name, uid, verified, raw = await _extract_user_info_standard(client, {}, cfg)
+
+        assert email == "user@zoom.com"
+        assert name == "Zoom User"
+        assert uid == "zoom-42"
+        assert verified is True
+        assert raw["id"] == "zoom-42"
+
+    @pytest.mark.asyncio
+    async def test_missing_userinfo_url_raises_400(self) -> None:
+        """Should raise HTTPException 400 when userinfo_url is absent."""
+        client = AsyncMock()
+        cfg = {}  # no userinfo_url key
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _extract_user_info_standard(client, {}, cfg)
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "no_userinfo_url"
+
+    @pytest.mark.asyncio
+    async def test_fetch_exception_raises_400(self) -> None:
+        """Should raise HTTPException 400 when the userinfo request fails."""
+        client = AsyncMock()
+        client.get = AsyncMock(side_effect=RuntimeError("connection refused"))
+        cfg = {"userinfo_url": "https://api.example.com/me"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _extract_user_info_standard(client, {}, cfg)
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "userinfo_fetch_failed"
+
+    @pytest.mark.asyncio
+    async def test_non_dict_response_raises_400(self) -> None:
+        """Should raise HTTPException 400 when userinfo response is not a dict."""
+        client = AsyncMock()
+        resp = MagicMock()
+        resp.json.return_value = ["unexpected", "list"]
+        client.get = AsyncMock(return_value=resp)
+        cfg = {"userinfo_url": "https://api.example.com/me"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _extract_user_info_standard(client, {}, cfg)
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "userinfo_invalid_response"
+
+    @pytest.mark.asyncio
+    async def test_twitter_nested_data_id(self) -> None:
+        """Should extract Twitter v2 user ID from nested data.id field."""
+        client = AsyncMock()
+        resp = MagicMock()
+        # Twitter v2: top-level fields are absent; only data.id is present
+        resp.json.return_value = {"data": {"id": "tw-999"}}
+        client.get = AsyncMock(return_value=resp)
+        cfg = {"userinfo_url": "https://api.twitter.com/2/users/me"}
+
+        email, name, uid, _, _ = await _extract_user_info_standard(client, {}, cfg)
+
+        assert uid == "tw-999"
+        assert email is None  # Twitter v2 does not return email by default
+
+    @pytest.mark.asyncio
+    async def test_display_name_fallback(self) -> None:
+        """Should fall back to display_name when name field is absent."""
+        client = AsyncMock()
+        resp = MagicMock()
+        resp.json.return_value = {
+            "email": "r@reddit.com",
+            "display_name": "redditor",
+            "id": "t2_abc",
+        }
+        client.get = AsyncMock(return_value=resp)
+        cfg = {"userinfo_url": "https://oauth.reddit.com/api/v1/me"}
+
+        email, name, uid, _, _ = await _extract_user_info_standard(client, {}, cfg)
+
+        assert name == "redditor"
+        assert uid == "t2_abc"
 
 
 class TestFindOrCreateUser:

--- a/tests/unit/auth/test_oauth_flow.py
+++ b/tests/unit/auth/test_oauth_flow.py
@@ -324,6 +324,145 @@ class TestProvidersFromSettings:
         assert result["okta"]["issuer"] == "https://dev-12345.okta.com"  # trailing slash stripped
 
 
+class TestProvidersFromSettingsRegistryPath:
+    """Tests for the primary connect-registry path in providers_from_settings."""
+
+    def _patch_registry(self, fake_registry):
+        """Return a context manager that replaces the module-level registry instance.
+
+        Uses sys.modules to avoid the attribute-shadowing problem: the connect
+        package re-exports 'registry' so ``import svc_infra.connect.registry as m``
+        via dotted lookup returns the ConnectRegistry *instance*, not the module.
+        """
+        import sys
+        from unittest.mock import patch as _patch
+
+        return _patch.object(sys.modules["svc_infra.connect.registry"], "registry", fake_registry)
+
+    def test_registry_login_enabled_provider_is_included(self) -> None:
+        """A login_enabled provider in the connect registry appears in result."""
+        from svc_infra.api.fastapi.auth.providers import providers_from_settings
+        from svc_infra.connect.registry import ConnectRegistry, OAuthProvider
+
+        fake_registry = ConnectRegistry()
+        fake_registry.register(
+            OAuthProvider(
+                name="discord",
+                client_id="discord-id",
+                client_secret="discord-sec",
+                authorize_url="https://discord.com/api/oauth2/authorize",
+                token_url="https://discord.com/api/oauth2/token",
+                default_scopes=["identify", "email"],
+                login_enabled=True,
+                userinfo_kind="standard",
+                userinfo_url="https://discord.com/api/users/@me",
+            )
+        )
+
+        with self._patch_registry(fake_registry):
+            result = providers_from_settings(object())
+
+        assert "discord" in result
+        assert result["discord"]["kind"] == "oauth2"
+        assert result["discord"]["authorize_url"] == "https://discord.com/api/oauth2/authorize"
+
+    def test_registry_non_login_enabled_provider_is_excluded(self) -> None:
+        """A provider with login_enabled=False is NOT included for auth."""
+        from svc_infra.api.fastapi.auth.providers import providers_from_settings
+        from svc_infra.connect.registry import ConnectRegistry, OAuthProvider
+
+        fake_registry = ConnectRegistry()
+        fake_registry.register(
+            OAuthProvider(
+                name="figma",
+                client_id="figma-id",
+                client_secret="figma-sec",
+                authorize_url="https://www.figma.com/oauth",
+                token_url="https://www.figma.com/api/oauth/token",
+                default_scopes=["files:read"],
+                login_enabled=False,
+            )
+        )
+
+        with self._patch_registry(fake_registry):
+            result = providers_from_settings(object())
+
+        assert "figma" not in result
+
+    def test_registry_oidc_provider_produces_oidc_kind(self) -> None:
+        """A connect provider with oidc_discovery_url produces kind=oidc in auth config."""
+        from svc_infra.api.fastapi.auth.providers import providers_from_settings
+        from svc_infra.connect.registry import ConnectRegistry, OAuthProvider
+
+        fake_registry = ConnectRegistry()
+        fake_registry.register(
+            OAuthProvider(
+                name="google",
+                client_id="g-id",
+                client_secret="g-sec",
+                authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
+                token_url="https://oauth2.googleapis.com/token",
+                default_scopes=[],
+                login_enabled=True,
+                oidc_discovery_url="https://accounts.google.com",
+                userinfo_kind="oidc",
+            )
+        )
+
+        with self._patch_registry(fake_registry):
+            result = providers_from_settings(object())
+
+        assert result["google"]["kind"] == "oidc"
+        assert result["google"]["issuer"] == "https://accounts.google.com"
+
+    def test_registry_takes_precedence_over_fallback(self) -> None:
+        """A provider from the registry prevents the AUTH_* fallback from overwriting it."""
+        from svc_infra.api.fastapi.auth.providers import providers_from_settings
+        from svc_infra.connect.registry import ConnectRegistry, OAuthProvider
+
+        fake_registry = ConnectRegistry()
+        fake_registry.register(
+            OAuthProvider(
+                name="github",
+                client_id="connect-gh-id",
+                client_secret="connect-gh-sec",
+                authorize_url="https://github.com/login/oauth/authorize",
+                token_url="https://github.com/login/oauth/access_token",
+                default_scopes=["user:email"],
+                login_enabled=True,
+                userinfo_kind="github",
+            )
+        )
+
+        class Settings:
+            github_client_id = "settings-gh-id"
+            github_client_secret = Mock(get_secret_value=lambda: "settings-gh-sec")
+
+        with self._patch_registry(fake_registry):
+            result = providers_from_settings(Settings())
+
+        # Registry value wins — settings fallback does not overwrite
+        assert result["github"]["client_id"] == "connect-gh-id"
+
+    def test_fallback_adds_provider_absent_from_registry(self) -> None:
+        """AUTH_* fallback adds a provider that the registry does not have."""
+        from svc_infra.api.fastapi.auth.providers import providers_from_settings
+        from svc_infra.connect.registry import ConnectRegistry
+
+        # Empty registry — no login-enabled providers
+        fake_registry = ConnectRegistry()
+
+        class Settings:
+            google_client_id = "settings-g-id"
+            google_client_secret = Mock(get_secret_value=lambda: "settings-g-sec")
+
+        with self._patch_registry(fake_registry):
+            result = providers_from_settings(Settings())
+
+        assert "google" in result
+        assert result["google"]["kind"] == "oidc"
+
+
 class TestCookieConfiguration:
     """Tests for OAuth cookie configuration."""
 

--- a/tests/unit/connect/test_generic_providers.py
+++ b/tests/unit/connect/test_generic_providers.py
@@ -1,0 +1,416 @@
+"""Tests for the master OAuth provider catalog (connect/providers/generic.py).
+
+Covers:
+- _resolve_creds: primary CONNECT_* vars, legacy env var fallbacks, missing
+- _load_known_provider: standard provider, dynamic builder, env overrides
+- _url_builders: microsoft, okta, auth0, shopify (with and without domain)
+- _load_generic_providers: empty, known via CONNECT_PROVIDERS, unknown with URLs
+- load_all_connect_providers: assembles known + overrides from CONNECT_PROVIDERS
+"""
+
+from __future__ import annotations
+
+from svc_infra.connect.providers.generic import (
+    _build_auth0_urls,
+    _build_microsoft_urls,
+    _build_okta_urls,
+    _build_shopify_urls,
+    _load_generic_providers,
+    _load_known_provider,
+    _resolve_creds,
+    load_all_connect_providers,
+)
+from svc_infra.connect.registry import OAuthProvider
+
+# ===========================================================================
+# _resolve_creds
+# ===========================================================================
+
+
+class TestResolveCreds:
+    def test_returns_primary_connect_vars(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_ID", "primary-id")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_SECRET", "primary-sec")
+        result = _resolve_creds("github")
+        assert result == ("primary-id", "primary-sec")
+
+    def test_primary_takes_precedence_over_legacy(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_ID", "primary-id")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_SECRET", "primary-sec")
+        monkeypatch.setenv("GITHUB_CLIENT_ID", "legacy-id")
+        monkeypatch.setenv("GITHUB_CLIENT_SECRET", "legacy-sec")
+        result = _resolve_creds("github")
+        assert result == ("primary-id", "primary-sec")
+
+    def test_falls_back_to_legacy_when_primary_absent(self, monkeypatch):
+        monkeypatch.delenv("CONNECT_GITHUB_CLIENT_ID", raising=False)
+        monkeypatch.delenv("CONNECT_GITHUB_CLIENT_SECRET", raising=False)
+        monkeypatch.setenv("GITHUB_CLIENT_ID", "legacy-id")
+        monkeypatch.setenv("GITHUB_CLIENT_SECRET", "legacy-sec")
+        result = _resolve_creds("github")
+        assert result == ("legacy-id", "legacy-sec")
+
+    def test_google_legacy_fallbacks(self, monkeypatch):
+        monkeypatch.delenv("CONNECT_GOOGLE_CLIENT_ID", raising=False)
+        monkeypatch.delenv("CONNECT_GOOGLE_CLIENT_SECRET", raising=False)
+        monkeypatch.setenv("GOOGLE_CONNECT_CLIENT_ID", "gc-id")
+        monkeypatch.setenv("GOOGLE_CONNECT_CLIENT_SECRET", "gc-sec")
+        result = _resolve_creds("google")
+        assert result == ("gc-id", "gc-sec")
+
+    def test_google_plain_legacy_fallback(self, monkeypatch):
+        for var in (
+            "CONNECT_GOOGLE_CLIENT_ID",
+            "CONNECT_GOOGLE_CLIENT_SECRET",
+            "GOOGLE_CONNECT_CLIENT_ID",
+            "GOOGLE_CONNECT_CLIENT_SECRET",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("GOOGLE_CLIENT_ID", "plain-id")
+        monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "plain-sec")
+        result = _resolve_creds("google")
+        assert result == ("plain-id", "plain-sec")
+
+    def test_returns_none_when_no_creds(self, monkeypatch):
+        monkeypatch.delenv("CONNECT_NOTION_CLIENT_ID", raising=False)
+        monkeypatch.delenv("CONNECT_NOTION_CLIENT_SECRET", raising=False)
+        monkeypatch.delenv("NOTION_CLIENT_ID", raising=False)
+        monkeypatch.delenv("NOTION_CLIENT_SECRET", raising=False)
+        assert _resolve_creds("notion") is None
+
+    def test_returns_none_when_only_id_set(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_SLACK_CLIENT_ID", "only-id")
+        monkeypatch.delenv("CONNECT_SLACK_CLIENT_SECRET", raising=False)
+        monkeypatch.delenv("SLACK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("SLACK_CLIENT_SECRET", raising=False)
+        assert _resolve_creds("slack") is None
+
+    def test_unknown_provider_without_legacy_uses_primary_only(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_ACME_CLIENT_ID", "acme-id")
+        monkeypatch.setenv("CONNECT_ACME_CLIENT_SECRET", "acme-sec")
+        result = _resolve_creds("acme")
+        assert result == ("acme-id", "acme-sec")
+
+
+# ===========================================================================
+# URL builders
+# ===========================================================================
+
+
+class TestBuildMicrosoftUrls:
+    def test_builds_with_default_tenant(self, monkeypatch):
+        monkeypatch.delenv("CONNECT_MICROSOFT_TENANT_ID", raising=False)
+        monkeypatch.delenv("MICROSOFT_TENANT_ID", raising=False)
+        urls = _build_microsoft_urls()
+        assert urls is not None
+        assert "common" in urls["authorize_url"]
+        assert "common" in urls["token_url"]
+
+    def test_builds_with_custom_tenant(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_MICROSOFT_TENANT_ID", "mytenant")
+        urls = _build_microsoft_urls()
+        assert urls is not None
+        assert "mytenant" in urls["authorize_url"]
+        assert "mytenant" in urls["token_url"]
+        assert "mytenant" in urls["oidc_discovery_url"]
+
+    def test_legacy_tenant_env_var(self, monkeypatch):
+        monkeypatch.delenv("CONNECT_MICROSOFT_TENANT_ID", raising=False)
+        monkeypatch.setenv("MICROSOFT_TENANT_ID", "legacy-tenant")
+        urls = _build_microsoft_urls()
+        assert urls is not None
+        assert "legacy-tenant" in urls["authorize_url"]
+
+
+class TestBuildOktaUrls:
+    def test_returns_none_without_domain(self, monkeypatch):
+        monkeypatch.delenv("CONNECT_OKTA_DOMAIN", raising=False)
+        monkeypatch.delenv("OKTA_DOMAIN", raising=False)
+        assert _build_okta_urls() is None
+
+    def test_builds_with_domain(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_OKTA_DOMAIN", "acme.okta.com")
+        urls = _build_okta_urls()
+        assert urls is not None
+        assert "acme.okta.com" in urls["authorize_url"]
+        assert "acme.okta.com" in urls["oidc_discovery_url"]
+
+    def test_strips_trailing_slash(self, monkeypatch):
+        monkeypatch.setenv("OKTA_DOMAIN", "acme.okta.com/")
+        monkeypatch.delenv("CONNECT_OKTA_DOMAIN", raising=False)
+        urls = _build_okta_urls()
+        assert urls is not None
+        # Domain trailing slash is stripped so the resulting URL has no double slash
+        assert "//oauth2" not in urls["authorize_url"]
+        assert urls["authorize_url"].startswith("https://acme.okta.com/oauth2")
+
+
+class TestBuildAuth0Urls:
+    def test_returns_none_without_domain(self, monkeypatch):
+        monkeypatch.delenv("CONNECT_AUTH0_DOMAIN", raising=False)
+        monkeypatch.delenv("AUTH0_DOMAIN", raising=False)
+        assert _build_auth0_urls() is None
+
+    def test_builds_with_domain(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_AUTH0_DOMAIN", "acme.auth0.com")
+        urls = _build_auth0_urls()
+        assert urls is not None
+        assert "acme.auth0.com" in urls["authorize_url"]
+        assert "acme.auth0.com" in urls["oidc_discovery_url"]
+
+
+class TestBuildShopifyUrls:
+    def test_returns_none_without_shop(self, monkeypatch):
+        monkeypatch.delenv("CONNECT_SHOPIFY_SHOP", raising=False)
+        monkeypatch.delenv("SHOPIFY_SHOP", raising=False)
+        assert _build_shopify_urls() is None
+
+    def test_builds_with_shop(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_SHOPIFY_SHOP", "mystore.myshopify.com")
+        urls = _build_shopify_urls()
+        assert urls is not None
+        assert "mystore.myshopify.com" in urls["authorize_url"]
+        assert "mystore.myshopify.com" in urls["token_url"]
+
+
+# ===========================================================================
+# _load_known_provider
+# ===========================================================================
+
+
+class TestLoadKnownProvider:
+    def test_loads_github_with_primary_vars(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_ID", "gh-id")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_SECRET", "gh-sec")
+        p = _load_known_provider("github")
+        assert p is not None
+        assert p.name == "github"
+        assert p.client_id == "gh-id"
+        assert p.login_enabled is True
+        assert p.userinfo_kind == "github"
+
+    def test_loads_github_with_legacy_vars(self, monkeypatch):
+        monkeypatch.delenv("CONNECT_GITHUB_CLIENT_ID", raising=False)
+        monkeypatch.delenv("CONNECT_GITHUB_CLIENT_SECRET", raising=False)
+        monkeypatch.setenv("GITHUB_CLIENT_ID", "legacy-gh-id")
+        monkeypatch.setenv("GITHUB_CLIENT_SECRET", "legacy-gh-sec")
+        p = _load_known_provider("github")
+        assert p is not None
+        assert p.client_id == "legacy-gh-id"
+
+    def test_returns_none_when_no_creds(self, monkeypatch):
+        monkeypatch.delenv("CONNECT_GITHUB_CLIENT_ID", raising=False)
+        monkeypatch.delenv("CONNECT_GITHUB_CLIENT_SECRET", raising=False)
+        monkeypatch.delenv("GITHUB_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GITHUB_CLIENT_SECRET", raising=False)
+        assert _load_known_provider("github") is None
+
+    def test_returns_none_for_unknown_name(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_UNKNOWN_CLIENT_ID", "id")
+        monkeypatch.setenv("CONNECT_UNKNOWN_CLIENT_SECRET", "sec")
+        assert _load_known_provider("unknown_provider_xyz") is None
+
+    def test_google_has_oidc_discovery_url(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_GOOGLE_CLIENT_ID", "g-id")
+        monkeypatch.setenv("CONNECT_GOOGLE_CLIENT_SECRET", "g-sec")
+        p = _load_known_provider("google")
+        assert p is not None
+        assert p.oidc_discovery_url == "https://accounts.google.com"
+        assert p.userinfo_kind == "oidc"
+
+    def test_microsoft_uses_builder(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_MICROSOFT_CLIENT_ID", "ms-id")
+        monkeypatch.setenv("CONNECT_MICROSOFT_CLIENT_SECRET", "ms-sec")
+        monkeypatch.delenv("CONNECT_MICROSOFT_TENANT_ID", raising=False)
+        monkeypatch.delenv("MICROSOFT_TENANT_ID", raising=False)
+        p = _load_known_provider("microsoft")
+        assert p is not None
+        assert "common" in p.authorize_url
+
+    def test_okta_returns_none_without_domain(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_OKTA_CLIENT_ID", "okta-id")
+        monkeypatch.setenv("CONNECT_OKTA_CLIENT_SECRET", "okta-sec")
+        monkeypatch.delenv("CONNECT_OKTA_DOMAIN", raising=False)
+        monkeypatch.delenv("OKTA_DOMAIN", raising=False)
+        assert _load_known_provider("okta") is None
+
+    def test_okta_loads_with_domain(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_OKTA_CLIENT_ID", "okta-id")
+        monkeypatch.setenv("CONNECT_OKTA_CLIENT_SECRET", "okta-sec")
+        monkeypatch.setenv("CONNECT_OKTA_DOMAIN", "corp.okta.com")
+        p = _load_known_provider("okta")
+        assert p is not None
+        assert "corp.okta.com" in p.authorize_url
+
+    def test_scope_override_via_env(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_ID", "gh-id")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_SECRET", "gh-sec")
+        monkeypatch.setenv("CONNECT_GITHUB_SCOPES", "repo,read:org")
+        p = _load_known_provider("github")
+        assert p is not None
+        assert p.default_scopes == ["repo", "read:org"]
+
+    def test_pkce_override_false(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_ID", "gh-id")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_SECRET", "gh-sec")
+        monkeypatch.setenv("CONNECT_GITHUB_PKCE", "false")
+        p = _load_known_provider("github")
+        assert p is not None
+        assert p.pkce_required is False
+
+    def test_login_override_false(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_ID", "gh-id")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_SECRET", "gh-sec")
+        monkeypatch.setenv("CONNECT_GITHUB_LOGIN", "false")
+        p = _load_known_provider("github")
+        assert p is not None
+        assert p.login_enabled is False
+
+    def test_login_override_true_for_non_login_provider(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_NOTION_CLIENT_ID", "n-id")
+        monkeypatch.setenv("CONNECT_NOTION_CLIENT_SECRET", "n-sec")
+        monkeypatch.setenv("CONNECT_NOTION_LOGIN", "true")
+        p = _load_known_provider("notion")
+        assert p is not None
+        assert p.login_enabled is True
+
+    def test_authorize_url_override(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_ID", "gh-id")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_SECRET", "gh-sec")
+        monkeypatch.setenv("CONNECT_GITHUB_AUTHORIZE_URL", "https://custom.host/auth")
+        p = _load_known_provider("github")
+        assert p is not None
+        assert p.authorize_url == "https://custom.host/auth"
+
+
+# ===========================================================================
+# _load_generic_providers (CONNECT_PROVIDERS list)
+# ===========================================================================
+
+
+class TestLoadGenericProviders:
+    def test_empty_when_connect_providers_not_set(self, monkeypatch):
+        monkeypatch.delenv("CONNECT_PROVIDERS", raising=False)
+        assert _load_generic_providers() == []
+
+    def test_empty_when_connect_providers_empty_string(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_PROVIDERS", "")
+        assert _load_generic_providers() == []
+
+    def test_loads_known_provider_from_list(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_PROVIDERS", "github")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_ID", "gh-id")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_SECRET", "gh-sec")
+        result = _load_generic_providers()
+        assert len(result) == 1
+        assert result[0].name == "github"
+
+    def test_loads_unknown_provider_with_full_config(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_PROVIDERS", "acme")
+        monkeypatch.setenv("CONNECT_ACME_CLIENT_ID", "acme-id")
+        monkeypatch.setenv("CONNECT_ACME_CLIENT_SECRET", "acme-sec")
+        monkeypatch.setenv("CONNECT_ACME_AUTHORIZE_URL", "https://acme.com/auth")
+        monkeypatch.setenv("CONNECT_ACME_TOKEN_URL", "https://acme.com/token")
+        result = _load_generic_providers()
+        assert len(result) == 1
+        p = result[0]
+        assert p.name == "acme"
+        assert p.authorize_url == "https://acme.com/auth"
+        assert p.token_url == "https://acme.com/token"
+
+    def test_skips_unknown_provider_missing_urls(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_PROVIDERS", "acme")
+        monkeypatch.setenv("CONNECT_ACME_CLIENT_ID", "acme-id")
+        monkeypatch.setenv("CONNECT_ACME_CLIENT_SECRET", "acme-sec")
+        monkeypatch.delenv("CONNECT_ACME_AUTHORIZE_URL", raising=False)
+        monkeypatch.delenv("CONNECT_ACME_TOKEN_URL", raising=False)
+        assert _load_generic_providers() == []
+
+    def test_skips_unknown_provider_missing_creds(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_PROVIDERS", "acme")
+        monkeypatch.delenv("CONNECT_ACME_CLIENT_ID", raising=False)
+        monkeypatch.delenv("CONNECT_ACME_CLIENT_SECRET", raising=False)
+        monkeypatch.setenv("CONNECT_ACME_AUTHORIZE_URL", "https://acme.com/auth")
+        monkeypatch.setenv("CONNECT_ACME_TOKEN_URL", "https://acme.com/token")
+        assert _load_generic_providers() == []
+
+    def test_unknown_provider_scopes_parsed(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_PROVIDERS", "acme")
+        monkeypatch.setenv("CONNECT_ACME_CLIENT_ID", "acme-id")
+        monkeypatch.setenv("CONNECT_ACME_CLIENT_SECRET", "acme-sec")
+        monkeypatch.setenv("CONNECT_ACME_AUTHORIZE_URL", "https://acme.com/auth")
+        monkeypatch.setenv("CONNECT_ACME_TOKEN_URL", "https://acme.com/token")
+        monkeypatch.setenv("CONNECT_ACME_SCOPES", "read,write,admin")
+        result = _load_generic_providers()
+        assert result[0].default_scopes == ["read", "write", "admin"]
+
+    def test_loads_multiple_providers(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_PROVIDERS", "github, acme")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_ID", "gh-id")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_SECRET", "gh-sec")
+        monkeypatch.setenv("CONNECT_ACME_CLIENT_ID", "acme-id")
+        monkeypatch.setenv("CONNECT_ACME_CLIENT_SECRET", "acme-sec")
+        monkeypatch.setenv("CONNECT_ACME_AUTHORIZE_URL", "https://acme.com/auth")
+        monkeypatch.setenv("CONNECT_ACME_TOKEN_URL", "https://acme.com/token")
+        result = _load_generic_providers()
+        names = {p.name for p in result}
+        assert names == {"github", "acme"}
+
+
+# ===========================================================================
+# load_all_connect_providers
+# ===========================================================================
+
+
+class TestLoadAllConnectProviders:
+    def test_returns_empty_when_no_creds(self, monkeypatch):
+        # Clear all provider env vars that could accidentally be set
+        for var in (
+            "CONNECT_GITHUB_CLIENT_ID",
+            "GITHUB_CLIENT_ID",
+            "CONNECT_GOOGLE_CLIENT_ID",
+            "GOOGLE_CLIENT_ID",
+            "GOOGLE_CONNECT_CLIENT_ID",
+            "CONNECT_SLACK_CLIENT_ID",
+            "SLACK_CLIENT_ID",
+            "CONNECT_NOTION_CLIENT_ID",
+            "NOTION_CLIENT_ID",
+            "CONNECT_PROVIDERS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        result = load_all_connect_providers()
+        assert result == []
+
+    def test_includes_github_when_creds_set(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_ID", "gh-id")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_SECRET", "gh-sec")
+        result = load_all_connect_providers()
+        names = {p.name for p in result}
+        assert "github" in names
+
+    def test_connect_providers_override_catalog_entry(self, monkeypatch):
+        # Provider in CONNECT_PROVIDERS overrides catalog entry
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_ID", "gh-catalog-id")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_SECRET", "gh-catalog-sec")
+        monkeypatch.setenv("CONNECT_PROVIDERS", "github")
+        result = load_all_connect_providers()
+        github = next(p for p in result if p.name == "github")
+        # The CONNECT_PROVIDERS entry wins (loads via _load_known_provider again
+        # but replaces the catalog entry in the dict — same result since same creds)
+        assert github.client_id == "gh-catalog-id"
+
+    def test_includes_unknown_provider_from_connect_providers(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_PROVIDERS", "acme")
+        monkeypatch.setenv("CONNECT_ACME_CLIENT_ID", "acme-id")
+        monkeypatch.setenv("CONNECT_ACME_CLIENT_SECRET", "acme-sec")
+        monkeypatch.setenv("CONNECT_ACME_AUTHORIZE_URL", "https://acme.com/auth")
+        monkeypatch.setenv("CONNECT_ACME_TOKEN_URL", "https://acme.com/token")
+        result = load_all_connect_providers()
+        names = {p.name for p in result}
+        assert "acme" in names
+
+    def test_returns_only_oauth_provider_instances(self, monkeypatch):
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_ID", "gh-id")
+        monkeypatch.setenv("CONNECT_GITHUB_CLIENT_SECRET", "gh-sec")
+        result = load_all_connect_providers()
+        assert all(isinstance(p, OAuthProvider) for p in result)

--- a/tests/unit/connect/test_mcp_discovery.py
+++ b/tests/unit/connect/test_mcp_discovery.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from svc_infra.connect import mcp_discovery as _mod
+from svc_infra.connect.mcp_discovery import (
+    MCPOAuthDiscovery,
+    MCPOAuthNotSupported,
+    parse_www_authenticate,
+)
+
+
+def _mock_http_response(
+    status_code: int, json_data: dict, headers: dict | None = None
+) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.headers = headers or {}
+    return resp
+
+
+class TestParseWwwAuthenticate:
+    def test_parses_resource_metadata(self):
+        header = 'Bearer resource_metadata="https://example.com/.well-known/oauth"'
+        result = parse_www_authenticate(header)
+        assert result.get("resource_metadata") == "https://example.com/.well-known/oauth"
+
+    def test_parses_multiple_fields(self):
+        header = 'Bearer resource_metadata="https://auth.example.com/meta" realm="api"'
+        result = parse_www_authenticate(header)
+        assert "resource_metadata" in result
+        assert "realm" in result
+
+    def test_empty_header_returns_empty_dict(self):
+        assert parse_www_authenticate("") == {}
+
+    def test_non_bearer_header_parsed_best_effort(self):
+        header = "Basic realm=example"
+        result = parse_www_authenticate(header)
+        assert "realm" in result
+
+
+class TestMCPOAuthDiscovery:
+    def setup_method(self):
+        _mod._DISCOVERY_CACHE.clear()
+
+    def _make_discovery(self) -> MCPOAuthDiscovery:
+        return MCPOAuthDiscovery()
+
+    @pytest.mark.asyncio
+    async def test_full_discovery_success(self):
+        """Happy path: resource metadata + auth server metadata → OAuthProvider."""
+        resource_meta = {
+            "resource": "https://mcp.example.com",
+            "authorization_servers": ["https://auth.example.com"],
+        }
+        auth_meta = {
+            "issuer": "https://auth.example.com",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+
+        discovery = self._make_discovery()
+        with (
+            patch.object(
+                discovery,
+                "_fetch_resource_metadata",
+                new_callable=AsyncMock,
+                return_value=resource_meta,
+            ),
+            patch.object(
+                discovery,
+                "_fetch_auth_server_metadata",
+                new_callable=AsyncMock,
+                return_value=auth_meta,
+            ),
+        ):
+            provider = await discovery.discover("https://mcp.example.com")
+
+        assert provider.name == "mcp:https://mcp.example.com"
+        assert provider.authorize_url == "https://auth.example.com/authorize"
+        assert provider.token_url == "https://auth.example.com/token"
+
+    @pytest.mark.asyncio
+    async def test_in_process_cache_hit(self):
+        """Second call with same URL returns cached result without calling helpers."""
+        resource_meta = {
+            "authorization_servers": ["https://auth.example.com"],
+        }
+        auth_meta = {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+
+        discovery = self._make_discovery()
+        with (
+            patch.object(
+                discovery,
+                "_fetch_resource_metadata",
+                new_callable=AsyncMock,
+                return_value=resource_meta,
+            ) as mock_res,
+            patch.object(
+                discovery,
+                "_fetch_auth_server_metadata",
+                new_callable=AsyncMock,
+                return_value=auth_meta,
+            ),
+        ):
+            await discovery.discover("https://mcp.example.com")
+            await discovery.discover("https://mcp.example.com")
+
+        assert mock_res.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cache_expires(self):
+        """Cache entry older than TTL triggers a fresh discovery."""
+        resource_meta = {"authorization_servers": ["https://auth.example.com"]}
+        auth_meta = {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+
+        url = "https://mcp.example.com"
+        discovery = self._make_discovery()
+
+        with (
+            patch.object(
+                discovery,
+                "_fetch_resource_metadata",
+                new_callable=AsyncMock,
+                return_value=resource_meta,
+            ) as mock_res,
+            patch.object(
+                discovery,
+                "_fetch_auth_server_metadata",
+                new_callable=AsyncMock,
+                return_value=auth_meta,
+            ),
+        ):
+            await discovery.discover(url)
+            _mod._DISCOVERY_CACHE[url] = (
+                _mod._DISCOVERY_CACHE[url][0],
+                time.monotonic() - _mod._CACHE_TTL_SECONDS - 1,
+            )
+            await discovery.discover(url)
+
+        assert mock_res.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_authorization_servers(self):
+        """Missing authorization_servers field → MCPOAuthNotSupported."""
+        resource_meta = {"resource": "https://mcp.example.com"}
+
+        discovery = self._make_discovery()
+        with patch.object(
+            discovery,
+            "_fetch_resource_metadata",
+            new_callable=AsyncMock,
+            return_value=resource_meta,
+        ):
+            with pytest.raises(MCPOAuthNotSupported, match="authorization_servers"):
+                await discovery.discover("https://mcp.example.com")
+
+    @pytest.mark.asyncio
+    async def test_raises_when_missing_authorize_endpoint(self):
+        """Auth server metadata missing authorization_endpoint → MCPOAuthNotSupported."""
+        resource_meta = {"authorization_servers": ["https://auth.example.com"]}
+        auth_meta = {"token_endpoint": "https://auth.example.com/token"}
+
+        discovery = self._make_discovery()
+        with (
+            patch.object(
+                discovery,
+                "_fetch_resource_metadata",
+                new_callable=AsyncMock,
+                return_value=resource_meta,
+            ),
+            patch.object(
+                discovery,
+                "_fetch_auth_server_metadata",
+                new_callable=AsyncMock,
+                return_value=auth_meta,
+            ),
+        ):
+            with pytest.raises(MCPOAuthNotSupported, match="authorization_endpoint"):
+                await discovery.discover("https://mcp.example.com")
+
+    @pytest.mark.asyncio
+    async def test_is_mcp_oauth_supported_true(self):
+        """Returns True when server responds 401 + Bearer WWW-Authenticate with resource_metadata."""
+        mock_resp = _mock_http_response(
+            401,
+            {},
+            headers={
+                "www-authenticate": 'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth"'
+            },
+        )
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        discovery = self._make_discovery()
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+            result = await discovery.is_mcp_oauth_supported("https://mcp.example.com")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_is_mcp_oauth_supported_false_on_200(self):
+        """Returns False when server responds with 200 instead of 401."""
+        mock_resp = _mock_http_response(200, {}, headers={})
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        discovery = self._make_discovery()
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+            result = await discovery.is_mcp_oauth_supported("https://mcp.example.com")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_is_mcp_oauth_supported_false_on_network_error(self):
+        """Returns False (no raise) when server is unreachable."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+
+        discovery = self._make_discovery()
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+            result = await discovery.is_mcp_oauth_supported("https://mcp.example.com")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_fetch_resource_metadata_raises_on_404(self):
+        """404 from resource metadata endpoint → MCPOAuthNotSupported."""
+        mock_resp = _mock_http_response(404, {})
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        discovery = self._make_discovery()
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(MCPOAuthNotSupported, match="RFC 9728"):
+                await discovery._fetch_resource_metadata("https://mcp.example.com")
+
+    @pytest.mark.asyncio
+    async def test_fetch_resource_metadata_raises_on_network_error(self):
+        """Network error fetching resource metadata → MCPOAuthNotSupported."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+        discovery = self._make_discovery()
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(MCPOAuthNotSupported, match="resource metadata"):
+                await discovery._fetch_resource_metadata("https://mcp.example.com")

--- a/tests/unit/connect/test_models.py
+++ b/tests/unit/connect/test_models.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from svc_infra.connect.models import ConnectionToken, OAuthState
+
+
+class TestConnectionTokenModel:
+    def test_table_name(self):
+        assert ConnectionToken.__tablename__ == "connection_tokens"
+
+    def test_unique_constraint_name(self):
+        constraints = {c.name for c in ConnectionToken.__table_args__ if hasattr(c, "name")}
+        assert "uq_connection_token" in constraints
+
+    def test_composite_index_exists(self):
+        indexes = {i.name for i in ConnectionToken.__table_args__ if hasattr(i, "name")}
+        assert "ix_connection_tokens_user_provider" in indexes
+
+    def test_instantiation_with_required_fields(self):
+        user_id = uuid.uuid4()
+        connection_id = uuid.uuid4()
+        token = ConnectionToken(
+            user_id=user_id,
+            connection_id=connection_id,
+            provider="github",
+            access_token="encrypted_token",
+            token_type="Bearer",
+        )
+        assert token.provider == "github"
+        assert token.token_type == "Bearer"
+        assert token.refresh_token is None
+        assert token.expires_at is None
+        assert token.scopes is None
+        assert token.raw_token is None
+
+    def test_explicit_id_is_stored(self):
+        custom_id = uuid.uuid4()
+        token = ConnectionToken(
+            id=custom_id,
+            user_id=uuid.uuid4(),
+            connection_id=uuid.uuid4(),
+            provider="github",
+            access_token="x",
+        )
+        assert token.id == custom_id
+        assert isinstance(token.id, uuid.UUID)
+
+
+class TestOAuthStateModel:
+    def test_table_name(self):
+        assert OAuthState.__tablename__ == "oauth_states"
+
+    def test_instantiation_with_required_fields(self):
+        user_id = uuid.uuid4()
+        expires_at = datetime.now(UTC) + timedelta(minutes=10)
+        state = OAuthState(
+            state="random_state_value",
+            pkce_verifier="verifier",
+            provider="github",
+            user_id=user_id,
+            redirect_uri="https://example.com/callback",
+            expires_at=expires_at,
+        )
+        assert state.state == "random_state_value"
+        assert state.connection_id is None
+
+    def test_explicit_id_is_stored(self):
+        custom_id = uuid.uuid4()
+        state = OAuthState(
+            id=custom_id,
+            state="s",
+            pkce_verifier="v",
+            provider="github",
+            user_id=uuid.uuid4(),
+            redirect_uri="https://example.com/callback",
+            expires_at=datetime.now(UTC) + timedelta(minutes=10),
+        )
+        assert state.id == custom_id
+        assert isinstance(state.id, uuid.UUID)

--- a/tests/unit/connect/test_pkce.py
+++ b/tests/unit/connect/test_pkce.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from svc_infra.connect.pkce import (
+    OAuthExchangeError,
+    OAuthRefreshError,
+    build_authorize_url,
+    coerce_expires_at,
+    exchange_code,
+    exchange_refresh,
+    generate_pkce_pair,
+    generate_state,
+    validate_redirect,
+)
+from svc_infra.connect.registry import OAuthProvider
+
+
+def _make_provider(**kwargs) -> OAuthProvider:
+    defaults = {
+        "name": "github",
+        "client_id": "cid",
+        "client_secret": "csecret",
+        "authorize_url": "https://github.com/login/oauth/authorize",
+        "token_url": "https://github.com/login/oauth/access_token",
+        "default_scopes": ["repo"],
+        "pkce_required": True,
+        "extra_authorize_params": {},
+    }
+    defaults.update(kwargs)
+    return OAuthProvider(**defaults)
+
+
+def _mock_http_response(status_code: int, json_data: dict) -> MagicMock:
+    """Create a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.text = str(json_data)
+    return resp
+
+
+class TestGeneratePkcePair:
+    def test_returns_two_strings(self):
+        verifier, challenge = generate_pkce_pair()
+        assert isinstance(verifier, str)
+        assert isinstance(challenge, str)
+
+    def test_verifier_and_challenge_are_different(self):
+        verifier, challenge = generate_pkce_pair()
+        assert verifier != challenge
+
+    def test_challenge_is_s256_of_verifier(self):
+        import base64
+        import hashlib
+
+        verifier, challenge = generate_pkce_pair()
+        digest = hashlib.sha256(verifier.encode()).digest()
+        expected = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+        assert challenge == expected
+
+    def test_each_call_produces_unique_pair(self):
+        v1, _ = generate_pkce_pair()
+        v2, _ = generate_pkce_pair()
+        assert v1 != v2
+
+
+class TestGenerateState:
+    def test_returns_string(self):
+        assert isinstance(generate_state(), str)
+
+    def test_unique_on_each_call(self):
+        assert generate_state() != generate_state()
+
+
+class TestValidateRedirect:
+    def test_allows_matching_host(self):
+        validate_redirect(
+            "https://example.com/callback",
+            ["example.com"],
+            require_https=True,
+        )
+
+    def test_rejects_disallowed_host(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_redirect(
+                "https://evil.com/callback",
+                ["example.com"],
+                require_https=True,
+            )
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "redirect_not_allowed"
+
+    def test_rejects_http_when_https_required(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_redirect(
+                "http://example.com/callback",
+                ["example.com"],
+                require_https=True,
+            )
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "https_required"
+
+    def test_allows_no_netloc(self):
+        validate_redirect("pulse-app://callback", [], require_https=False)
+
+    def test_allows_http_when_https_not_required(self):
+        validate_redirect(
+            "http://localhost:3000/callback",
+            ["localhost:3000"],
+            require_https=False,
+        )
+
+
+class TestCoerceExpiresAt:
+    def test_none_input(self):
+        assert coerce_expires_at(None) is None
+
+    def test_non_dict_input(self):
+        assert coerce_expires_at("string") is None  # type: ignore[arg-type]
+
+    def test_expires_at_unix_timestamp(self):
+        future = datetime.now(UTC) + timedelta(hours=1)
+        ts = future.timestamp()
+        result = coerce_expires_at({"expires_at": ts})
+        assert result is not None
+        assert abs((result - future).total_seconds()) < 2
+
+    def test_expires_at_milliseconds(self):
+        future = datetime.now(UTC) + timedelta(hours=1)
+        ts_ms = future.timestamp() * 1000
+        result = coerce_expires_at({"expires_at": ts_ms})
+        assert result is not None
+        assert abs((result - future).total_seconds()) < 2
+
+    def test_expires_in_seconds(self):
+        result = coerce_expires_at({"expires_in": 3600})
+        assert result is not None
+        expected = datetime.now(UTC) + timedelta(seconds=3600)
+        assert abs((result - expected).total_seconds()) < 2
+
+    def test_empty_dict_returns_none(self):
+        assert coerce_expires_at({}) is None
+
+
+class TestBuildAuthorizeUrl:
+    def test_includes_required_params(self):
+        provider = _make_provider()
+        url = build_authorize_url(
+            provider,
+            state="s",
+            pkce_challenge="ch",
+            redirect_uri="https://example.com/callback",
+        )
+        assert "client_id=cid" in url
+        assert "response_type=code" in url
+        assert "state=s" in url
+        assert "code_challenge=ch" in url
+        assert "code_challenge_method=S256" in url
+
+    def test_scope_override(self):
+        provider = _make_provider()
+        url = build_authorize_url(
+            provider,
+            state="s",
+            pkce_challenge="ch",
+            redirect_uri="https://example.com/callback",
+            scopes=["read", "write"],
+        )
+        assert "read" in url and "write" in url
+
+    def test_no_pkce_when_not_required(self):
+        provider = _make_provider(pkce_required=False)
+        url = build_authorize_url(
+            provider,
+            state="s",
+            pkce_challenge="ch",
+            redirect_uri="https://example.com/callback",
+        )
+        assert "code_challenge" not in url
+
+    def test_extra_params_included(self):
+        provider = _make_provider(extra_authorize_params={"allow_signup": "false"})
+        url = build_authorize_url(
+            provider,
+            state="s",
+            pkce_challenge="ch",
+            redirect_uri="https://example.com/callback",
+        )
+        assert "allow_signup=false" in url
+
+
+@pytest.mark.asyncio
+class TestExchangeCode:
+    async def test_success(self):
+        provider = _make_provider()
+        mock_resp = _mock_http_response(200, {"access_token": "tok", "token_type": "Bearer"})
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch("svc_infra.connect.pkce.httpx.AsyncClient", return_value=mock_client):
+            result = await exchange_code(
+                provider,
+                code="code123",
+                pkce_verifier="verifier",
+                redirect_uri="https://example.com/callback",
+            )
+        assert result["access_token"] == "tok"
+
+    async def test_raises_on_non_200(self):
+        provider = _make_provider()
+        mock_resp = _mock_http_response(400, {"error": "bad_request"})
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch("svc_infra.connect.pkce.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(OAuthExchangeError):
+                await exchange_code(
+                    provider, code="code", pkce_verifier="v", redirect_uri="https://x.com"
+                )
+
+    async def test_raises_on_error_field(self):
+        provider = _make_provider()
+        mock_resp = _mock_http_response(200, {"error": "invalid_grant"})
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch("svc_infra.connect.pkce.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(OAuthExchangeError):
+                await exchange_code(
+                    provider, code="code", pkce_verifier="v", redirect_uri="https://x.com"
+                )
+
+
+@pytest.mark.asyncio
+class TestExchangeRefresh:
+    async def test_success(self):
+        provider = _make_provider()
+        mock_resp = _mock_http_response(200, {"access_token": "new_tok", "token_type": "Bearer"})
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch("svc_infra.connect.pkce.httpx.AsyncClient", return_value=mock_client):
+            result = await exchange_refresh(provider, "refresh_token_value")
+        assert result["access_token"] == "new_tok"
+
+    async def test_raises_on_non_200(self):
+        provider = _make_provider()
+        mock_resp = _mock_http_response(401, {"error": "invalid_token"})
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch("svc_infra.connect.pkce.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(OAuthRefreshError):
+                await exchange_refresh(provider, "bad_refresh")
+
+    async def test_raises_when_no_access_token(self):
+        provider = _make_provider()
+        mock_resp = _mock_http_response(200, {"token_type": "Bearer"})
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch("svc_infra.connect.pkce.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(OAuthRefreshError):
+                await exchange_refresh(provider, "refresh")

--- a/tests/unit/connect/test_registry.py
+++ b/tests/unit/connect/test_registry.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from svc_infra.connect.registry import ConnectRegistry, OAuthProvider
+
+
+def _make_provider(name: str = "test") -> OAuthProvider:
+    return OAuthProvider(
+        name=name,
+        client_id="cid",
+        client_secret="csecret",
+        authorize_url="https://example.com/auth",
+        token_url="https://example.com/token",
+        default_scopes=["read"],
+    )
+
+
+class TestConnectRegistry:
+    def test_register_and_get(self):
+        reg = ConnectRegistry()
+        provider = _make_provider("github")
+        reg.register(provider)
+        assert reg.get("github") is provider
+
+    def test_get_returns_none_for_unknown(self):
+        reg = ConnectRegistry()
+        assert reg.get("unknown") is None
+
+    def test_list_returns_all(self):
+        reg = ConnectRegistry()
+        p1 = _make_provider("github")
+        p2 = _make_provider("notion")
+        reg.register(p1)
+        reg.register(p2)
+        names = {p.name for p in reg.list()}
+        assert names == {"github", "notion"}
+
+    def test_register_replaces_existing(self):
+        reg = ConnectRegistry()
+        p1 = _make_provider("github")
+        p2 = OAuthProvider(
+            name="github",
+            client_id="new_cid",
+            client_secret="new_secret",
+            authorize_url="https://github.com/login/oauth/authorize",
+            token_url="https://github.com/login/oauth/access_token",
+            default_scopes=["repo"],
+        )
+        reg.register(p1)
+        reg.register(p2)
+        assert reg.get("github").client_id == "new_cid"
+
+    def test_list_empty_by_default(self):
+        reg = ConnectRegistry()
+        assert reg.list() == []
+
+    def test_client_secret_is_masked(self):
+        provider = _make_provider()
+        # SecretStr should not expose secret in repr
+        assert "csecret" not in repr(provider.client_secret)
+
+    def test_pkce_required_defaults_true(self):
+        provider = _make_provider()
+        assert provider.pkce_required is True
+
+    def test_token_placement_defaults_header(self):
+        provider = _make_provider()
+        assert provider.token_placement == "header"
+
+    def test_login_enabled_defaults_false(self):
+        provider = _make_provider()
+        assert provider.login_enabled is False
+
+    def test_login_enabled_can_be_set(self):
+        provider = OAuthProvider(
+            name="discord",
+            client_id="cid",
+            client_secret="sec",
+            authorize_url="https://discord.com/oauth2/authorize",
+            token_url="https://discord.com/api/oauth2/token",
+            default_scopes=["identify"],
+            login_enabled=True,
+        )
+        assert provider.login_enabled is True
+
+    def test_oidc_discovery_url_defaults_none(self):
+        provider = _make_provider()
+        assert provider.oidc_discovery_url is None
+
+    def test_oidc_discovery_url_can_be_set(self):
+        provider = OAuthProvider(
+            name="google",
+            client_id="cid",
+            client_secret="sec",
+            authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
+            token_url="https://oauth2.googleapis.com/token",
+            default_scopes=[],
+            oidc_discovery_url="https://accounts.google.com",
+        )
+        assert provider.oidc_discovery_url == "https://accounts.google.com"
+
+    def test_userinfo_kind_defaults_standard(self):
+        provider = _make_provider()
+        assert provider.userinfo_kind == "standard"
+
+    def test_userinfo_kind_github(self):
+        provider = OAuthProvider(
+            name="github",
+            client_id="cid",
+            client_secret="sec",
+            authorize_url="https://github.com/login/oauth/authorize",
+            token_url="https://github.com/login/oauth/access_token",
+            default_scopes=["user:email"],
+            userinfo_kind="github",
+        )
+        assert provider.userinfo_kind == "github"
+
+    def test_extra_token_params_defaults_empty(self):
+        provider = _make_provider()
+        assert provider.extra_token_params == {}
+
+    def test_extra_token_params_can_be_set(self):
+        provider = OAuthProvider(
+            name="notion",
+            client_id="cid",
+            client_secret="sec",
+            authorize_url="https://api.notion.com/v1/oauth/authorize",
+            token_url="https://api.notion.com/v1/oauth/token",
+            default_scopes=[],
+            extra_token_params={"grant_type": "authorization_code"},
+        )
+        assert provider.extra_token_params == {"grant_type": "authorization_code"}
+
+    def test_list_filters_login_enabled(self):
+        reg = ConnectRegistry()
+        reg.register(_make_provider("tool-only"))
+        reg.register(
+            OAuthProvider(
+                name="login-capable",
+                client_id="cid",
+                client_secret="sec",
+                authorize_url="https://example.com/auth",
+                token_url="https://example.com/token",
+                default_scopes=[],
+                login_enabled=True,
+            )
+        )
+        login_providers = [p for p in reg.list() if p.login_enabled]
+        assert len(login_providers) == 1
+        assert login_providers[0].name == "login-capable"

--- a/tests/unit/connect/test_router.py
+++ b/tests/unit/connect/test_router.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from svc_infra.connect.registry import ConnectRegistry, OAuthProvider
+from svc_infra.connect.settings import ConnectSettings
+from svc_infra.connect.state import set_connect_state
+from svc_infra.connect.token_manager import ConnectionTokenManager
+
+_KEY = Fernet.generate_key().decode()
+_USER_ID = uuid4()
+_CONN_ID = uuid4()
+
+
+def _make_provider() -> OAuthProvider:
+    return OAuthProvider(
+        name="github",
+        client_id="cid",
+        client_secret="csecret",
+        authorize_url="https://github.com/login/oauth/authorize",
+        token_url="https://github.com/login/oauth/access_token",
+        default_scopes=["repo"],
+    )
+
+
+@pytest_asyncio.fixture
+async def connect_app(mocker):
+    """FastAPI app with connect router mounted and all deps mocked."""
+    from svc_infra.api.fastapi.auth.security import _current_principal
+    from svc_infra.api.fastapi.db.sql.session import get_session
+    from svc_infra.connect.router import connect_router
+
+    app = FastAPI()
+
+    # ---- mock principal ----------------------------------------
+    mock_user = mocker.Mock()
+    mock_user.id = _USER_ID
+    mock_principal = mocker.Mock()
+    mock_principal.user = mock_user
+
+    async def _mock_principal():
+        return mock_principal
+
+    app.dependency_overrides[_current_principal] = _mock_principal
+
+    # ---- mock db session ----------------------------------------
+    from tests.unit.utils.test_helpers import MockDatabaseSession
+
+    mock_db = MockDatabaseSession()
+
+    async def _mock_session():
+        return mock_db
+
+    app.dependency_overrides[get_session] = _mock_session
+
+    # ---- connect state ------------------------------------------
+    reg = ConnectRegistry()
+    reg.register(_make_provider())
+
+    settings = ConnectSettings(
+        connect_token_encryption_key=_KEY,
+        connect_api_base="http://testserver",
+        connect_default_redirect_uri="https://app.example.com/callback",
+        connect_state_ttl_seconds=600,
+        connect_redirect_allow_hosts="app.example.com",
+    )
+    token_manager = ConnectionTokenManager(_KEY, registry=reg)
+    set_connect_state(settings, token_manager)
+
+    # patch registry used inside router
+    with patch("svc_infra.connect.router._default_registry", reg):
+        app.include_router(connect_router, prefix="/connect")
+        yield app, mock_db, token_manager, reg
+
+
+@pytest_asyncio.fixture
+async def connect_client(connect_app):
+    app, mock_db, token_manager, reg = connect_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        yield client, mock_db, token_manager, reg
+
+
+@pytest.mark.asyncio
+class TestAuthorizeEndpoint:
+    async def test_returns_authorize_url(self, connect_client):
+        client, _, _, _ = connect_client
+        resp = await client.get(
+            "/connect/authorize",
+            params={
+                "provider": "github",
+                "connection_id": str(_CONN_ID),
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "authorize_url" in body
+        assert "github.com/login/oauth/authorize" in body["authorize_url"]
+        assert "code_challenge" in body["authorize_url"]
+
+    async def test_returns_404_for_unknown_provider(self, connect_client):
+        client, _, _, _ = connect_client
+        resp = await client.get(
+            "/connect/authorize",
+            params={
+                "provider": "unknown_provider_xyz",
+                "connection_id": str(_CONN_ID),
+            },
+        )
+        assert resp.status_code == 404
+
+    async def test_returns_400_when_no_provider_or_mcp_url(self, connect_client):
+        client, _, _, _ = connect_client
+        resp = await client.get(
+            "/connect/authorize",
+            params={"connection_id": str(_CONN_ID)},
+        )
+        assert resp.status_code == 400
+
+    async def test_mcp_discovery_path(self, connect_client):
+        """mcp_server_url triggers MCPOAuthDiscovery.discover() and resolves provider."""
+        client, _, _, reg = connect_client
+
+        mock_provider = _make_provider()
+        mock_provider = mock_provider.model_copy(update={"name": "mcp:https://mcp.example.com"})
+
+        with patch("svc_infra.connect.router._mcp_discovery") as mock_disc:
+            mock_disc.discover = AsyncMock(return_value=mock_provider)
+            resp = await client.get(
+                "/connect/authorize",
+                params={
+                    "mcp_server_url": "https://mcp.example.com",
+                    "connection_id": str(_CONN_ID),
+                },
+            )
+
+        assert resp.status_code == 200
+        mock_disc.discover.assert_awaited_once()
+
+    async def test_mcp_discovery_not_supported_returns_422(self, connect_client):
+        from svc_infra.connect.mcp_discovery import MCPOAuthNotSupported
+
+        client, _, _, _ = connect_client
+        with patch("svc_infra.connect.router._mcp_discovery") as mock_disc:
+            mock_disc.discover = AsyncMock(side_effect=MCPOAuthNotSupported("no oauth"))
+            resp = await client.get(
+                "/connect/authorize",
+                params={
+                    "mcp_server_url": "https://mcp.example.com",
+                    "connection_id": str(_CONN_ID),
+                },
+            )
+        assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+class TestCallbackEndpoint:
+    def _make_oauth_state(self, manager: ConnectionTokenManager, provider: str = "github"):
+        from svc_infra.connect.models import OAuthState
+
+        state = MagicMock(spec=OAuthState)
+        state.state = "valid_state"
+        state.provider = provider
+        state.pkce_verifier = "verifier"
+        state.user_id = _USER_ID
+        state.connection_id = _CONN_ID
+        state.redirect_uri = "http://app.example.com/callback"
+        state.expires_at = datetime.now(UTC) + timedelta(seconds=600)
+        return state
+
+    async def test_callback_success_redirects(self, connect_client):
+        client, mock_db, token_manager, _ = connect_client
+        oauth_state = self._make_oauth_state(token_manager)
+
+        # Patch db.execute to return the oauth state
+        async def _execute(_stmt):
+            result = MagicMock()
+            scalars = MagicMock()
+            scalars.first = MagicMock(return_value=oauth_state)
+            result.scalars = MagicMock(return_value=scalars)
+            return result
+
+        mock_db.execute = _execute
+
+        with (
+            patch(
+                "svc_infra.connect.router.exchange_code",
+                new_callable=AsyncMock,
+                return_value={"access_token": "tok", "token_type": "Bearer"},
+            ),
+            patch.object(token_manager, "store", new_callable=AsyncMock, return_value=MagicMock()),
+        ):
+            resp = await client.get(
+                "/connect/callback/github",
+                params={"code": "auth_code_123", "state": "valid_state"},
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert "success=true" in resp.headers["location"]
+
+    async def test_callback_invalid_state_redirects_with_error(self, connect_client):
+        client, mock_db, _, _ = connect_client
+
+        # Return None for the state query
+        async def _execute(_stmt):
+            result = MagicMock()
+            scalars = MagicMock()
+            scalars.first = MagicMock(return_value=None)
+            result.scalars = MagicMock(return_value=scalars)
+            return result
+
+        mock_db.execute = _execute
+
+        resp = await client.get(
+            "/connect/callback/github",
+            params={"code": "code", "state": "invalid_state"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert "error=invalid_state" in resp.headers["location"]
+
+    async def test_callback_with_error_param_redirects(self, connect_client):
+        client, mock_db, token_manager, _ = connect_client
+        oauth_state = self._make_oauth_state(token_manager)
+
+        async def _execute(_stmt):
+            result = MagicMock()
+            scalars = MagicMock()
+            scalars.first = MagicMock(return_value=oauth_state)
+            result.scalars = MagicMock(return_value=scalars)
+            return result
+
+        mock_db.execute = _execute
+
+        resp = await client.get(
+            "/connect/callback/github",
+            params={"code": "code", "state": "valid_state", "error": "access_denied"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert "access_denied" in resp.headers["location"]
+
+    async def test_callback_exchange_failure_redirects_with_error(self, connect_client):
+        from svc_infra.connect.pkce import OAuthExchangeError
+
+        client, mock_db, token_manager, _ = connect_client
+        oauth_state = self._make_oauth_state(token_manager)
+
+        async def _execute(_stmt):
+            result = MagicMock()
+            scalars = MagicMock()
+            scalars.first = MagicMock(return_value=oauth_state)
+            result.scalars = MagicMock(return_value=scalars)
+            return result
+
+        mock_db.execute = _execute
+
+        with patch(
+            "svc_infra.connect.router.exchange_code",
+            new_callable=AsyncMock,
+            side_effect=OAuthExchangeError("bad code"),
+        ):
+            resp = await client.get(
+                "/connect/callback/github",
+                params={"code": "bad", "state": "valid_state"},
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert "exchange_failed" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+class TestGetTokenEndpoint:
+    def _make_token_row(self, manager: ConnectionTokenManager):
+        from svc_infra.connect.models import ConnectionToken
+
+        row = MagicMock(spec=ConnectionToken)
+        row.id = uuid4()
+        row.user_id = _USER_ID
+        row.connection_id = _CONN_ID
+        row.provider = "github"
+        row.access_token = manager._encrypt("my_access_token")
+        row.refresh_token = None
+        row.expires_at = datetime.now(UTC) + timedelta(hours=2)
+        return row
+
+    async def test_returns_valid_token(self, connect_client):
+        client, _, token_manager, _ = connect_client
+        row = self._make_token_row(token_manager)
+
+        with (
+            patch.object(
+                token_manager,
+                "get_valid_token",
+                new_callable=AsyncMock,
+                return_value="my_access_token",
+            ),
+            patch.object(token_manager, "get", new_callable=AsyncMock, return_value=row),
+        ):
+            resp = await client.get(
+                f"/connect/token/{_CONN_ID}",
+                params={"provider": "github"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["token"] == "my_access_token"
+        assert "expires_at" in body
+
+    async def test_returns_404_when_no_token_stored(self, connect_client):
+        client, _, token_manager, _ = connect_client
+
+        with (
+            patch.object(
+                token_manager, "get_valid_token", new_callable=AsyncMock, return_value=None
+            ),
+            patch.object(token_manager, "get", new_callable=AsyncMock, return_value=None),
+        ):
+            resp = await client.get(
+                f"/connect/token/{_CONN_ID}",
+                params={"provider": "github"},
+            )
+
+        assert resp.status_code == 404
+
+    async def test_returns_502_when_token_exists_but_refresh_failed(self, connect_client):
+        client, _, token_manager, _ = connect_client
+        row = self._make_token_row(token_manager)
+
+        with (
+            patch.object(
+                token_manager, "get_valid_token", new_callable=AsyncMock, return_value=None
+            ),
+            patch.object(token_manager, "get", new_callable=AsyncMock, return_value=row),
+        ):
+            resp = await client.get(
+                f"/connect/token/{_CONN_ID}",
+                params={"provider": "github"},
+            )
+
+        assert resp.status_code == 502

--- a/tests/unit/connect/test_token_manager.py
+++ b/tests/unit/connect/test_token_manager.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from cryptography.fernet import Fernet
+
+from svc_infra.connect.models import ConnectionToken
+from svc_infra.connect.pkce import OAuthRefreshError
+from svc_infra.connect.registry import ConnectRegistry, OAuthProvider
+from svc_infra.connect.token_manager import ConnectionTokenManager
+
+_KEY = Fernet.generate_key().decode()
+
+_USER_ID = uuid4()
+_CONN_ID = uuid4()
+_PROVIDER = "github"
+
+
+def _make_registry() -> ConnectRegistry:
+    reg = ConnectRegistry()
+    reg.register(
+        OAuthProvider(
+            name=_PROVIDER,
+            client_id="cid",
+            client_secret="csecret",
+            authorize_url="https://github.com/login/oauth/authorize",
+            token_url="https://github.com/login/oauth/access_token",
+            revoke_url="https://github.com/login/oauth/revoke",
+            default_scopes=["repo"],
+        )
+    )
+    return reg
+
+
+def _make_manager(registry: ConnectRegistry | None = None) -> ConnectionTokenManager:
+    return ConnectionTokenManager(_KEY, registry=registry)
+
+
+def _make_token_row(
+    manager: ConnectionTokenManager,
+    *,
+    access_token: str = "access",
+    refresh_token: str | None = "refresh",
+    expires_at: datetime | None = None,
+) -> ConnectionToken:
+    row = MagicMock(spec=ConnectionToken)
+    row.id = uuid4()
+    row.user_id = _USER_ID
+    row.connection_id = _CONN_ID
+    row.provider = _PROVIDER
+    row.access_token = manager._encrypt(access_token)
+    row.refresh_token = manager._encrypt(refresh_token) if refresh_token else None
+    row.token_type = "Bearer"
+    row.scopes = ["repo"]
+    row.expires_at = expires_at
+    row.raw_token = manager._encrypt_json({"access_token": access_token})
+    return row
+
+
+def _make_db(*execute_returns) -> MagicMock:
+    """Return a mock db session whose sequential execute() calls yield the given scalars."""
+    idx = [0]
+    values = list(execute_returns)
+
+    async def _execute(_stmt):
+        result = MagicMock()
+        scalars_mock = MagicMock()
+        scalars_mock.first = MagicMock(
+            return_value=values[idx[0]] if idx[0] < len(values) else None
+        )
+        scalars_mock.all = MagicMock(return_value=[values[idx[0]]] if idx[0] < len(values) else [])
+        result.scalars = MagicMock(return_value=scalars_mock)
+        idx[0] += 1
+        return result
+
+    db = MagicMock()
+    db.execute = _execute
+    db.flush = AsyncMock()
+    db.delete = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+class TestEncryptionRoundtrip:
+    def test_encrypt_decrypt_string(self):
+        manager = _make_manager()
+        plaintext = "my-access-token"
+        encrypted = manager._encrypt(plaintext)
+        assert encrypted != plaintext
+        assert manager._decrypt(encrypted) == plaintext
+
+    def test_encrypt_decrypt_json(self):
+        manager = _make_manager()
+        data = {"access_token": "tok", "scopes": ["read", "write"]}
+        encrypted = manager._encrypt_json(data)
+        assert isinstance(encrypted, str)
+        assert manager._decrypt_json(encrypted) == data
+
+
+@pytest.mark.asyncio
+class TestStore:
+    async def test_creates_new_row_when_none_exists(self, mocker):
+        manager = _make_manager()
+        db = _make_db(None)  # get() returns None → create path
+
+        fake_row = _make_token_row(manager)
+        mock_create = mocker.patch.object(
+            manager._repo, "create", new_callable=AsyncMock, return_value=fake_row
+        )
+
+        result = await manager.store(
+            db,
+            user_id=_USER_ID,
+            connection_id=_CONN_ID,
+            provider=_PROVIDER,
+            token_response={"access_token": "access", "token_type": "Bearer"},
+        )
+
+        mock_create.assert_awaited_once()
+        assert result is fake_row
+
+    async def test_updates_existing_row(self, mocker):
+        manager = _make_manager()
+        existing_row = _make_token_row(manager)
+        db = _make_db(existing_row)
+
+        mock_update = mocker.patch.object(
+            manager._repo, "update", new_callable=AsyncMock, return_value=existing_row
+        )
+
+        await manager.store(
+            db,
+            user_id=_USER_ID,
+            connection_id=_CONN_ID,
+            provider=_PROVIDER,
+            token_response={"access_token": "new_access", "token_type": "Bearer"},
+        )
+
+        mock_update.assert_awaited_once()
+
+    async def test_stores_encrypted_access_token(self, mocker):
+        manager = _make_manager()
+        db = _make_db(None)
+
+        captured: dict = {}
+
+        async def capture_create(_db, data: dict):
+            captured.update(data)
+            return _make_token_row(manager, access_token="plain_access")
+
+        mocker.patch.object(manager._repo, "create", side_effect=capture_create)
+
+        await manager.store(
+            db,
+            user_id=_USER_ID,
+            connection_id=_CONN_ID,
+            provider=_PROVIDER,
+            token_response={"access_token": "plain_access", "token_type": "Bearer"},
+        )
+
+        # The stored access_token must be encrypted (not plaintext)
+        stored_enc = captured["access_token"]
+        assert stored_enc != "plain_access"
+        assert manager._decrypt(stored_enc) == "plain_access"
+
+
+@pytest.mark.asyncio
+class TestGetValidToken:
+    async def test_returns_valid_token(self, mocker):
+        manager = _make_manager()
+        row = _make_token_row(
+            manager, access_token="my_token", expires_at=datetime.now(UTC) + timedelta(hours=1)
+        )
+        db = _make_db(row)
+
+        token = await manager.get_valid_token(
+            db, connection_id=_CONN_ID, user_id=_USER_ID, provider=_PROVIDER
+        )
+        assert token == "my_token"
+
+    async def test_returns_none_when_no_row(self):
+        manager = _make_manager()
+        db = _make_db(None)
+
+        token = await manager.get_valid_token(
+            db, connection_id=_CONN_ID, user_id=_USER_ID, provider=_PROVIDER
+        )
+        assert token is None
+
+    async def test_triggers_refresh_near_expiry(self, mocker):
+        manager = _make_manager(registry=_make_registry())
+        near_expiry = datetime.now(UTC) + timedelta(minutes=2)
+        row = _make_token_row(
+            manager, access_token="old", refresh_token="rt", expires_at=near_expiry
+        )
+        refreshed_row = _make_token_row(manager, access_token="new_tok")
+
+        db = _make_db(row)
+
+        mock_refresh = mocker.patch.object(
+            manager, "_refresh_token", new_callable=AsyncMock, return_value=refreshed_row
+        )
+
+        token = await manager.get_valid_token(
+            db, connection_id=_CONN_ID, user_id=_USER_ID, provider=_PROVIDER
+        )
+
+        mock_refresh.assert_awaited_once_with(db, row)
+        assert token == "new_tok"
+
+    async def test_returns_none_when_refresh_fails(self, mocker):
+        manager = _make_manager(registry=_make_registry())
+        near_expiry = datetime.now(UTC) + timedelta(minutes=2)
+        row = _make_token_row(
+            manager, access_token="old", refresh_token="rt", expires_at=near_expiry
+        )
+        db = _make_db(row)
+
+        mocker.patch.object(manager, "_refresh_token", new_callable=AsyncMock, return_value=None)
+
+        token = await manager.get_valid_token(
+            db, connection_id=_CONN_ID, user_id=_USER_ID, provider=_PROVIDER
+        )
+        assert token is None
+
+    async def test_does_not_raise_on_exception(self):
+        """get_valid_token must never raise; return None instead."""
+        manager = _make_manager()
+        db = MagicMock()
+        db.execute = AsyncMock(side_effect=RuntimeError("db error"))
+
+        token = await manager.get_valid_token(
+            db, connection_id=_CONN_ID, user_id=_USER_ID, provider=_PROVIDER
+        )
+        assert token is None
+
+
+@pytest.mark.asyncio
+class TestRevoke:
+    async def test_deletes_row(self, mocker):
+        manager = _make_manager()
+        row = _make_token_row(manager)
+        db = _make_db(row)
+
+        mock_delete = mocker.patch.object(manager._repo, "delete", new_callable=AsyncMock)
+
+        await manager.revoke(db, connection_id=_CONN_ID, user_id=_USER_ID, provider=_PROVIDER)
+
+        mock_delete.assert_awaited_once_with(db, row.id)
+
+    async def test_calls_revoke_url_when_configured(self, mocker):
+        manager = _make_manager(registry=_make_registry())
+        row = _make_token_row(manager)
+        db = _make_db(row)
+
+        mocker.patch.object(manager._repo, "delete", new_callable=AsyncMock)
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
+
+        with patch("svc_infra.connect.token_manager.httpx.AsyncClient", return_value=mock_client):
+            await manager.revoke(db, connection_id=_CONN_ID, user_id=_USER_ID, provider=_PROVIDER)
+
+        mock_client.post.assert_awaited_once()
+
+    async def test_no_op_when_no_row(self, mocker):
+        manager = _make_manager()
+        db = _make_db(None)
+
+        mock_delete = mocker.patch.object(manager._repo, "delete", new_callable=AsyncMock)
+        await manager.revoke(db, connection_id=_CONN_ID, user_id=_USER_ID, provider=_PROVIDER)
+
+        mock_delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestDeleteAllForConnection:
+    async def test_executes_bulk_delete(self):
+        manager = _make_manager()
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=MagicMock())
+        db.flush = AsyncMock()
+
+        await manager.delete_all_for_connection(db, _CONN_ID)
+
+        db.execute.assert_awaited_once()
+        db.flush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+class TestRefreshExpiringTokens:
+    async def test_returns_count_of_refreshed_tokens(self, mocker):
+        manager = _make_manager(registry=_make_registry())
+        row1 = _make_token_row(manager)
+        row2 = _make_token_row(manager)
+        db = MagicMock()
+
+        async def _execute(_stmt):
+            result = MagicMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all = MagicMock(return_value=[row1, row2])
+            result.scalars = MagicMock(return_value=scalars_mock)
+            return result
+
+        db.execute = _execute
+
+        mocker.patch.object(
+            manager, "_refresh_token", new_callable=AsyncMock, return_value=_make_token_row(manager)
+        )
+
+        count = await manager.refresh_expiring_tokens(db)
+        assert count == 2
+
+    async def test_skips_failed_refresh(self, mocker):
+        manager = _make_manager(registry=_make_registry())
+        row1 = _make_token_row(manager)
+        db = MagicMock()
+
+        async def _execute(_stmt):
+            result = MagicMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all = MagicMock(return_value=[row1])
+            result.scalars = MagicMock(return_value=scalars_mock)
+            return result
+
+        db.execute = _execute
+
+        mocker.patch.object(
+            manager,
+            "_refresh_token",
+            new_callable=AsyncMock,
+            side_effect=OAuthRefreshError("failed"),
+        )
+
+        count = await manager.refresh_expiring_tokens(db)
+        assert count == 0


### PR DESCRIPTION
## Summary

Adds a new `svc_infra.connect` OAuth module providing a unified, production-ready OAuth 2.0 integration layer. Centralises all provider management so both "connect" (third-party app connections) and "auth" (login) go through a single catalog rather than two separate systems.

## Changes

### New module: `src/svc_infra/connect/`
- `registry.py` — `OAuthProvider` model + `ConnectRegistry` singleton (supports `login_enabled`, `oidc_discovery_url`, `userinfo_kind`, `extra_token_params`)
- `providers/generic.py` — master catalog of 60+ providers (GitHub, Google, Microsoft, Slack, Discord, Notion, Figma, Zoom, Reddit, Twitter, Spotify, Salesforce, HubSpot, QuickBooks, Xero, and more); dynamic URL builders for tenant-scoped providers (Okta, Auth0, Keycloak, Cognito, Zendesk, Freshdesk, Shopify, Microsoft/Azure AD)
- `providers/__init__.py` — single `load_all_connect_providers()` entry point; backward-compat re-exports for 7 individual provider mod- `p- `token_manager.py`, `state- `providers/__init__.py` — single `load_all_connect_providers()` entry point; backward-compat re-exports for 7 individual provider mod- `p- `token_manager.py`, `state- `providers/__init__.py` — single `load_all_connect_providers()` entry point; backward-compat re, f- `provi to- `providers/__init__.py` — single \; \- `providers/__init__.py` — single `load_all_connect_providers()` entry point; backward-compat re-exports for 7 individual provider mod- `p- \d branch to `_register_oauth_providers()`; new `_extract_user_info_standard()` function for generic userinfo endpoints (Discord, Zoom, Reddit, Twitter v2, etc.)
- `settings.py`, `ws_security.py` — minor additions

### Docs and examples
- `docs/connect.md` — full provider catalog, env var pattern, PKCE flow
- `docs/connect-mcp-oauth.md` — MCP OAuth integration guide
- `examples/docs/connect-basic-oauth.py`, `examples/docs/connect-mcp-oauth.py`

## Tests

All 2862 existing unit tests pass. New tests added:
- `tests/unit/connect/test_registry.py` — 9 new tests for new `OAuthProvider` fields
- `tests/unit/connect/test_generic_providers.py` — 40+ tests: `_resolve_creds`, URL builders, `_load_known_provider`, `_load_generic_providers`, `load_all_connect_providers`
- `tests/unit/auth/test_oauth_flow.py` — `TestProvidersFromSettingsRegistryPath` (5 tests: registry primary path, oidc kind, precedence over fallback)
- `tests/unit/auth/routers/test_oauth_helpers.py` — `TestExtractUserInfoStandard` (6 tests) + `test_routes_to_oauth2`
