### PR TITLE
fix: preserve dict/list detail in HTTPException error handlers and enhance MCP OAuth discovery

### DIFF
--- a/src/svc_infra/api/fastapi/middleware/errors/handlers.py
+++ b/src/svc_infra/api/fastapi/middleware/errors/handlers.py
@@ -120,6 +120,24 @@ def register_error_handlers(app):
     @app.exception_handler(HTTPException)
     async def handle_http_exception(request: Request, exc: HTTPException):
         trace_id = _trace_id_from_request(request)
+        # Preserve headers set on the exception (e.g., Retry-After for rate limits)
+        hdrs: dict[str, str] | None = None
+        try:
+            exc_headers = getattr(exc, "headers", None)
+            if exc_headers is not None:
+                # FastAPI/Starlette exceptions store headers as a dict[str, str]
+                hdrs = dict(exc_headers)
+        except Exception:
+            hdrs = None
+        # When detail is intentionally structured (dict/list), preserve
+        # FastAPI's default JSON format.  Converting to problem+json would
+        # stringify the structured data, breaking clients that parse it.
+        if isinstance(exc.detail, (dict, list)):
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=hdrs,
+            )
         title = {
             401: "Unauthorized",
             403: "Forbidden",
@@ -131,19 +149,10 @@ def register_error_handlers(app):
             if not IS_PROD or exc.status_code < 500
             else "Something went wrong. Please contact support."
         )
-        # Preserve headers set on the exception (e.g., Retry-After for rate limits)
-        hdrs: dict[str, str] | None = None
-        try:
-            exc_headers = getattr(exc, "headers", None)
-            if exc_headers is not None:
-                # FastAPI/Starlette exceptions store headers as a dict[str, str]
-                hdrs = dict(exc_headers)
-        except Exception:
-            hdrs = None
         return problem_response(
             status=exc.status_code,
             title=title,
-            detail=str(detail) if isinstance(detail, (dict, list)) else detail,
+            detail=detail,
             code=title.replace(" ", "_").upper(),
             instance=str(request.url),
             trace_id=trace_id,
@@ -152,6 +161,20 @@ def register_error_handlers(app):
 
     @app.exception_handler(StarletteHTTPException)
     async def handle_starlette_http_exception(request: Request, exc: StarletteHTTPException):
+        hdrs: dict[str, str] | None = None
+        try:
+            exc_headers = getattr(exc, "headers", None)
+            if exc_headers is not None:
+                hdrs = dict(exc_headers)
+        except Exception:
+            hdrs = None
+        # Structured dict/list details: preserve FastAPI's default format.
+        if isinstance(exc.detail, (dict, list)):
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=hdrs,
+            )
         trace_id = _trace_id_from_request(request)
         title = {
             401: "Unauthorized",
@@ -164,17 +187,10 @@ def register_error_handlers(app):
             if not IS_PROD or exc.status_code < 500
             else "Something went wrong. Please contact support."
         )
-        hdrs: dict[str, str] | None = None
-        try:
-            exc_headers = getattr(exc, "headers", None)
-            if exc_headers is not None:
-                hdrs = dict(exc_headers)
-        except Exception:
-            hdrs = None
         return problem_response(
             status=exc.status_code,
             title=title,
-            detail=str(detail) if isinstance(detail, (dict, list)) else detail,
+            detail=detail,
             code=title.replace(" ", "_").upper(),
             instance=str(request.url),
             trace_id=trace_id,

--- a/src/svc_infra/connect/add.py
+++ b/src/svc_infra/connect/add.py
@@ -57,6 +57,20 @@ def add_connect(app: FastAPI, *, prefix: str = "/connect") -> None:
         )
         set_connect_state(settings, token_manager)
 
+        # Populate the OAuth provider registry from environment variables.
+        # Must happen inside the lifespan (after env vars are set) so that
+        # credentials like GITHUB_CLIENT_ID are visible.
+        from svc_infra.connect.providers.generic import load_all_connect_providers
+
+        for _provider in load_all_connect_providers():
+            _default_registry.register(_provider)
+
+        _loaded = len(_default_registry.list())
+        if _loaded:
+            logger.info("connect: loaded %d OAuth provider(s) from environment", _loaded)
+        else:
+            logger.warning("connect: no OAuth providers found in environment")
+
         _, scheduler = easy_jobs()
 
         from svc_infra.api.fastapi.db.sql.session import _SessionLocal

--- a/src/svc_infra/connect/mcp_discovery.py
+++ b/src/svc_infra/connect/mcp_discovery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 import time
 from typing import Any
@@ -8,6 +9,9 @@ import httpx
 from pydantic import SecretStr
 
 from svc_infra.connect.registry import OAuthProvider
+from svc_infra.connect.registry import registry as _registry
+
+logger = logging.getLogger(__name__)
 
 
 class MCPOAuthNotSupported(Exception):
@@ -58,10 +62,40 @@ class MCPOAuthDiscovery:
         if cached is not None:
             provider, ts = cached
             if now - ts < _CACHE_TTL_SECONDS:
+                logger.debug(
+                    "discover: cache hit", extra={"url": mcp_server_url, "provider": provider.name}
+                )
                 return provider
 
         resource_meta = await self._fetch_resource_metadata(mcp_server_url)
         auth_server_url = self._extract_auth_server(resource_meta)
+        logger.debug("discover: auth_server_url=%s", auth_server_url, extra={"url": mcp_server_url})
+
+        registered = _registry.list()
+        logger.info(
+            "discover: registry has %d provider(s): %s",
+            len(registered),
+            [p.name for p in registered],
+            extra={"url": mcp_server_url},
+        )
+        # Shortcut: if a registered provider already covers this auth server
+        # (i.e. its authorize_url begins with the auth_server_url), use it
+        # directly.  This avoids the RFC 8414 metadata fetch for providers
+        # like GitHub that do not publish /.well-known/oauth-authorization-server.
+        for existing in registered:
+            if existing.authorize_url.startswith(auth_server_url):
+                logger.info(
+                    "discover: shortcut matched provider=%s",
+                    existing.name,
+                    extra={"url": mcp_server_url},
+                )
+                _DISCOVERY_CACHE[mcp_server_url] = (existing, now)
+                return existing
+
+        logger.info(
+            "discover: no shortcut match, falling back to RFC 8414",
+            extra={"url": mcp_server_url, "auth_server_url": auth_server_url},
+        )
         auth_meta = await self._fetch_auth_server_metadata(auth_server_url)
 
         provider = self._build_provider(mcp_server_url, auth_meta)
@@ -81,18 +115,46 @@ class MCPOAuthDiscovery:
                     json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
                     headers={"Content-Type": "application/json"},
                 )
+            logger.debug(
+                "OAuth probe response",
+                extra={
+                    "url": mcp_server_url,
+                    "status": response.status_code,
+                    "www_auth": response.headers.get("www-authenticate", ""),
+                },
+            )
             if response.status_code != 401:
+                logger.debug(
+                    "OAuth probe: not 401, returning False",
+                    extra={"url": mcp_server_url, "status": response.status_code},
+                )
                 return False
             www_auth = response.headers.get("www-authenticate", "")
             if not www_auth.lower().startswith("bearer"):
+                logger.debug(
+                    "OAuth probe: no bearer www-authenticate, returning False",
+                    extra={"url": mcp_server_url},
+                )
                 return False
             parsed = parse_www_authenticate(www_auth)
-            return "resource_metadata" in parsed
-        except (httpx.RequestError, httpx.HTTPStatusError):
+            result = "resource_metadata" in parsed
+            logger.info(
+                "OAuth probe: resource_metadata=%s",
+                result,
+                extra={"url": mcp_server_url, "parsed_keys": list(parsed.keys())},
+            )
+            return result
+        except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+            logger.warning(
+                "OAuth probe request failed", extra={"url": mcp_server_url, "error": str(exc)}
+            )
             return False
 
     async def _fetch_resource_metadata(self, mcp_server_url: str) -> dict[str, Any]:
-        url = mcp_server_url.rstrip("/") + "/.well-known/oauth-protected-resource"
+        # RFC 9728 §3: the protected resource advertises its metadata URL in the
+        # WWW-Authenticate header of its 401 response.  Probe the MCP endpoint
+        # first so we can use the canonical URL rather than constructing a guess.
+        url = await self._probe_resource_metadata_url(mcp_server_url)
         try:
             async with httpx.AsyncClient(timeout=15.0) as client:
                 response = await client.get(url, headers={"Accept": "application/json"})
@@ -115,6 +177,37 @@ class MCPOAuthDiscovery:
             raise MCPOAuthNotSupported("Resource metadata response is not valid JSON") from exc
 
         return data
+
+    async def _probe_resource_metadata_url(self, mcp_server_url: str) -> str:
+        """Probe the MCP server to discover the canonical resource metadata URL.
+
+        Sends an unauthenticated POST to the MCP endpoint and extracts
+        ``resource_metadata`` from the ``WWW-Authenticate`` header of the 401
+        response (RFC 9728 §3).  Falls back to constructing the default path
+        (``<mcp_server_url>/.well-known/oauth-protected-resource``) if the
+        server does not include the field or is unreachable.
+        """
+        default = mcp_server_url.rstrip("/") + "/.well-known/oauth-protected-resource"
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(
+                    mcp_server_url,
+                    json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
+                    headers={"Content-Type": "application/json"},
+                )
+        except httpx.RequestError:
+            return default
+
+        if response.status_code != 401:
+            return default
+
+        www_auth = response.headers.get("www-authenticate", "")
+        if www_auth.lower().startswith("bearer"):
+            parsed = parse_www_authenticate(www_auth)
+            if "resource_metadata" in parsed:
+                return parsed["resource_metadata"]
+
+        return default
 
     def _extract_auth_server(self, resource_meta: dict[str, Any]) -> str:
         servers = resource_meta.get("authorization_servers")
@@ -155,9 +248,15 @@ class MCPOAuthDiscovery:
         supported_methods = auth_meta.get("code_challenge_methods_supported", [])
         pkce_required = "S256" in supported_methods or not supported_methods
 
-        from svc_infra.connect.registry import OAuthProvider as _OAuthProvider
+        # If a registered provider already covers this authorization_endpoint,
+        # reuse it so the pre-configured client_id/secret are preserved.
+        # This is required for providers like GitHub that do not support
+        # dynamic client registration (RFC 7591).
+        for existing in _registry.list():
+            if existing.authorize_url.rstrip("/") == authorize_url.rstrip("/"):
+                return existing
 
-        return _OAuthProvider(
+        return OAuthProvider(
             name=f"mcp:{mcp_server_url}",
             client_id="",
             client_secret=SecretStr(""),

--- a/tests/unit/connect/test_mcp_discovery.py
+++ b/tests/unit/connect/test_mcp_discovery.py
@@ -248,7 +248,15 @@ class TestMCPOAuthDiscovery:
         mock_client.get = AsyncMock(return_value=mock_resp)
 
         discovery = self._make_discovery()
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+        with (
+            patch.object(
+                discovery,
+                "_probe_resource_metadata_url",
+                new_callable=AsyncMock,
+                return_value="https://mcp.example.com/.well-known/oauth-protected-resource",
+            ),
+            patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client),
+        ):
             with pytest.raises(MCPOAuthNotSupported, match="RFC 9728"):
                 await discovery._fetch_resource_metadata("https://mcp.example.com")
 
@@ -261,6 +269,176 @@ class TestMCPOAuthDiscovery:
         mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
 
         discovery = self._make_discovery()
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+        with (
+            patch.object(
+                discovery,
+                "_probe_resource_metadata_url",
+                new_callable=AsyncMock,
+                return_value="https://mcp.example.com/.well-known/oauth-protected-resource",
+            ),
+            patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client),
+        ):
             with pytest.raises(MCPOAuthNotSupported, match="resource metadata"):
                 await discovery._fetch_resource_metadata("https://mcp.example.com")
+
+    @pytest.mark.asyncio
+    async def test_probe_resource_metadata_url_returns_header_url(self):
+        """When server returns 401 with resource_metadata in WWW-Authenticate, use that URL."""
+        mock_resp = _mock_http_response(
+            401,
+            {},
+            headers={
+                "www-authenticate": 'Bearer resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp/"'
+            },
+        )
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        discovery = self._make_discovery()
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+            url = await discovery._probe_resource_metadata_url("https://api.example.com/mcp/")
+
+        assert url == "https://api.example.com/.well-known/oauth-protected-resource/mcp/"
+
+    @pytest.mark.asyncio
+    async def test_probe_resource_metadata_url_falls_back_on_200(self):
+        """When server returns 200 (no auth), fall back to default URL construction."""
+        mock_resp = _mock_http_response(200, {}, headers={})
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        discovery = self._make_discovery()
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+            url = await discovery._probe_resource_metadata_url("https://mcp.example.com/")
+
+        assert url == "https://mcp.example.com/.well-known/oauth-protected-resource"
+
+    @pytest.mark.asyncio
+    async def test_probe_resource_metadata_url_falls_back_on_network_error(self):
+        """Network error probing server falls back to default URL construction."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+        discovery = self._make_discovery()
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+            url = await discovery._probe_resource_metadata_url("https://mcp.example.com/")
+
+        assert url == "https://mcp.example.com/.well-known/oauth-protected-resource"
+
+    def test_build_provider_reuses_registered_provider_on_matching_auth_url(self):
+        """When a registered provider's authorize_url matches the discovered
+        authorization_endpoint, _build_provider returns that provider so its
+        client_id/secret are preserved (needed for GitHub which has no dynamic
+        client registration)."""
+        from pydantic import SecretStr as _SecretStr
+
+        from svc_infra.connect.registry import OAuthProvider
+
+        github_provider = OAuthProvider(
+            name="github",
+            client_id="test-client-id",
+            client_secret=_SecretStr("test-client-secret"),
+            authorize_url="https://github.com/login/oauth/authorize",
+            token_url="https://github.com/login/oauth/access_token",
+            default_scopes=["repo", "user:email"],
+        )
+
+        discovery = self._make_discovery()
+        auth_meta = {
+            "authorization_endpoint": "https://github.com/login/oauth/authorize",
+            "token_endpoint": "https://github.com/login/oauth/access_token",
+            "code_challenge_methods_supported": ["S256"],
+        }
+
+        with patch("svc_infra.connect.mcp_discovery._registry") as mock_reg:
+            mock_reg.list.return_value = [github_provider]
+            result = discovery._build_provider("https://api.githubcopilot.com/mcp/", auth_meta)
+
+        assert result is github_provider
+        assert result.client_id == "test-client-id"
+
+    def test_build_provider_creates_new_provider_when_no_match(self):
+        """When no registered provider matches, _build_provider builds a new
+        one with empty client_id (standard MCP dynamic registration path)."""
+        discovery = self._make_discovery()
+        auth_meta = {
+            "authorization_endpoint": "https://auth.example.com/oauth/authorize",
+            "token_endpoint": "https://auth.example.com/oauth/token",
+            "code_challenge_methods_supported": ["S256"],
+        }
+
+        with patch("svc_infra.connect.mcp_discovery._registry") as mock_reg:
+            mock_reg.list.return_value = []
+            result = discovery._build_provider("https://mcp.example.com/", auth_meta)
+
+        assert result.client_id == ""
+        assert result.name == "mcp:https://mcp.example.com/"
+
+    @pytest.mark.asyncio
+    async def test_discover_uses_registry_shortcut_for_providers_without_rfc8414(self):
+        """discover() skips the RFC 8414 metadata fetch when a registered
+        provider's authorize_url starts with the extracted auth_server_url.
+        This is the critical path for GitHub, which does not publish
+        /.well-known/oauth-authorization-server."""
+        from pydantic import SecretStr as _SecretStr
+
+        from svc_infra.connect.registry import OAuthProvider
+
+        github_provider = OAuthProvider(
+            name="github",
+            client_id="real-client-id",
+            client_secret=_SecretStr("real-client-secret"),
+            authorize_url="https://github.com/login/oauth/authorize",
+            token_url="https://github.com/login/oauth/access_token",
+            default_scopes=["repo"],
+        )
+
+        resource_meta_response = _mock_http_response(
+            200,
+            {"authorization_servers": ["https://github.com/login/oauth"]},
+        )
+        www_auth_header = 'Bearer resource_metadata="https://api.githubcopilot.com/.well-known/oauth-protected-resource/mcp/"'
+        probe_401_response = _mock_http_response(
+            401,
+            {},
+            {"www-authenticate": www_auth_header, "content-type": "text/plain"},
+        )
+
+        discovery = self._make_discovery()
+
+        async def fake_post(*args, **kwargs):
+            return probe_401_response
+
+        async def fake_get(url, **kwargs):
+            return resource_meta_response
+
+        with (
+            patch("svc_infra.connect.mcp_discovery._registry") as mock_reg,
+            patch.object(
+                discovery,
+                "_probe_resource_metadata_url",
+                return_value="https://api.githubcopilot.com/.well-known/oauth-protected-resource/mcp/",
+            ),
+            patch.object(
+                discovery,
+                "_fetch_resource_metadata",
+                return_value={"authorization_servers": ["https://github.com/login/oauth"]},
+            ),
+        ):
+            mock_reg.list.return_value = [github_provider]
+            # _fetch_auth_server_metadata must NOT be called for this path
+            with patch.object(
+                discovery,
+                "_fetch_auth_server_metadata",
+                side_effect=AssertionError("should not be called"),
+            ):
+                result = await discovery.discover("https://api.githubcopilot.com/mcp/")
+
+        assert result is github_provider
+        assert result.client_id == "real-client-id"

--- a/tests/unit/middleware/test_error_handlers.py
+++ b/tests/unit/middleware/test_error_handlers.py
@@ -170,3 +170,83 @@ class TestProblemMediaType:
     def test_correct_media_type(self) -> None:
         """Media type is application/problem+json."""
         assert PROBLEM_MT == "application/problem+json"
+
+
+class TestHTTPExceptionHandlerDictDetail:
+    """Verify that HTTPException with dict/list detail is preserved, not stringified."""
+
+    def test_dict_detail_preserved_in_json_response(self) -> None:
+        """Dict detail is returned as structured JSON, not str(detail)."""
+        from fastapi import FastAPI
+        from fastapi import HTTPException as _HTTPException
+        from fastapi.testclient import TestClient
+
+        from svc_infra.api.fastapi.middleware.errors.handlers import register_error_handlers
+
+        app = FastAPI()
+        register_error_handlers(app)
+
+        @app.get("/oauth-502")
+        async def oauth_trigger():
+            raise _HTTPException(
+                status_code=502,
+                detail={
+                    "error": "Unauthorized",
+                    "oauth_supported": True,
+                    "authorize_url": "https://github.com/login/oauth/authorize?client_id=abc",
+                },
+            )
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/oauth-502")
+        assert resp.status_code == 502
+        body = resp.json()
+        # detail must be a dict, not a stringified repr
+        assert isinstance(body["detail"], dict)
+        assert body["detail"]["oauth_supported"] is True
+        assert body["detail"]["authorize_url"].startswith("https://github.com/")
+
+    def test_list_detail_preserved_in_json_response(self) -> None:
+        """List detail is returned as structured JSON, not str(detail)."""
+        from fastapi import FastAPI
+        from fastapi import HTTPException as _HTTPException
+        from fastapi.testclient import TestClient
+
+        from svc_infra.api.fastapi.middleware.errors.handlers import register_error_handlers
+
+        app = FastAPI()
+        register_error_handlers(app)
+
+        @app.get("/list-detail")
+        async def list_trigger():
+            raise _HTTPException(status_code=400, detail=[{"field": "email", "error": "required"}])
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/list-detail")
+        assert resp.status_code == 400
+        body = resp.json()
+        assert isinstance(body["detail"], list)
+        assert body["detail"][0]["field"] == "email"
+
+    def test_string_detail_uses_problem_json(self) -> None:
+        """String detail still returns RFC 7807 problem+json."""
+        from fastapi import FastAPI
+        from fastapi import HTTPException as _HTTPException
+        from fastapi.testclient import TestClient
+
+        from svc_infra.api.fastapi.middleware.errors.handlers import register_error_handlers
+
+        app = FastAPI()
+        register_error_handlers(app)
+
+        @app.get("/string-detail")
+        async def string_trigger():
+            raise _HTTPException(status_code=404, detail="Resource not found")
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/string-detail")
+        assert resp.status_code == 404
+        body = resp.json()
+        assert body["detail"] == "Resource not found"
+        assert body["title"] == "Not Found"
+        assert resp.headers["content-type"].startswith("application/problem+json")


### PR DESCRIPTION
fix: preserve dict/list detail in HTTPException error handlers and enhance MCP OAuth discovery