### PR TITLE
feat: complete MCP OAuth flow with RFC 9728 well-known fallback, dynamic registration, and public client support

### DIFF
--- a/src/svc_infra/connect/mcp_discovery.py
+++ b/src/svc_infra/connect/mcp_discovery.py
@@ -4,6 +4,7 @@ import logging
 import re
 import time
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from pydantic import SecretStr
@@ -23,6 +24,20 @@ class MCPOAuthNotSupported(Exception):
 
 _DISCOVERY_CACHE: dict[str, tuple[OAuthProvider, float]] = {}
 _CACHE_TTL_SECONDS = 3600  # MCP server metadata rarely changes
+
+
+def _origin_url(url: str) -> str:
+    """Extract the origin (scheme + authority) from a URL.
+
+    RFC 9728 well-known endpoints live at the origin level, not relative
+    to the resource path.  For ``https://mcp.notion.com/mcp`` this returns
+    ``https://mcp.notion.com``.
+    """
+    parsed = urlparse(url)
+    origin = f"{parsed.scheme}://{parsed.hostname or 'localhost'}"
+    if parsed.port:
+        origin += f":{parsed.port}"
+    return origin
 
 
 def parse_www_authenticate(header: str) -> dict[str, str]:
@@ -48,10 +63,19 @@ class MCPOAuthDiscovery:
     refreshing the token; protocol internals remain in ai-infra.
     """
 
-    async def discover(self, mcp_server_url: str) -> OAuthProvider:
+    async def discover(
+        self,
+        mcp_server_url: str,
+        *,
+        api_base: str | None = None,
+    ) -> OAuthProvider:
         """Discover a fully-populated OAuthProvider for the given MCP server URL.
 
         Results are cached in-process for 1 hour.
+
+        When *api_base* is provided and the authorization server advertises a
+        ``registration_endpoint`` (RFC 7591), the client is dynamically
+        registered so a valid ``client_id`` is obtained automatically.
 
         Raises MCPOAuthNotSupported if:
         - The server does not implement RFC 9728 resource metadata
@@ -99,14 +123,27 @@ class MCPOAuthDiscovery:
         auth_meta = await self._fetch_auth_server_metadata(auth_server_url)
 
         provider = self._build_provider(mcp_server_url, auth_meta)
+
+        # Dynamic client registration (RFC 7591): when no pre-configured
+        # client_id exists and the auth server offers a registration endpoint,
+        # register automatically to obtain credentials.
+        registration_endpoint = auth_meta.get("registration_endpoint")
+        if not provider.client_id and registration_endpoint and api_base:
+            redirect_uri = f"{api_base}/connect/callback/{provider.name}"
+            provider = await self._register_dynamic_client(
+                provider, registration_endpoint, redirect_uri
+            )
+
         _DISCOVERY_CACHE[mcp_server_url] = (provider, now)
         return provider
 
     async def is_mcp_oauth_supported(self, mcp_server_url: str) -> bool:
-        """Lightweight check: probe the MCP server and inspect the 401 response headers.
+        """Check whether the MCP server requires OAuth authorization.
 
-        Returns True if the server returns a WWW-Authenticate: Bearer header containing
-        resource_metadata, indicating it implements RFC 9728.
+        First probes the server for a 401 response with a WWW-Authenticate:
+        Bearer header (RFC 9728 §3).  If the server does not return 401 (some
+        servers return 404 for unauthenticated requests), falls back to
+        checking the well-known resource metadata endpoint directly.
         """
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
@@ -123,32 +160,73 @@ class MCPOAuthDiscovery:
                     "www_auth": response.headers.get("www-authenticate", ""),
                 },
             )
-            if response.status_code != 401:
+            if response.status_code == 401:
+                www_auth = response.headers.get("www-authenticate", "")
+                if www_auth.lower().startswith("bearer"):
+                    parsed = parse_www_authenticate(www_auth)
+                    if "resource_metadata" in parsed:
+                        logger.info(
+                            "OAuth probe: 401 with resource_metadata",
+                            extra={"url": mcp_server_url, "parsed_keys": list(parsed.keys())},
+                        )
+                        return True
+
+            # 401 without resource_metadata field — some servers (e.g.
+            # Notion /mcp) return a plain Bearer challenge.  Fall through to
+            # the well-known check below.
+            if response.status_code == 401:
                 logger.debug(
-                    "OAuth probe: not 401, returning False",
-                    extra={"url": mcp_server_url, "status": response.status_code},
-                )
-                return False
-            www_auth = response.headers.get("www-authenticate", "")
-            if not www_auth.lower().startswith("bearer"):
-                logger.debug(
-                    "OAuth probe: no bearer www-authenticate, returning False",
+                    "OAuth probe: 401 without resource_metadata, trying well-known",
                     extra={"url": mcp_server_url},
                 )
-                return False
-            parsed = parse_www_authenticate(www_auth)
-            result = "resource_metadata" in parsed
-            logger.info(
-                "OAuth probe: resource_metadata=%s",
-                result,
-                extra={"url": mcp_server_url, "parsed_keys": list(parsed.keys())},
+                return await self._check_wellknown_resource_metadata(mcp_server_url)
+
+            # Server did not return 401 — fall back to checking the well-known
+            # endpoint directly.  Some servers (e.g. Notion) return 404 for
+            # unauthenticated requests but still publish RFC 9728 metadata.
+            logger.debug(
+                "OAuth probe: no 401, trying well-known fallback",
+                extra={"url": mcp_server_url, "status": response.status_code},
             )
-            return result
+            return await self._check_wellknown_resource_metadata(mcp_server_url)
         except (httpx.RequestError, httpx.HTTPStatusError) as exc:
             logger.warning(
                 "OAuth probe request failed", extra={"url": mcp_server_url, "error": str(exc)}
             )
             return False
+
+    async def _check_wellknown_resource_metadata(self, mcp_server_url: str) -> bool:
+        """GET the well-known resource metadata URL and check for authorization_servers."""
+        url = _origin_url(mcp_server_url) + "/.well-known/oauth-protected-resource"
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(url, headers={"Accept": "application/json"})
+        except httpx.RequestError as exc:
+            logger.debug(
+                "Well-known fallback request failed",
+                extra={"url": url, "error": str(exc)},
+            )
+            return False
+
+        if response.status_code != 200:
+            logger.debug(
+                "Well-known fallback: non-200",
+                extra={"url": url, "status": response.status_code},
+            )
+            return False
+
+        try:
+            data = response.json()
+        except Exception:
+            return False
+
+        result = bool(data.get("authorization_servers"))
+        logger.info(
+            "Well-known fallback: authorization_servers=%s",
+            result,
+            extra={"url": url},
+        )
+        return result
 
     async def _fetch_resource_metadata(self, mcp_server_url: str) -> dict[str, Any]:
         # RFC 9728 §3: the protected resource advertises its metadata URL in the
@@ -187,7 +265,7 @@ class MCPOAuthDiscovery:
         (``<mcp_server_url>/.well-known/oauth-protected-resource``) if the
         server does not include the field or is unreachable.
         """
-        default = mcp_server_url.rstrip("/") + "/.well-known/oauth-protected-resource"
+        default = _origin_url(mcp_server_url) + "/.well-known/oauth-protected-resource"
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 response = await client.post(
@@ -256,8 +334,9 @@ class MCPOAuthDiscovery:
             if existing.authorize_url.rstrip("/") == authorize_url.rstrip("/"):
                 return existing
 
+        hostname = urlparse(mcp_server_url).hostname or "unknown"
         return OAuthProvider(
-            name=f"mcp:{mcp_server_url}",
+            name=f"mcp-{hostname}",
             client_id="",
             client_secret=SecretStr(""),
             authorize_url=authorize_url,
@@ -267,4 +346,75 @@ class MCPOAuthDiscovery:
             pkce_required=pkce_required,
             extra_authorize_params={},
             userinfo_url=None,
+        )
+
+    async def _register_dynamic_client(
+        self,
+        provider: OAuthProvider,
+        registration_endpoint: str,
+        redirect_uri: str,
+    ) -> OAuthProvider:
+        """RFC 7591 Dynamic Client Registration.
+
+        Registers with the authorization server to obtain a ``client_id``.
+        Returns a new OAuthProvider with the credentials populated.
+        Falls back to the original provider (empty client_id) on failure.
+        """
+        body = {
+            "client_name": "nfrax-connect",
+            "redirect_uris": [redirect_uri],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+        }
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                response = await client.post(
+                    registration_endpoint,
+                    json=body,
+                    headers={"Content-Type": "application/json"},
+                )
+        except httpx.RequestError as exc:
+            logger.warning(
+                "Dynamic client registration request failed: %s",
+                exc,
+                extra={"endpoint": registration_endpoint},
+            )
+            return provider
+
+        if response.status_code not in (200, 201):
+            logger.warning(
+                "Dynamic client registration returned %d",
+                response.status_code,
+                extra={
+                    "endpoint": registration_endpoint,
+                    "body": response.text[:500],
+                },
+            )
+            return provider
+
+        try:
+            data = response.json()
+        except Exception:
+            logger.warning("Dynamic client registration response is not valid JSON")
+            return provider
+
+        client_id = data.get("client_id", "")
+        client_secret = data.get("client_secret", "")
+        if not client_id:
+            logger.warning("Dynamic client registration response missing client_id")
+            return provider
+
+        logger.info(
+            "Dynamic client registered: client_id=%s provider=%s",
+            client_id,
+            provider.name,
+            extra={"endpoint": registration_endpoint},
+        )
+
+        return provider.model_copy(
+            update={
+                "client_id": client_id,
+                "client_secret": SecretStr(client_secret) if client_secret else SecretStr(""),
+            }
         )

--- a/src/svc_infra/connect/pkce.py
+++ b/src/svc_infra/connect/pkce.py
@@ -126,8 +126,10 @@ async def exchange_code(
         "code": code,
         "redirect_uri": redirect_uri,
         "client_id": provider.client_id,
-        "client_secret": provider.client_secret.get_secret_value(),
     }
+    secret = provider.client_secret.get_secret_value()
+    if secret:
+        payload["client_secret"] = secret
     if provider.pkce_required:
         payload["code_verifier"] = pkce_verifier
 
@@ -162,8 +164,10 @@ async def exchange_refresh(
         "grant_type": "refresh_token",
         "refresh_token": refresh_token_str,
         "client_id": provider.client_id,
-        "client_secret": provider.client_secret.get_secret_value(),
     }
+    secret = provider.client_secret.get_secret_value()
+    if secret:
+        payload["client_secret"] = secret
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.post(

--- a/src/svc_infra/connect/router.py
+++ b/src/svc_infra/connect/router.py
@@ -60,7 +60,9 @@ async def authorize(
 
     if mcp_server_url is not None:
         try:
-            resolved_provider = await _mcp_discovery.discover(mcp_server_url)
+            resolved_provider = await _mcp_discovery.discover(
+                mcp_server_url, api_base=settings.connect_api_base or None
+            )
             _default_registry.register(resolved_provider)
             provider = resolved_provider.name
         except MCPOAuthNotSupported as exc:
@@ -101,10 +103,11 @@ async def authorize(
 
 @connect_router.get("/callback/{provider}")
 async def callback(
+    request: Request,
     provider: str,
     db: SqlSessionDep,
-    code: str = Query(...),
-    state: str = Query(...),
+    code: str | None = Query(None),
+    state: str | None = Query(None),
     error: str | None = Query(None),
     error_description: str | None = Query(None),
 ) -> RedirectResponse:
@@ -114,6 +117,31 @@ async def callback(
     """
     settings = get_connect_settings()
     token_manager = get_connect_token_manager()
+    fallback_redirect = settings.connect_default_redirect_uri
+
+    logger.info(
+        "OAuth callback received: provider=%s query=%s",
+        provider,
+        dict(request.query_params),
+    )
+
+    if error:
+        logger.warning(
+            "OAuth callback error from provider=%s: %s (%s)",
+            provider,
+            error,
+            error_description,
+        )
+        return RedirectResponse(url=f"{fallback_redirect}?error={error}", status_code=302)
+
+    if not code or not state:
+        logger.error(
+            "OAuth callback missing required params: provider=%s code=%s state=%s",
+            provider,
+            bool(code),
+            bool(state),
+        )
+        return RedirectResponse(url=f"{fallback_redirect}?error=missing_params", status_code=302)
 
     from sqlalchemy import and_, select
 
@@ -131,21 +159,33 @@ async def callback(
     if oauth_state is None:
         logger.warning("OAuth callback: no valid state found for provider=%s", provider)
         return RedirectResponse(
-            url=f"{settings.connect_default_redirect_uri}?error=invalid_state",
+            url=f"{fallback_redirect}?error=invalid_state",
             status_code=302,
         )
 
-    fallback_redirect = oauth_state.redirect_uri or settings.connect_default_redirect_uri
-
-    if error:
-        logger.warning("OAuth callback error from provider=%s: %s", provider, error)
-        await db.delete(oauth_state)
-        await db.flush()
-        return RedirectResponse(url=f"{fallback_redirect}?error={error}", status_code=302)
+    fallback_redirect = oauth_state.redirect_uri or fallback_redirect
 
     resolved_provider = _default_registry.get(provider)
     if resolved_provider is None:
-        logger.error("OAuth callback: provider '%s' not in registry", provider)
+        # Provider not in registry — attempt re-discovery for dynamically
+        # registered MCP providers that may have been lost on restart.
+        logger.warning(
+            "OAuth callback: provider '%s' not in registry, attempting re-discovery",
+            provider,
+        )
+        if provider.startswith("mcp-") and settings.connect_api_base:
+            mcp_url = "https://" + provider.removeprefix("mcp-")
+            try:
+                resolved_provider = await _mcp_discovery.discover(
+                    mcp_url, api_base=settings.connect_api_base
+                )
+                _default_registry.register(resolved_provider)
+                logger.info("OAuth callback: re-discovered provider '%s'", provider)
+            except MCPOAuthNotSupported:
+                logger.error("OAuth callback: re-discovery failed for '%s'", provider)
+
+    if resolved_provider is None:
+        logger.error("OAuth callback: provider '%s' not found after re-discovery", provider)
         await db.delete(oauth_state)
         await db.flush()
         return RedirectResponse(
@@ -169,6 +209,12 @@ async def callback(
     connection_id = oauth_state.connection_id
     user_id = oauth_state.user_id
     assert connection_id is not None
+
+    logger.info(
+        "OAuth token exchange succeeded: provider=%s connection_id=%s",
+        provider,
+        connection_id,
+    )
 
     await db.delete(oauth_state)
     await token_manager.store(

--- a/tests/unit/connect/test_mcp_discovery.py
+++ b/tests/unit/connect/test_mcp_discovery.py
@@ -82,7 +82,7 @@ class TestMCPOAuthDiscovery:
         ):
             provider = await discovery.discover("https://mcp.example.com")
 
-        assert provider.name == "mcp:https://mcp.example.com"
+        assert provider.name == "mcp-mcp.example.com"
         assert provider.authorize_url == "https://auth.example.com/authorize"
         assert provider.token_url == "https://auth.example.com/token"
 
@@ -378,7 +378,7 @@ class TestMCPOAuthDiscovery:
             result = discovery._build_provider("https://mcp.example.com/", auth_meta)
 
         assert result.client_id == ""
-        assert result.name == "mcp:https://mcp.example.com/"
+        assert result.name == "mcp-mcp.example.com"
 
     @pytest.mark.asyncio
     async def test_discover_uses_registry_shortcut_for_providers_without_rfc8414(self):
@@ -442,3 +442,256 @@ class TestMCPOAuthDiscovery:
 
         assert result is github_provider
         assert result.client_id == "real-client-id"
+
+
+class TestWellKnownFallback:
+    """Tests for the .well-known/oauth-protected-resource fallback."""
+
+    @pytest.mark.asyncio
+    async def test_wellknown_fallback_when_server_returns_404(self):
+        """OAuth is detected when the server returns 404 (not 401) but publishes .well-known."""
+        from svc_infra.connect.mcp_discovery import MCPOAuthDiscovery
+
+        discovery = MCPOAuthDiscovery()
+
+        # Server returns 404 for POST (like Notion)
+        mock_post_resp = MagicMock()
+        mock_post_resp.status_code = 404
+        mock_post_resp.headers = {}
+
+        # .well-known returns valid metadata
+        mock_wellknown_resp = MagicMock()
+        mock_wellknown_resp.status_code = 200
+        mock_wellknown_resp.json.return_value = {
+            "resource": "https://mcp.notion.com",
+            "authorization_servers": ["https://mcp.notion.com"],
+        }
+
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient") as MockClient:
+            client_instance = AsyncMock()
+            client_instance.post.return_value = mock_post_resp
+            client_instance.get.return_value = mock_wellknown_resp
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=client_instance)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await discovery.is_mcp_oauth_supported("https://mcp.notion.com/")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_wellknown_fallback_returns_false_when_no_metadata(self):
+        """OAuth is not detected when .well-known also fails."""
+        from svc_infra.connect.mcp_discovery import MCPOAuthDiscovery
+
+        discovery = MCPOAuthDiscovery()
+
+        mock_post_resp = MagicMock()
+        mock_post_resp.status_code = 404
+        mock_post_resp.headers = {}
+
+        mock_wellknown_resp = MagicMock()
+        mock_wellknown_resp.status_code = 404
+
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient") as MockClient:
+            client_instance = AsyncMock()
+            client_instance.post.return_value = mock_post_resp
+            client_instance.get.return_value = mock_wellknown_resp
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=client_instance)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await discovery.is_mcp_oauth_supported("https://mcp.example.com/")
+
+        assert result is False
+
+
+class TestDynamicClientRegistration:
+    """Tests for RFC 7591 dynamic client registration."""
+
+    @pytest.mark.asyncio
+    async def test_dynamic_registration_populates_client_id(self):
+        """When auth server has registration_endpoint, discover() registers dynamically."""
+        from svc_infra.connect.mcp_discovery import _DISCOVERY_CACHE, MCPOAuthDiscovery
+
+        _DISCOVERY_CACHE.clear()
+        discovery = MCPOAuthDiscovery()
+
+        resource_meta = {
+            "authorization_servers": ["https://mcp.notion.com"],
+        }
+        auth_meta = {
+            "authorization_endpoint": "https://mcp.notion.com/authorize",
+            "token_endpoint": "https://mcp.notion.com/token",
+            "registration_endpoint": "https://mcp.notion.com/register",
+            "code_challenge_methods_supported": ["S256"],
+        }
+        registration_response = {
+            "client_id": "dynamic-client-abc",
+            "client_secret": "",
+        }
+
+        with (
+            patch.object(
+                discovery,
+                "_fetch_resource_metadata",
+                new_callable=AsyncMock,
+                return_value=resource_meta,
+            ),
+            patch.object(
+                discovery,
+                "_fetch_auth_server_metadata",
+                new_callable=AsyncMock,
+                return_value=auth_meta,
+            ),
+            patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient") as MockClient,
+        ):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 201
+            mock_resp.json.return_value = registration_response
+            client_instance = AsyncMock()
+            client_instance.post.return_value = mock_resp
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=client_instance)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            provider = await discovery.discover(
+                "https://mcp.notion.com/",
+                api_base="http://127.0.0.1:8765",
+            )
+
+        assert provider.client_id == "dynamic-client-abc"
+        assert provider.name == "mcp-mcp.notion.com"
+        assert provider.authorize_url == "https://mcp.notion.com/authorize"
+
+    @pytest.mark.asyncio
+    async def test_no_registration_without_api_base(self):
+        """Without api_base, discover() skips dynamic registration."""
+        from svc_infra.connect.mcp_discovery import _DISCOVERY_CACHE, MCPOAuthDiscovery
+
+        _DISCOVERY_CACHE.clear()
+        discovery = MCPOAuthDiscovery()
+
+        resource_meta = {"authorization_servers": ["https://mcp.notion.com"]}
+        auth_meta = {
+            "authorization_endpoint": "https://mcp.notion.com/authorize",
+            "token_endpoint": "https://mcp.notion.com/token",
+            "registration_endpoint": "https://mcp.notion.com/register",
+        }
+
+        with (
+            patch.object(
+                discovery,
+                "_fetch_resource_metadata",
+                new_callable=AsyncMock,
+                return_value=resource_meta,
+            ),
+            patch.object(
+                discovery,
+                "_fetch_auth_server_metadata",
+                new_callable=AsyncMock,
+                return_value=auth_meta,
+            ),
+        ):
+            provider = await discovery.discover("https://mcp.notion.com/")
+
+        assert provider.client_id == ""  # no registration attempted
+
+
+class TestOriginUrl:
+    """Tests for _origin_url — RFC 9728 well-known endpoints live at origin level."""
+
+    def test_url_without_path(self):
+        from svc_infra.connect.mcp_discovery import _origin_url
+
+        assert _origin_url("https://mcp.example.com") == "https://mcp.example.com"
+
+    def test_url_with_path(self):
+        from svc_infra.connect.mcp_discovery import _origin_url
+
+        assert _origin_url("https://mcp.notion.com/mcp") == "https://mcp.notion.com"
+
+    def test_url_with_trailing_slash(self):
+        from svc_infra.connect.mcp_discovery import _origin_url
+
+        assert _origin_url("https://mcp.example.com/") == "https://mcp.example.com"
+
+    def test_url_with_port(self):
+        from svc_infra.connect.mcp_discovery import _origin_url
+
+        assert _origin_url("https://localhost:8080/mcp/v1") == "https://localhost:8080"
+
+    def test_url_with_deep_path(self):
+        from svc_infra.connect.mcp_discovery import _origin_url
+
+        assert _origin_url("https://api.example.com/v2/mcp/endpoint") == "https://api.example.com"
+
+
+class TestOriginUrlInWellKnown:
+    """Verify well-known URL construction uses origin, not full path."""
+
+    @pytest.mark.asyncio
+    async def test_probe_falls_back_to_origin_wellknown_for_path_url(self):
+        """For https://mcp.notion.com/mcp, default should be
+        https://mcp.notion.com/.well-known/..., NOT .../mcp/.well-known/..."""
+        mock_resp = _mock_http_response(200, {}, headers={})
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        discovery = MCPOAuthDiscovery()
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+            url = await discovery._probe_resource_metadata_url("https://mcp.notion.com/mcp")
+
+        assert url == "https://mcp.notion.com/.well-known/oauth-protected-resource"
+
+    @pytest.mark.asyncio
+    async def test_wellknown_check_uses_origin_for_path_url(self):
+        """_check_wellknown_resource_metadata for a path URL hits origin."""
+        mock_wellknown_resp = MagicMock()
+        mock_wellknown_resp.status_code = 200
+        mock_wellknown_resp.json.return_value = {
+            "resource": "https://mcp.notion.com",
+            "authorization_servers": ["https://mcp.notion.com"],
+        }
+
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient") as MockClient:
+            client_instance = AsyncMock()
+            client_instance.get.return_value = mock_wellknown_resp
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=client_instance)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            discovery = MCPOAuthDiscovery()
+            result = await discovery._check_wellknown_resource_metadata(
+                "https://mcp.notion.com/mcp"
+            )
+
+        assert result is True
+        # Verify the GET was to the origin, not the path
+        call_args = client_instance.get.call_args
+        assert call_args[0][0] == "https://mcp.notion.com/.well-known/oauth-protected-resource"
+
+    @pytest.mark.asyncio
+    async def test_is_mcp_oauth_supported_401_without_resource_metadata(self):
+        """401 + Bearer but no resource_metadata field falls through to well-known check."""
+        mock_post_resp = _mock_http_response(
+            401,
+            {},
+            headers={"www-authenticate": 'Bearer realm="OAuth", error="invalid_token"'},
+        )
+        mock_wellknown_resp = MagicMock()
+        mock_wellknown_resp.status_code = 200
+        mock_wellknown_resp.json.return_value = {
+            "resource": "https://mcp.notion.com",
+            "authorization_servers": ["https://mcp.notion.com"],
+        }
+
+        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient") as MockClient:
+            client_instance = AsyncMock()
+            client_instance.post.return_value = mock_post_resp
+            client_instance.get.return_value = mock_wellknown_resp
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=client_instance)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            discovery = MCPOAuthDiscovery()
+            result = await discovery.is_mcp_oauth_supported("https://mcp.notion.com/mcp")
+
+        assert result is True

--- a/tests/unit/connect/test_router.py
+++ b/tests/unit/connect/test_router.py
@@ -281,6 +281,68 @@ class TestCallbackEndpoint:
         assert resp.status_code == 302
         assert "exchange_failed" in resp.headers["location"]
 
+    async def test_callback_missing_code_redirects_with_error(self, connect_client):
+        client, _, _, _ = connect_client
+
+        resp = await client.get(
+            "/connect/callback/github",
+            params={"state": "some_state"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert "error=missing_params" in resp.headers["location"]
+
+    async def test_callback_missing_state_redirects_with_error(self, connect_client):
+        client, _, _, _ = connect_client
+
+        resp = await client.get(
+            "/connect/callback/github",
+            params={"code": "some_code"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert "error=missing_params" in resp.headers["location"]
+
+    async def test_callback_provider_rediscovery(self, connect_client):
+        """When provider is not in registry, callback attempts re-discovery for MCP providers."""
+        client, mock_db, token_manager, reg = connect_client
+        oauth_state = self._make_oauth_state(token_manager, provider="mcp-mcp.example.com")
+
+        async def _execute(_stmt):
+            result = MagicMock()
+            scalars = MagicMock()
+            scalars.first = MagicMock(return_value=oauth_state)
+            result.scalars = MagicMock(return_value=scalars)
+            return result
+
+        mock_db.execute = _execute
+
+        mock_provider = _make_provider()
+        mock_provider = mock_provider.model_copy(update={"name": "mcp-mcp.example.com"})
+
+        with (
+            patch("svc_infra.connect.router._mcp_discovery") as mock_disc,
+            patch(
+                "svc_infra.connect.router.exchange_code",
+                new_callable=AsyncMock,
+                return_value={"access_token": "tok", "token_type": "Bearer"},
+            ),
+            patch.object(token_manager, "store", new_callable=AsyncMock, return_value=MagicMock()),
+        ):
+            mock_disc.discover = AsyncMock(return_value=mock_provider)
+
+            resp = await client.get(
+                "/connect/callback/mcp-mcp.example.com",
+                params={"code": "auth_code_123", "state": "valid_state"},
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert "success=true" in resp.headers["location"]
+        mock_disc.discover.assert_awaited_once()
+
 
 @pytest.mark.asyncio
 class TestGetTokenEndpoint:


### PR DESCRIPTION
feat: complete MCP OAuth flow with RFC 9728 well-known fallback, dynamic registration, and public client support