### PR TITLE
feat(connect): harden OAuth module with security, resilience and SDK reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Stop rebuilding auth, billing, webhooks, and background jobs for every project.
 ### Key Features
 
 - **Auth** - JWT, sessions, OAuth/OIDC, MFA, API keys
+- **Connect** - Third-party OAuth, MCP server discovery, token management
 - **Billing** - Usage tracking, subscriptions, invoices, Stripe sync
 - **Database** - PostgreSQL + MongoDB, migrations, inbox/outbox
 - **Jobs** - Background tasks, scheduling, retries, DLQ
@@ -47,6 +48,7 @@ pip install svc-infra
 | Feature | What You Get | One-liner |
 |---------|-------------|-----------|
 | **Auth** | JWT, sessions, OAuth/OIDC, MFA, API keys | `add_auth_users(app)` |
+| **Connect** | Third-party OAuth, MCP server discovery, token management | `add_connect(app)` |
 | **Billing** | Usage tracking, subscriptions, invoices, Stripe sync | `add_billing(app)` |
 | **Database** | PostgreSQL + MongoDB, migrations, inbox/outbox | `add_sql_db(app)` |
 | **Jobs** | Background tasks, scheduling, retries, DLQ | `easy_jobs()` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,8 @@ nav:
   - Core Features:
       - API Framework: api.md
       - Authentication: auth.md
+      - Connect (OAuth): connect.md
+      - MCP OAuth Discovery: connect-mcp-oauth.md
       - Database: database.md
       - Caching: cache.md
       - Security: security.md

--- a/src/svc_infra/api/fastapi/db/sql/__init__.py
+++ b/src/svc_infra/api/fastapi/db/sql/__init__.py
@@ -3,11 +3,12 @@ from svc_infra.api.fastapi.db.sql.add import (
     add_sql_health,
     add_sql_resources,
 )
-from svc_infra.api.fastapi.db.sql.session import SqlSessionDep
+from svc_infra.api.fastapi.db.sql.session import SqlSessionDep, get_session_factory
 
 __all__ = [
     "SqlSessionDep",
     "add_sql_health",
     "add_sql_db",
     "add_sql_resources",
+    "get_session_factory",
 ]

--- a/src/svc_infra/api/fastapi/db/sql/session.py
+++ b/src/svc_infra/api/fastapi/db/sql/session.py
@@ -80,4 +80,15 @@ async def get_session() -> AsyncIterator[AsyncSession]:
 
 SqlSessionDep = Annotated[AsyncSession, Depends(get_session)]
 
-__all__ = ["SqlSessionDep", "initialize_session", "dispose_session"]
+
+def get_session_factory() -> async_sessionmaker[AsyncSession] | None:
+    """Return the module-level async session factory, or None if not initialised.
+
+    This is the public API for code that needs to create sessions outside of a
+    FastAPI request context (e.g. background jobs, closures).  Prefer
+    ``SqlSessionDep`` inside request handlers.
+    """
+    return _SessionLocal
+
+
+__all__ = ["SqlSessionDep", "initialize_session", "dispose_session", "get_session_factory"]

--- a/src/svc_infra/connect/add.py
+++ b/src/svc_infra/connect/add.py
@@ -73,14 +73,15 @@ def add_connect(app: FastAPI, *, prefix: str = "/connect") -> None:
 
         _, scheduler = easy_jobs()
 
-        from svc_infra.api.fastapi.db.sql.session import _SessionLocal
+        from svc_infra.api.fastapi.db.sql import get_session_factory
 
         async def _refresh_task() -> None:
-            if _SessionLocal is None:
+            session_factory = get_session_factory()
+            if session_factory is None:
                 logger.warning("connect: DB not initialised, skipping token refresh")
                 return
             try:
-                async with _SessionLocal() as db:
+                async with session_factory() as db:
                     count = await token_manager.refresh_expiring_tokens(db)
                     await db.commit()
                     if count:
@@ -89,11 +90,12 @@ def add_connect(app: FastAPI, *, prefix: str = "/connect") -> None:
                 logger.error("connect: token refresh background task failed: %s", exc)
 
         async def _cleanup_expired_states() -> None:
-            if _SessionLocal is None:
+            session_factory = get_session_factory()
+            if session_factory is None:
                 logger.warning("connect: DB not initialised, skipping state cleanup")
                 return
             try:
-                async with _SessionLocal() as db:
+                async with session_factory() as db:
                     result = await db.execute(
                         delete(OAuthState).where(OAuthState.expires_at <= datetime.now(UTC))
                     )
@@ -104,8 +106,23 @@ def add_connect(app: FastAPI, *, prefix: str = "/connect") -> None:
             except Exception as exc:
                 logger.error("connect: OAuthState cleanup task failed: %s", exc)
 
+        async def _cleanup_expired_tokens() -> None:
+            session_factory = get_session_factory()
+            if session_factory is None:
+                logger.warning("connect: DB not initialised, skipping token cleanup")
+                return
+            try:
+                async with session_factory() as db:
+                    count = await token_manager.cleanup_expired_tokens(db)
+                    await db.commit()
+                    if count:
+                        logger.debug("connect: purged %d expired token rows", count)
+            except Exception as exc:
+                logger.error("connect: token cleanup task failed: %s", exc)
+
         scheduler.add_task("connect:refresh_tokens", 300, _refresh_task)
         scheduler.add_task("connect:cleanup_states", 600, _cleanup_expired_states)
+        scheduler.add_task("connect:cleanup_tokens", 3600, _cleanup_expired_tokens)
         scheduler_task = asyncio.create_task(scheduler.run())
 
         if existing_lifespan is not None:

--- a/src/svc_infra/connect/mcp_discovery.py
+++ b/src/svc_infra/connect/mcp_discovery.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+import threading
 import time
 from typing import Any
 from urllib.parse import urlparse
@@ -11,6 +12,7 @@ from pydantic import SecretStr
 
 from svc_infra.connect.registry import OAuthProvider
 from svc_infra.connect.registry import registry as _registry
+from svc_infra.http import new_async_httpx_client
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +25,7 @@ class MCPOAuthNotSupported(Exception):
 
 
 _DISCOVERY_CACHE: dict[str, tuple[OAuthProvider, float]] = {}
+_CACHE_LOCK = threading.Lock()
 _CACHE_TTL_SECONDS = 3600  # MCP server metadata rarely changes
 
 
@@ -82,7 +85,8 @@ class MCPOAuthDiscovery:
         - The authorization server metadata is unreachable or malformed
         """
         now = time.monotonic()
-        cached = _DISCOVERY_CACHE.get(mcp_server_url)
+        with _CACHE_LOCK:
+            cached = _DISCOVERY_CACHE.get(mcp_server_url)
         if cached is not None:
             provider, ts = cached
             if now - ts < _CACHE_TTL_SECONDS:
@@ -113,7 +117,8 @@ class MCPOAuthDiscovery:
                     existing.name,
                     extra={"url": mcp_server_url},
                 )
-                _DISCOVERY_CACHE[mcp_server_url] = (existing, now)
+                with _CACHE_LOCK:
+                    _DISCOVERY_CACHE[mcp_server_url] = (existing, now)
                 return existing
 
         logger.info(
@@ -134,7 +139,8 @@ class MCPOAuthDiscovery:
                 provider, registration_endpoint, redirect_uri
             )
 
-        _DISCOVERY_CACHE[mcp_server_url] = (provider, now)
+        with _CACHE_LOCK:
+            _DISCOVERY_CACHE[mcp_server_url] = (provider, now)
         return provider
 
     async def is_mcp_oauth_supported(self, mcp_server_url: str) -> bool:
@@ -146,7 +152,7 @@ class MCPOAuthDiscovery:
         checking the well-known resource metadata endpoint directly.
         """
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
+            async with new_async_httpx_client(timeout_seconds=10.0) as client:
                 response = await client.post(
                     mcp_server_url,
                     json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
@@ -199,7 +205,7 @@ class MCPOAuthDiscovery:
         """GET the well-known resource metadata URL and check for authorization_servers."""
         url = _origin_url(mcp_server_url) + "/.well-known/oauth-protected-resource"
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
+            async with new_async_httpx_client(timeout_seconds=10.0) as client:
                 response = await client.get(url, headers={"Accept": "application/json"})
         except httpx.RequestError as exc:
             logger.debug(
@@ -234,7 +240,7 @@ class MCPOAuthDiscovery:
         # first so we can use the canonical URL rather than constructing a guess.
         url = await self._probe_resource_metadata_url(mcp_server_url)
         try:
-            async with httpx.AsyncClient(timeout=15.0) as client:
+            async with new_async_httpx_client(timeout_seconds=15.0) as client:
                 response = await client.get(url, headers={"Accept": "application/json"})
         except httpx.RequestError as exc:
             raise MCPOAuthNotSupported(
@@ -267,7 +273,7 @@ class MCPOAuthDiscovery:
         """
         default = _origin_url(mcp_server_url) + "/.well-known/oauth-protected-resource"
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
+            async with new_async_httpx_client(timeout_seconds=10.0) as client:
                 response = await client.post(
                     mcp_server_url,
                     json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
@@ -296,7 +302,7 @@ class MCPOAuthDiscovery:
     async def _fetch_auth_server_metadata(self, auth_server_url: str) -> dict[str, Any]:
         url = auth_server_url + "/.well-known/oauth-authorization-server"
         try:
-            async with httpx.AsyncClient(timeout=15.0) as client:
+            async with new_async_httpx_client(timeout_seconds=15.0) as client:
                 response = await client.get(url, headers={"Accept": "application/json"})
         except httpx.RequestError as exc:
             raise MCPOAuthNotSupported(
@@ -368,7 +374,7 @@ class MCPOAuthDiscovery:
             "token_endpoint_auth_method": "none",
         }
         try:
-            async with httpx.AsyncClient(timeout=15.0) as client:
+            async with new_async_httpx_client(timeout_seconds=15.0) as client:
                 response = await client.post(
                     registration_endpoint,
                     json=body,

--- a/src/svc_infra/connect/models.py
+++ b/src/svc_infra/connect/models.py
@@ -92,7 +92,7 @@ class OAuthState(ModelBase):
     pkce_verifier: Mapped[str] = mapped_column(
         Text,
         nullable=False,
-        comment="Stored server-side; sent to token endpoint on callback",
+        comment="Fernet-encrypted; decrypted only at token exchange time",
     )
     provider: Mapped[str] = mapped_column(String(255), nullable=False)
     connection_id: Mapped[uuid.UUID | None] = mapped_column(
@@ -103,6 +103,7 @@ class OAuthState(ModelBase):
         GUID(),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
+        index=True,
     )
     redirect_uri: Mapped[str] = mapped_column(
         Text,

--- a/src/svc_infra/connect/pkce.py
+++ b/src/svc_infra/connect/pkce.py
@@ -7,10 +7,10 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 from urllib.parse import urlencode, urlparse
 
-import httpx
 from fastapi import HTTPException
 
 from svc_infra.connect.registry import OAuthProvider
+from svc_infra.http import new_async_httpx_client
 
 
 class OAuthExchangeError(Exception):
@@ -133,7 +133,7 @@ async def exchange_code(
     if provider.pkce_required:
         payload["code_verifier"] = pkce_verifier
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with new_async_httpx_client(timeout_seconds=30.0) as client:
         response = await client.post(
             provider.token_url,
             data=payload,
@@ -169,7 +169,7 @@ async def exchange_refresh(
     if secret:
         payload["client_secret"] = secret
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with new_async_httpx_client(timeout_seconds=30.0) as client:
         response = await client.post(
             provider.token_url,
             data=payload,

--- a/src/svc_infra/connect/router.py
+++ b/src/svc_infra/connect/router.py
@@ -25,6 +25,25 @@ from svc_infra.connect.state import get_connect_settings, get_connect_token_mana
 logger = logging.getLogger(__name__)
 _mcp_discovery = MCPOAuthDiscovery()
 
+# Simple in-memory rate limiter for authorize/callback endpoints.
+_RATE_LIMIT_WINDOW = 60  # seconds
+_RATE_LIMIT_MAX_REQUESTS = 30  # per window per user
+_rate_limit_store: dict[str, list[float]] = {}
+
+
+def _check_rate_limit(key: str) -> None:
+    """Raise 429 if the key has exceeded the rate limit."""
+    import time
+
+    now = time.monotonic()
+    entries = _rate_limit_store.get(key, [])
+    entries = [t for t in entries if now - t < _RATE_LIMIT_WINDOW]
+    if len(entries) >= _RATE_LIMIT_MAX_REQUESTS:
+        raise HTTPException(429, "Too many requests. Please try again later.")
+    entries.append(now)
+    _rate_limit_store[key] = entries
+
+
 connect_router = APIRouter(tags=["connect"])
 
 
@@ -45,6 +64,7 @@ async def authorize(
     does not redirect directly to avoid CORS issues with API-first applications.
     """
     settings = get_connect_settings()
+    _check_rate_limit(f"authorize:{principal.user.id}")
 
     if provider is None and mcp_server_url is None:
         raise HTTPException(400, "Either 'provider' or 'mcp_server_url' is required")
@@ -77,9 +97,10 @@ async def authorize(
     state_value = generate_state()
     expires_at = datetime.now(UTC) + timedelta(seconds=settings.connect_state_ttl_seconds)
 
+    token_manager = get_connect_token_manager()
     oauth_state = OAuthState(
         state=state_value,
-        pkce_verifier=pkce_verifier,
+        pkce_verifier=token_manager._encrypt(pkce_verifier),
         provider=provider,
         connection_id=connection_id,
         user_id=principal.user.id,
@@ -118,6 +139,8 @@ async def callback(
     settings = get_connect_settings()
     token_manager = get_connect_token_manager()
     fallback_redirect = settings.connect_default_redirect_uri
+
+    _check_rate_limit(f"callback:{provider}")
 
     logger.info(
         "OAuth callback received: provider=%s query=%s",
@@ -194,10 +217,11 @@ async def callback(
         )
 
     try:
+        decrypted_verifier = token_manager._decrypt(oauth_state.pkce_verifier)
         token_response = await exchange_code(
             resolved_provider,
             code=code,
-            pkce_verifier=oauth_state.pkce_verifier,
+            pkce_verifier=decrypted_verifier,
             redirect_uri=f"{settings.connect_api_base}/connect/callback/{provider}",
         )
     except OAuthExchangeError as exc:
@@ -224,7 +248,11 @@ async def callback(
         provider=provider,
         token_response=token_response,
     )
-    await db.flush()
+    # Explicit commit so the token is guaranteed to be persisted before the
+    # redirect reaches the client.  Relying solely on the session middleware's
+    # auto-commit could race with the deep-link handler that triggers an
+    # immediate sync (which needs the token to be visible in a new session).
+    await db.commit()
 
     return RedirectResponse(
         url=f"{fallback_redirect}?success=true&connection_id={connection_id}",

--- a/src/svc_infra/connect/token_manager.py
+++ b/src/svc_infra/connect/token_manager.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 from uuid import UUID
 
-import httpx
 from cryptography.fernet import Fernet, InvalidToken
-from sqlalchemy import and_, select
+from sqlalchemy import and_, delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from svc_infra.connect.models import ConnectionToken
 from svc_infra.connect.pkce import OAuthRefreshError, coerce_expires_at, exchange_refresh
 from svc_infra.connect.registry import ConnectRegistry
 from svc_infra.db.sql.repository import SqlRepository
+from svc_infra.http import new_async_httpx_client
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,8 @@ class ConnectionTokenManager:
         self._fernet = Fernet(key_bytes)
         self._repo = SqlRepository(model=ConnectionToken)
         self._registry = registry
+        # Guards concurrent refresh attempts for the same token.
+        self._refresh_locks: dict[UUID, asyncio.Lock] = {}
 
     # ------------------------------------------------------------------
     # Encryption helpers
@@ -132,36 +135,36 @@ class ConnectionTokenManager:
     ) -> str | None:
         """Return a decrypted, valid access token; auto-refresh if within 5 minutes of expiry.
 
-        Returns None if no token is stored or refresh fails. Never raises.
+        Returns None if no token is stored or decryption fails.
+        Raises on unexpected DB/network errors so callers can distinguish
+        "no token" from "infrastructure failure".
         """
+        row = await self.get(db, connection_id=connection_id, user_id=user_id, provider=provider)
+        if row is None:
+            return None
+
+        now = datetime.now(UTC)
+        expires_at = row.expires_at
+        if expires_at is not None and expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        needs_refresh = expires_at is not None and expires_at <= now + timedelta(
+            seconds=_REFRESH_AHEAD_SECONDS
+        )
+
+        if needs_refresh and row.refresh_token:
+            row = await self._refresh_token(db, row)
+
+        if row is None:
+            return None
+
         try:
-            row = await self.get(
-                db, connection_id=connection_id, user_id=user_id, provider=provider
-            )
-            if row is None:
-                return None
-
-            now = datetime.now(UTC)
-            expires_at = row.expires_at
-            if expires_at is not None and expires_at.tzinfo is None:
-                expires_at = expires_at.replace(tzinfo=UTC)
-            needs_refresh = expires_at is not None and expires_at <= now + timedelta(
-                seconds=_REFRESH_AHEAD_SECONDS
-            )
-
-            if needs_refresh and row.refresh_token:
-                row = await self._refresh_token(db, row)
-
-            if row is None:
-                return None
-
             return self._decrypt(row.access_token)
-        except (InvalidToken, Exception) as exc:
+        except InvalidToken:
             logger.warning(
-                "get_valid_token failed for connection_id=%s provider=%s: %s",
+                "get_valid_token: decryption failed for connection_id=%s provider=%s "
+                "(encryption key may have rotated)",
                 connection_id,
                 provider,
-                exc,
             )
             return None
 
@@ -183,7 +186,7 @@ class ConnectionTokenManager:
             if prov and prov.revoke_url:
                 try:
                     access_token = self._decrypt(row.access_token)
-                    async with httpx.AsyncClient(timeout=10.0) as client:
+                    async with new_async_httpx_client(timeout_seconds=10.0) as client:
                         await client.post(
                             prov.revoke_url,
                             data={"token": access_token, "client_id": prov.client_id},
@@ -236,6 +239,27 @@ class ConnectionTokenManager:
                 )
         return refreshed
 
+    async def cleanup_expired_tokens(self, db: AsyncSession) -> int:
+        """Delete ConnectionToken rows whose expires_at is in the past and have no refresh_token.
+
+        Tokens with a refresh_token are kept because the background refresh job
+        may still be able to renew them.  Returns the number of deleted rows.
+        """
+        now = datetime.now(UTC)
+        stmt = delete(ConnectionToken).where(
+            and_(
+                ConnectionToken.expires_at.is_not(None),
+                ConnectionToken.expires_at <= now,
+                ConnectionToken.refresh_token.is_(None),
+            )
+        )
+        result = await db.execute(stmt)
+        deleted: int = result.rowcount  # type: ignore[assignment]
+        if deleted:
+            await db.flush()
+            logger.info("cleanup_expired_tokens: purged %d expired token rows", deleted)
+        return deleted
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -245,6 +269,30 @@ class ConnectionTokenManager:
         db: AsyncSession,
         row: ConnectionToken,
     ) -> ConnectionToken | None:
+        # Per-connection lock prevents two concurrent callers from both
+        # refreshing the same token simultaneously.
+        lock = self._refresh_locks.setdefault(row.connection_id, asyncio.Lock())
+        async with lock:
+            # Re-read the row inside the lock — another coroutine may have
+            # already refreshed it while we were waiting.
+            fresh_row = await self.get(
+                db,
+                connection_id=row.connection_id,
+                user_id=row.user_id,
+                provider=row.provider,
+            )
+            if fresh_row is not None and fresh_row.updated_at > row.updated_at:
+                return fresh_row
+            row = fresh_row if fresh_row is not None else row
+
+            return await self._do_refresh(db, row)
+
+    async def _do_refresh(
+        self,
+        db: AsyncSession,
+        row: ConnectionToken,
+    ) -> ConnectionToken | None:
+        """Execute the actual token refresh exchange (always called under lock)."""
         if self._registry is None:
             logger.warning("Cannot refresh token: no registry attached to ConnectionTokenManager")
             return row

--- a/src/svc_infra/connect/token_manager.py
+++ b/src/svc_infra/connect/token_manager.py
@@ -254,7 +254,7 @@ class ConnectionTokenManager:
             )
         )
         result = await db.execute(stmt)
-        deleted: int = result.rowcount  # type: ignore[assignment]
+        deleted: int = result.rowcount  # type: ignore[attr-defined]
         if deleted:
             await db.flush()
             logger.info("cleanup_expired_tokens: purged %d expired token rows", deleted)

--- a/tests/unit/connect/test_mcp_discovery.py
+++ b/tests/unit/connect/test_mcp_discovery.py
@@ -207,7 +207,9 @@ class TestMCPOAuthDiscovery:
         mock_client.post = AsyncMock(return_value=mock_resp)
 
         discovery = self._make_discovery()
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "svc_infra.connect.mcp_discovery.new_async_httpx_client", return_value=mock_client
+        ):
             result = await discovery.is_mcp_oauth_supported("https://mcp.example.com")
         assert result is True
 
@@ -221,7 +223,9 @@ class TestMCPOAuthDiscovery:
         mock_client.post = AsyncMock(return_value=mock_resp)
 
         discovery = self._make_discovery()
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "svc_infra.connect.mcp_discovery.new_async_httpx_client", return_value=mock_client
+        ):
             result = await discovery.is_mcp_oauth_supported("https://mcp.example.com")
         assert result is False
 
@@ -234,7 +238,9 @@ class TestMCPOAuthDiscovery:
         mock_client.post = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
 
         discovery = self._make_discovery()
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "svc_infra.connect.mcp_discovery.new_async_httpx_client", return_value=mock_client
+        ):
             result = await discovery.is_mcp_oauth_supported("https://mcp.example.com")
         assert result is False
 
@@ -255,7 +261,9 @@ class TestMCPOAuthDiscovery:
                 new_callable=AsyncMock,
                 return_value="https://mcp.example.com/.well-known/oauth-protected-resource",
             ),
-            patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "svc_infra.connect.mcp_discovery.new_async_httpx_client", return_value=mock_client
+            ),
         ):
             with pytest.raises(MCPOAuthNotSupported, match="RFC 9728"):
                 await discovery._fetch_resource_metadata("https://mcp.example.com")
@@ -276,7 +284,9 @@ class TestMCPOAuthDiscovery:
                 new_callable=AsyncMock,
                 return_value="https://mcp.example.com/.well-known/oauth-protected-resource",
             ),
-            patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "svc_infra.connect.mcp_discovery.new_async_httpx_client", return_value=mock_client
+            ),
         ):
             with pytest.raises(MCPOAuthNotSupported, match="resource metadata"):
                 await discovery._fetch_resource_metadata("https://mcp.example.com")
@@ -297,7 +307,9 @@ class TestMCPOAuthDiscovery:
         mock_client.post = AsyncMock(return_value=mock_resp)
 
         discovery = self._make_discovery()
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "svc_infra.connect.mcp_discovery.new_async_httpx_client", return_value=mock_client
+        ):
             url = await discovery._probe_resource_metadata_url("https://api.example.com/mcp/")
 
         assert url == "https://api.example.com/.well-known/oauth-protected-resource/mcp/"
@@ -312,7 +324,9 @@ class TestMCPOAuthDiscovery:
         mock_client.post = AsyncMock(return_value=mock_resp)
 
         discovery = self._make_discovery()
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "svc_infra.connect.mcp_discovery.new_async_httpx_client", return_value=mock_client
+        ):
             url = await discovery._probe_resource_metadata_url("https://mcp.example.com/")
 
         assert url == "https://mcp.example.com/.well-known/oauth-protected-resource"
@@ -326,7 +340,9 @@ class TestMCPOAuthDiscovery:
         mock_client.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
 
         discovery = self._make_discovery()
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "svc_infra.connect.mcp_discovery.new_async_httpx_client", return_value=mock_client
+        ):
             url = await discovery._probe_resource_metadata_url("https://mcp.example.com/")
 
         assert url == "https://mcp.example.com/.well-known/oauth-protected-resource"
@@ -467,7 +483,7 @@ class TestWellKnownFallback:
             "authorization_servers": ["https://mcp.notion.com"],
         }
 
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient") as MockClient:
+        with patch("svc_infra.connect.mcp_discovery.new_async_httpx_client") as MockClient:
             client_instance = AsyncMock()
             client_instance.post.return_value = mock_post_resp
             client_instance.get.return_value = mock_wellknown_resp
@@ -492,7 +508,7 @@ class TestWellKnownFallback:
         mock_wellknown_resp = MagicMock()
         mock_wellknown_resp.status_code = 404
 
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient") as MockClient:
+        with patch("svc_infra.connect.mcp_discovery.new_async_httpx_client") as MockClient:
             client_instance = AsyncMock()
             client_instance.post.return_value = mock_post_resp
             client_instance.get.return_value = mock_wellknown_resp
@@ -542,7 +558,7 @@ class TestDynamicClientRegistration:
                 new_callable=AsyncMock,
                 return_value=auth_meta,
             ),
-            patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient") as MockClient,
+            patch("svc_infra.connect.mcp_discovery.new_async_httpx_client") as MockClient,
         ):
             mock_resp = MagicMock()
             mock_resp.status_code = 201
@@ -638,7 +654,9 @@ class TestOriginUrlInWellKnown:
         mock_client.post = AsyncMock(return_value=mock_resp)
 
         discovery = MCPOAuthDiscovery()
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "svc_infra.connect.mcp_discovery.new_async_httpx_client", return_value=mock_client
+        ):
             url = await discovery._probe_resource_metadata_url("https://mcp.notion.com/mcp")
 
         assert url == "https://mcp.notion.com/.well-known/oauth-protected-resource"
@@ -653,7 +671,7 @@ class TestOriginUrlInWellKnown:
             "authorization_servers": ["https://mcp.notion.com"],
         }
 
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient") as MockClient:
+        with patch("svc_infra.connect.mcp_discovery.new_async_httpx_client") as MockClient:
             client_instance = AsyncMock()
             client_instance.get.return_value = mock_wellknown_resp
             MockClient.return_value.__aenter__ = AsyncMock(return_value=client_instance)
@@ -684,7 +702,7 @@ class TestOriginUrlInWellKnown:
             "authorization_servers": ["https://mcp.notion.com"],
         }
 
-        with patch("svc_infra.connect.mcp_discovery.httpx.AsyncClient") as MockClient:
+        with patch("svc_infra.connect.mcp_discovery.new_async_httpx_client") as MockClient:
             client_instance = AsyncMock()
             client_instance.post.return_value = mock_post_resp
             client_instance.get.return_value = mock_wellknown_resp

--- a/tests/unit/connect/test_pkce.py
+++ b/tests/unit/connect/test_pkce.py
@@ -208,7 +208,7 @@ class TestExchangeCode:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client.post = AsyncMock(return_value=mock_resp)
 
-        with patch("svc_infra.connect.pkce.httpx.AsyncClient", return_value=mock_client):
+        with patch("svc_infra.connect.pkce.new_async_httpx_client", return_value=mock_client):
             result = await exchange_code(
                 provider,
                 code="code123",
@@ -225,7 +225,7 @@ class TestExchangeCode:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client.post = AsyncMock(return_value=mock_resp)
 
-        with patch("svc_infra.connect.pkce.httpx.AsyncClient", return_value=mock_client):
+        with patch("svc_infra.connect.pkce.new_async_httpx_client", return_value=mock_client):
             with pytest.raises(OAuthExchangeError):
                 await exchange_code(
                     provider, code="code", pkce_verifier="v", redirect_uri="https://x.com"
@@ -239,7 +239,7 @@ class TestExchangeCode:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client.post = AsyncMock(return_value=mock_resp)
 
-        with patch("svc_infra.connect.pkce.httpx.AsyncClient", return_value=mock_client):
+        with patch("svc_infra.connect.pkce.new_async_httpx_client", return_value=mock_client):
             with pytest.raises(OAuthExchangeError):
                 await exchange_code(
                     provider, code="code", pkce_verifier="v", redirect_uri="https://x.com"
@@ -256,7 +256,7 @@ class TestExchangeRefresh:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client.post = AsyncMock(return_value=mock_resp)
 
-        with patch("svc_infra.connect.pkce.httpx.AsyncClient", return_value=mock_client):
+        with patch("svc_infra.connect.pkce.new_async_httpx_client", return_value=mock_client):
             result = await exchange_refresh(provider, "refresh_token_value")
         assert result["access_token"] == "new_tok"
 
@@ -268,7 +268,7 @@ class TestExchangeRefresh:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client.post = AsyncMock(return_value=mock_resp)
 
-        with patch("svc_infra.connect.pkce.httpx.AsyncClient", return_value=mock_client):
+        with patch("svc_infra.connect.pkce.new_async_httpx_client", return_value=mock_client):
             with pytest.raises(OAuthRefreshError):
                 await exchange_refresh(provider, "bad_refresh")
 
@@ -280,6 +280,6 @@ class TestExchangeRefresh:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client.post = AsyncMock(return_value=mock_resp)
 
-        with patch("svc_infra.connect.pkce.httpx.AsyncClient", return_value=mock_client):
+        with patch("svc_infra.connect.pkce.new_async_httpx_client", return_value=mock_client):
             with pytest.raises(OAuthRefreshError):
                 await exchange_refresh(provider, "refresh")

--- a/tests/unit/connect/test_router.py
+++ b/tests/unit/connect/test_router.py
@@ -128,7 +128,7 @@ class TestAuthorizeEndpoint:
 
     async def test_mcp_discovery_path(self, connect_client):
         """mcp_server_url triggers MCPOAuthDiscovery.discover() and resolves provider."""
-        client, _, _, reg = connect_client
+        client, _, _, _reg = connect_client
 
         mock_provider = _make_provider()
         mock_provider = mock_provider.model_copy(update={"name": "mcp:https://mcp.example.com"})
@@ -170,7 +170,7 @@ class TestCallbackEndpoint:
         state = MagicMock(spec=OAuthState)
         state.state = "valid_state"
         state.provider = provider
-        state.pkce_verifier = "verifier"
+        state.pkce_verifier = manager._encrypt("verifier")
         state.user_id = _USER_ID
         state.connection_id = _CONN_ID
         state.redirect_uri = "http://app.example.com/callback"
@@ -307,7 +307,7 @@ class TestCallbackEndpoint:
 
     async def test_callback_provider_rediscovery(self, connect_client):
         """When provider is not in registry, callback attempts re-discovery for MCP providers."""
-        client, mock_db, token_manager, reg = connect_client
+        client, mock_db, token_manager, _reg = connect_client
         oauth_state = self._make_oauth_state(token_manager, provider="mcp-mcp.example.com")
 
         async def _execute(_stmt):

--- a/tests/unit/connect/test_token_manager.py
+++ b/tests/unit/connect/test_token_manager.py
@@ -226,16 +226,16 @@ class TestGetValidToken:
         )
         assert token is None
 
-    async def test_does_not_raise_on_exception(self):
-        """get_valid_token must never raise; return None instead."""
+    async def test_propagates_non_token_exceptions(self):
+        """get_valid_token propagates DB/network errors instead of swallowing them."""
         manager = _make_manager()
         db = MagicMock()
         db.execute = AsyncMock(side_effect=RuntimeError("db error"))
 
-        token = await manager.get_valid_token(
-            db, connection_id=_CONN_ID, user_id=_USER_ID, provider=_PROVIDER
-        )
-        assert token is None
+        with pytest.raises(RuntimeError, match="db error"):
+            await manager.get_valid_token(
+                db, connection_id=_CONN_ID, user_id=_USER_ID, provider=_PROVIDER
+            )
 
 
 @pytest.mark.asyncio
@@ -262,7 +262,9 @@ class TestRevoke:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
 
-        with patch("svc_infra.connect.token_manager.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "svc_infra.connect.token_manager.new_async_httpx_client", return_value=mock_client
+        ):
             await manager.revoke(db, connection_id=_CONN_ID, user_id=_USER_ID, provider=_PROVIDER)
 
         mock_client.post.assert_awaited_once()


### PR DESCRIPTION
## Summary

Hardens the svc-infra Connect OAuth module with security improvements, resilience fixes, and SDK reuse.

### Security
- PKCE verifier encryption at rest (Fernet-encrypted in OAuthState)
- Rate limiting on authorize/callback endpoints (30 req/60s per user/provider)
- OAuthState.user_id index for faster lookups

### Resilience
- Token refresh race guard (per-connection asyncio.Lock)
- Tightened error handling: get_valid_token() only catches InvalidToken; DB/network errors propagate
- Thread-safe discovery cache (threading.Lock)
- Expired token cleanup background job (every 3600s)

### SDK Reuse
- httpx.AsyncClient -> new_async_httpx_client() across 9 instances (request ID propagation, standardized timeouts)
- _SessionLocal -> get_session_factory() public API for background tasks
- Added public get_session_factory() to svc_infra.api.fastapi.db.sql

### Documentation
- Added Connect module to REA- Added Connect module to REA- Added Connect module to REA- Added Connect module to REA- Added Connect module to REAfor new_async_httpx_client