### PR TITLE
feat(jobs): add cloud-ready scheduling primitives

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -57,7 +57,7 @@ jobs:
           path: sbom.${{ matrix.backend }}.cdx.json
 
       - name: Set up Trivy
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: 'image'
           image-ref: 'python:3.12-slim'
@@ -72,7 +72,7 @@ jobs:
 
       - name: Scan redis:7-alpine with Trivy (CRITICAL gate)
         if: matrix.backend == 'pg-redis'
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: 'image'
           image-ref: 'redis:7-alpine'
@@ -88,7 +88,7 @@ jobs:
 
       - name: Scan postgres:16-alpine with Trivy (CRITICAL gate)
         if: matrix.backend == 'pg-redis'
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: 'image'
           image-ref: 'postgres:16-alpine'

--- a/README.md
+++ b/README.md
@@ -147,14 +147,19 @@ queue.enqueue("send_email", {"to": "user@example.com", "template": "welcome"})
 
 # Schedule recurring tasks
 scheduler.add("cleanup", interval_seconds=3600, target="myapp.tasks:cleanup")
+scheduler.add("weekday-digest", cron="0 9 * * mon-fri", target="myapp.tasks:digest")
+scheduler.add_job("daily-email", cron="0 9 * * *", job_queue=queue, job_name="send_email")
+
+# In Redis mode, scheduler leadership is coordinated automatically
+# so multiple replicas can run safely in the cloud.
 ```
 
 ```bash
-# Run the worker
-svc-infra jobs run
+# Run the worker with a registry from your app
+JOBS_REGISTRY_TARGET=myapp.jobs:registry svc-infra jobs run
 ```
 
-**Includes:** Visibility timeout, exponential backoff, dead letter queue, interval scheduler, CLI worker.
+**Includes:** Visibility timeout, exponential backoff, dead letter queue, interval and cron scheduling, durable scheduled job emission, Redis-backed scheduler leadership, CLI worker.
 
 ### Webhooks
 

--- a/docs/api/cronschedule.json
+++ b/docs/api/cronschedule.json
@@ -1,0 +1,260 @@
+{
+  "name": "CronSchedule",
+  "module": "svc_infra.jobs.scheduler",
+  "docstring": null,
+  "parameters": [
+    {
+      "name": "expression",
+      "type": "str",
+      "default": null,
+      "description": null,
+      "required": true
+    },
+    {
+      "name": "timezone_name",
+      "type": "str",
+      "default": null,
+      "description": null,
+      "required": true
+    },
+    {
+      "name": "timezone",
+      "type": "ZoneInfo",
+      "default": null,
+      "description": null,
+      "required": true
+    },
+    {
+      "name": "minute_values",
+      "type": "frozenset[int]",
+      "default": null,
+      "description": null,
+      "required": true
+    },
+    {
+      "name": "hour_values",
+      "type": "frozenset[int]",
+      "default": null,
+      "description": null,
+      "required": true
+    },
+    {
+      "name": "day_values",
+      "type": "frozenset[int]",
+      "default": null,
+      "description": null,
+      "required": true
+    },
+    {
+      "name": "month_values",
+      "type": "frozenset[int]",
+      "default": null,
+      "description": null,
+      "required": true
+    },
+    {
+      "name": "weekday_values",
+      "type": "frozenset[int]",
+      "default": null,
+      "description": null,
+      "required": true
+    },
+    {
+      "name": "day_is_wildcard",
+      "type": "bool",
+      "default": null,
+      "description": null,
+      "required": true
+    },
+    {
+      "name": "weekday_is_wildcard",
+      "type": "bool",
+      "default": null,
+      "description": null,
+      "required": true
+    }
+  ],
+  "methods": [
+    {
+      "name": "__init__",
+      "signature": "(expression: str, timezone_name: str, timezone: ZoneInfo, minute_values: frozenset[int], hour_values: frozenset[int], day_values: frozenset[int], month_values: frozenset[int], weekday_values: frozenset[int], day_is_wildcard: bool, weekday_is_wildcard: bool) -> None",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "self",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "expression",
+          "type": "str",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "timezone_name",
+          "type": "str",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "timezone",
+          "type": "ZoneInfo",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "minute_values",
+          "type": "frozenset[int]",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "hour_values",
+          "type": "frozenset[int]",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "day_values",
+          "type": "frozenset[int]",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "month_values",
+          "type": "frozenset[int]",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "weekday_values",
+          "type": "frozenset[int]",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "day_is_wildcard",
+          "type": "bool",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "weekday_is_wildcard",
+          "type": "bool",
+          "default": null,
+          "description": null,
+          "required": true
+        }
+      ],
+      "returns": "None",
+      "is_async": false,
+      "is_classmethod": false,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    },
+    {
+      "name": "matches",
+      "signature": "(dt: datetime) -> bool",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "self",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "dt",
+          "type": "datetime",
+          "default": null,
+          "description": null,
+          "required": true
+        }
+      ],
+      "returns": "bool",
+      "is_async": false,
+      "is_classmethod": false,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    },
+    {
+      "name": "next_run_after",
+      "signature": "(after: datetime) -> datetime",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "self",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "after",
+          "type": "datetime",
+          "default": null,
+          "description": null,
+          "required": true
+        }
+      ],
+      "returns": "datetime",
+      "is_async": false,
+      "is_classmethod": false,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    },
+    {
+      "name": "parse",
+      "signature": "(expression: str, timezone: str = 'UTC') -> CronSchedule",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "cls",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "expression",
+          "type": "str",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "timezone",
+          "type": "str",
+          "default": "'UTC'",
+          "description": null,
+          "required": false
+        }
+      ],
+      "returns": "CronSchedule",
+      "is_async": false,
+      "is_classmethod": true,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    }
+  ],
+  "bases": [],
+  "source_file": "src/svc_infra/jobs/scheduler.py",
+  "source_line": 192
+}

--- a/docs/api/inmemoryscheduler.json
+++ b/docs/api/inmemoryscheduler.json
@@ -1,7 +1,7 @@
 {
   "name": "InMemoryScheduler",
   "module": "svc_infra.jobs.scheduler",
-  "docstring": "Interval-based scheduler for simple periodic tasks (tests/local).\n\nNot a full cron parser. Tracks next_run_at per task.",
+  "docstring": "In-process scheduler for interval and cron jobs.\n\nThe scheduler keeps all task state in memory, which makes it a good default\nfor local development, tests, and simple service processes.",
   "parameters": [
     {
       "name": "tick_interval",
@@ -9,12 +9,33 @@
       "default": "60.0",
       "description": null,
       "required": false
+    },
+    {
+      "name": "timezone",
+      "type": "str",
+      "default": "'UTC'",
+      "description": null,
+      "required": false
+    },
+    {
+      "name": "now_provider",
+      "type": "Callable[[], datetime] | None",
+      "default": "None",
+      "description": null,
+      "required": false
+    },
+    {
+      "name": "leader",
+      "type": "SchedulerLeadership | None",
+      "default": "None",
+      "description": null,
+      "required": false
     }
   ],
   "methods": [
     {
       "name": "__init__",
-      "signature": "(tick_interval: float = 60.0)",
+      "signature": "(tick_interval: float = 60.0, timezone: str = 'UTC', now_provider: Callable[[], datetime] | None = None, leader: SchedulerLeadership | None = None)",
       "docstring": null,
       "parameters": [
         {
@@ -30,6 +51,27 @@
           "default": "60.0",
           "description": null,
           "required": false
+        },
+        {
+          "name": "timezone",
+          "type": "str",
+          "default": "'UTC'",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "now_provider",
+          "type": "Callable[[], datetime] | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "leader",
+          "type": "SchedulerLeadership | None",
+          "default": "None",
+          "description": null,
+          "required": false
         }
       ],
       "returns": null,
@@ -40,8 +82,8 @@
       "raises": null
     },
     {
-      "name": "add_task",
-      "signature": "(name: str, interval_seconds: int, func: CronFunc) -> None",
+      "name": "add",
+      "signature": "(name: str, interval_seconds: int | float | None = None, cron: str | None = None, func: RawScheduledFunc | None = None, target: str | None = None, job_queue: JobQueue | None = None, job_name: str | None = None, payload: Mapping[str, Any] | None = None, payload_factory: Callable[[], Mapping[str, Any]] | None = None, delay_seconds: int = 0, timezone: str | None = None) -> None",
       "docstring": null,
       "parameters": [
         {
@@ -60,14 +102,242 @@
         },
         {
           "name": "interval_seconds",
+          "type": "int | float | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "cron",
+          "type": "str | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "func",
+          "type": "RawScheduledFunc | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "target",
+          "type": "str | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "job_queue",
+          "type": "JobQueue | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "job_name",
+          "type": "str | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "payload",
+          "type": "Mapping[str, Any] | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "payload_factory",
+          "type": "Callable[[], Mapping[str, Any]] | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "delay_seconds",
           "type": "int",
+          "default": "0",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "timezone",
+          "type": "str | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        }
+      ],
+      "returns": "None",
+      "is_async": false,
+      "is_classmethod": false,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    },
+    {
+      "name": "add_cron",
+      "signature": "(name: str, cron: str, func: RawScheduledFunc, timezone: str | None = None) -> None",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "self",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "name",
+          "type": "str",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "cron",
+          "type": "str",
           "default": null,
           "description": null,
           "required": true
         },
         {
           "name": "func",
-          "type": "CronFunc",
+          "type": "RawScheduledFunc",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "timezone",
+          "type": "str | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        }
+      ],
+      "returns": "None",
+      "is_async": false,
+      "is_classmethod": false,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    },
+    {
+      "name": "add_job",
+      "signature": "(name: str, job_queue: JobQueue, job_name: str, interval_seconds: int | float | None = None, cron: str | None = None, payload: Mapping[str, Any] | None = None, payload_factory: Callable[[], Mapping[str, Any]] | None = None, delay_seconds: int = 0, timezone: str | None = None) -> None",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "self",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "name",
+          "type": "str",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "job_queue",
+          "type": "JobQueue",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "job_name",
+          "type": "str",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "interval_seconds",
+          "type": "int | float | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "cron",
+          "type": "str | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "payload",
+          "type": "Mapping[str, Any] | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "payload_factory",
+          "type": "Callable[[], Mapping[str, Any]] | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "delay_seconds",
+          "type": "int",
+          "default": "0",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "timezone",
+          "type": "str | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        }
+      ],
+      "returns": "None",
+      "is_async": false,
+      "is_classmethod": false,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    },
+    {
+      "name": "add_task",
+      "signature": "(name: str, interval_seconds: int | float, func: RawScheduledFunc) -> None",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "self",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "name",
+          "type": "str",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "interval_seconds",
+          "type": "int | float",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "func",
+          "type": "RawScheduledFunc",
           "default": null,
           "description": null,
           "required": true
@@ -81,9 +351,29 @@
       "raises": null
     },
     {
+      "name": "close",
+      "signature": "() -> None",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "self",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        }
+      ],
+      "returns": "None",
+      "is_async": false,
+      "is_classmethod": false,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    },
+    {
       "name": "run",
       "signature": "() -> None",
-      "docstring": "Run the scheduler loop indefinitely.\n\nCalls tick() at regular intervals to check and execute due tasks.\nThis method runs forever until cancelled.",
+      "docstring": "Run the scheduler loop indefinitely.",
       "parameters": [
         {
           "name": "self",
@@ -102,13 +392,20 @@
     },
     {
       "name": "tick",
-      "signature": "() -> None",
+      "signature": "(now: datetime | None = None) -> None",
       "docstring": null,
       "parameters": [
         {
           "name": "self",
           "type": null,
           "default": null,
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "now",
+          "type": "datetime | None",
+          "default": "None",
           "description": null,
           "required": false
         }
@@ -123,5 +420,5 @@
   ],
   "bases": [],
   "source_file": "src/svc_infra/jobs/scheduler.py",
-  "source_line": 19
+  "source_line": 314
 }

--- a/docs/api/redisschedulerleader.json
+++ b/docs/api/redisschedulerleader.json
@@ -1,0 +1,128 @@
+{
+  "name": "RedisSchedulerLeader",
+  "module": "svc_infra.jobs.leadership",
+  "docstring": "Redis-backed leadership lease for cloud-safe scheduler coordination.",
+  "parameters": [
+    {
+      "name": "client",
+      "type": "Redis",
+      "default": null,
+      "description": null,
+      "required": true
+    },
+    {
+      "name": "key",
+      "type": "str",
+      "default": "'jobs:scheduler:leader'",
+      "description": null,
+      "required": false
+    },
+    {
+      "name": "lease_seconds",
+      "type": "int",
+      "default": "180",
+      "description": null,
+      "required": false
+    },
+    {
+      "name": "owner_id",
+      "type": "str | None",
+      "default": "None",
+      "description": null,
+      "required": false
+    }
+  ],
+  "methods": [
+    {
+      "name": "__init__",
+      "signature": "(client: Redis, key: str = 'jobs:scheduler:leader', lease_seconds: int = 180, owner_id: str | None = None)",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "self",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "client",
+          "type": "Redis",
+          "default": null,
+          "description": null,
+          "required": true
+        },
+        {
+          "name": "key",
+          "type": "str",
+          "default": "'jobs:scheduler:leader'",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "lease_seconds",
+          "type": "int",
+          "default": "180",
+          "description": null,
+          "required": false
+        },
+        {
+          "name": "owner_id",
+          "type": "str | None",
+          "default": "None",
+          "description": null,
+          "required": false
+        }
+      ],
+      "returns": null,
+      "is_async": false,
+      "is_classmethod": false,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    },
+    {
+      "name": "ensure_leader",
+      "signature": "() -> bool",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "self",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        }
+      ],
+      "returns": "bool",
+      "is_async": false,
+      "is_classmethod": false,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    },
+    {
+      "name": "release",
+      "signature": "() -> None",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "self",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        }
+      ],
+      "returns": "None",
+      "is_async": false,
+      "is_classmethod": false,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    }
+  ],
+  "bases": [],
+  "source_file": "src/svc_infra/jobs/leadership.py",
+  "source_line": 35
+}

--- a/docs/api/schedulerleadership.json
+++ b/docs/api/schedulerleadership.json
@@ -1,0 +1,53 @@
+{
+  "name": "SchedulerLeadership",
+  "module": "svc_infra.jobs.leadership",
+  "docstring": null,
+  "parameters": [],
+  "methods": [
+    {
+      "name": "ensure_leader",
+      "signature": "() -> bool",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "self",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        }
+      ],
+      "returns": "bool",
+      "is_async": false,
+      "is_classmethod": false,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    },
+    {
+      "name": "release",
+      "signature": "() -> None",
+      "docstring": null,
+      "parameters": [
+        {
+          "name": "self",
+          "type": null,
+          "default": null,
+          "description": null,
+          "required": false
+        }
+      ],
+      "returns": "None",
+      "is_async": false,
+      "is_classmethod": false,
+      "is_staticmethod": false,
+      "is_property": false,
+      "raises": null
+    }
+  ],
+  "bases": [
+    "Protocol"
+  ],
+  "source_file": "src/svc_infra/jobs/leadership.py",
+  "source_line": 26
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -369,6 +369,10 @@ svc-infra jobs run --poll-interval 1.0
 
 # Limited loops for testing
 svc-infra jobs run --max-loops 100
+
+# Resolve handlers from your app
+svc-infra jobs run --registry-target myapp.jobs:registry
+svc-infra jobs run --handler-target myapp.jobs:process_job
 ```
 
 **Options:**
@@ -376,8 +380,13 @@ svc-infra jobs run --max-loops 100
 |--------|---------|-------------|
 | `--poll-interval` | `0.5` | Seconds between idle loops |
 | `--max-loops` | none | Maximum iterations (for tests) |
+| `--handler-target` | none | `module:path` handler callable taking one job |
+| `--registry-target` | none | `module:path` `JobRegistry` instance or factory |
 
-**Note:** The default handler is a no-op. Implement your own job handler for actual processing.
+**Note:** The runner loads interval and cron schedules from `JOBS_SCHEDULE_JSON`.
+With `JOBS_DRIVER=redis`, scheduler leadership is coordinated automatically so
+multiple replicas can run safely. Use `--registry-target` / `JOBS_REGISTRY_TARGET`
+or `--handler-target` / `JOBS_HANDLER_TARGET` for actual job processing.
 
 ---
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -162,7 +162,12 @@ cache_ttl = pick(
 |----------|---------|-------------|
 | `JOBS_DRIVER` | `memory` | Queue driver (`redis` or `memory`) |
 | `REDIS_URL` | `redis://localhost:6379/0` | Redis URL for jobs |
-| `JOBS_SCHEDULE_JSON` | — | JSON array of scheduled tasks |
+| `JOBS_SCHEDULE_JSON` | — | JSON array of interval/cron scheduled tasks |
+| `JOBS_SCHEDULER_COORDINATION` | `auto` | Scheduler coordination mode (`auto`, `redis`, `off`) |
+| `JOBS_SCHEDULER_LEASE_SECONDS` | `180` | Redis scheduler leadership TTL |
+| `JOBS_SCHEDULER_LEASE_KEY` | `jobs:scheduler:leader` | Redis key used for scheduler leadership |
+| `JOBS_HANDLER_TARGET` | — | `module:path` job handler callable for `svc-infra jobs run` |
+| `JOBS_REGISTRY_TARGET` | — | `module:path` `JobRegistry` instance or factory |
 
 ### Observability
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -11,7 +11,8 @@ svc-infra provides a flexible background job system:
 - **Retry Logic**: Exponential backoff with configurable max attempts
 - **Dead Letter Queue**: Failed jobs are moved to DLQ after max retries
 - **Visibility Timeout**: Prevents duplicate processing with automatic re-queuing
-- **Interval Scheduler**: Simple scheduling for periodic tasks
+- **Recurring Scheduler**: Interval and cron-based scheduling for periodic tasks
+- **Cloud-Safe Leadership**: Redis-backed scheduler lease for multi-replica deployments
 - **Built-in Jobs**: Webhook delivery, outbox processing
 
 ## Quick Start
@@ -63,7 +64,10 @@ svc-infra jobs run
 | `JOBS_DRIVER` | `memory` | Backend driver (`memory` or `redis`) |
 | `REDIS_URL` | `redis://localhost:6379/0` | Redis connection URL |
 | `JOB_DEFAULT_TIMEOUT_SECONDS` | — | Per-job execution timeout |
-| `JOBS_SCHEDULE_JSON` | — | JSON array of scheduled tasks |
+| `JOBS_SCHEDULE_JSON` | — | JSON array of interval and cron scheduled tasks |
+| `JOBS_SCHEDULER_COORDINATION` | `auto` | Scheduler coordination mode (`auto`, `redis`, `off`) |
+| `JOBS_SCHEDULER_LEASE_SECONDS` | `180` | Redis scheduler leadership TTL |
+| `JOBS_SCHEDULER_LEASE_KEY` | `jobs:scheduler:leader` | Redis key for scheduler leadership |
 
 ### Backend Selection
 
@@ -74,6 +78,7 @@ JOBS_DRIVER=memory
 # Production (Redis)
 JOBS_DRIVER=redis
 REDIS_URL=redis://redis.example.com:6379/0
+# In redis mode, scheduler leadership is enabled automatically
 ```
 
 ### Programmatic Configuration
@@ -387,12 +392,12 @@ async def run_workers(num_workers: int = 4):
 
 ## Scheduling
 
-### Interval-Based Scheduling
+### Recurring Scheduling
 
 ```python
-from svc_infra.jobs.scheduler import InMemoryScheduler
+from svc_infra.jobs.easy import easy_jobs
 
-scheduler = InMemoryScheduler(tick_interval=60.0)
+queue, scheduler = easy_jobs(driver="redis")
 
 # Add periodic tasks
 async def cleanup_sessions():
@@ -401,12 +406,50 @@ async def cleanup_sessions():
 async def send_daily_digest():
     await email_service.send_digest()
 
-scheduler.add_task("cleanup_sessions", 300, cleanup_sessions)  # Every 5 minutes
-scheduler.add_task("daily_digest", 86400, send_daily_digest)   # Every 24 hours
+# Interval-based tasks
+scheduler.add("cleanup_sessions", interval_seconds=300, func=cleanup_sessions)
+
+# Cron-style schedules support standard 5-field syntax and common aliases
+scheduler.add(
+    "daily_digest",
+    cron="0 9 * * mon-fri",
+    target="myapp.tasks:send_daily_digest",
+    timezone="America/New_York",
+)
+
+# Production-friendly path: emit a queue job instead of doing the work inline
+scheduler.add_job(
+    "daily_digest_job",
+    cron="0 9 * * mon-fri",
+    job_queue=queue,
+    job_name="send_daily_digest",
+    payload={"kind": "weekday"},
+)
 
 # Run scheduler (blocks indefinitely)
 await scheduler.run()
 ```
+
+`scheduler.add_task(...)` and `scheduler.add_cron(...)` are still available as
+compatibility helpers, but `scheduler.add(...)` and `scheduler.add_job(...)`
+are the recommended APIs.
+
+### Cron Syntax
+
+svc-infra supports standard 5-field cron expressions:
+
+```text
+minute hour day-of-month month day-of-week
+```
+
+Supported syntax includes:
+
+- wildcards: `*`
+- step values: `*/5`, `1-10/2`
+- lists: `0,15,30,45`
+- ranges: `9-17`
+- month and weekday names: `jan`, `mon-fri`
+- common aliases: `@hourly`, `@daily`, `@weekly`, `@monthly`, `@yearly`
 
 ### Environment-Based Schedule
 
@@ -415,25 +458,61 @@ Configure tasks via JSON environment variable:
 ```bash
 JOBS_SCHEDULE_JSON='[
   {"name": "cleanup", "interval_seconds": 300, "target": "myapp.tasks:cleanup"},
-  {"name": "health_check", "interval_seconds": 60, "target": "myapp.tasks:health_ping"}
+  {
+    "name": "weekday-digest",
+    "cron": "0 9 * * mon-fri",
+    "timezone": "America/New_York",
+    "job_name": "send_daily_digest",
+    "payload": {"kind": "weekday"}
+  }
 ]'
 ```
 
 Load and register:
 
 ```python
+from svc_infra.jobs.easy import easy_jobs
 from svc_infra.jobs.loader import schedule_from_env
-from svc_infra.jobs.scheduler import InMemoryScheduler
 
-scheduler = InMemoryScheduler()
-schedule_from_env(scheduler)  # Reads JOBS_SCHEDULE_JSON
+queue, scheduler = easy_jobs()
+schedule_from_env(scheduler, queue=queue)  # Reads JOBS_SCHEDULE_JSON
 
 await scheduler.run()
 ```
 
+### Cloud Scheduler Leadership
+
+When `JOBS_DRIVER=redis`, `easy_jobs()` automatically attaches a Redis-backed
+leadership lease to the scheduler. This means:
+
+- one replica is active for schedule emission
+- standby replicas do not double-fire scheduled automations
+- all replicas can still process queued jobs from Redis
+
+Use a real Redis transport URL here (`redis://`, `rediss://`, or `unix://`).
+REST-style Redis URLs are not supported by `redis-py`.
+
+Disable coordination explicitly if you want single-process behavior:
+
+```bash
+JOBS_SCHEDULER_COORDINATION=off
+```
+
+Or force Redis-backed leadership even if the queue driver is not Redis:
+
+```python
+from svc_infra.jobs.easy import easy_jobs
+
+queue, scheduler = easy_jobs(
+    driver="memory",
+    scheduler_coordination="redis",
+)
+```
+
 ### Target Format
 
-The `target` must be an import path in `module:function` format:
+The `target` must be an import path in `module:function` format. It works in
+both `scheduler.add(..., target="...")` and `JOBS_SCHEDULE_JSON`:
 
 ```python
 # myapp/tasks.py
@@ -451,6 +530,25 @@ def sync_task():
 {"target": "myapp.tasks:cleanup"}
 {"target": "myapp.tasks:sync_task"}
 ```
+
+### Queue-Backed Scheduled Jobs
+
+For production automations, prefer emitting jobs into the queue:
+
+```python
+queue, scheduler = easy_jobs(driver="redis")
+
+scheduler.add_job(
+    "invoice-reminders",
+    cron="0 10 * * *",
+    job_queue=queue,
+    job_name="send_invoice_reminders",
+    payload={"channel": "email"},
+)
+```
+
+That gives scheduled work the same retry, backoff, DLQ, and visibility-timeout
+behavior as any other queued job.
 
 ---
 
@@ -489,6 +587,17 @@ job.backoff_seconds = 60    # Base backoff
 # Attempt 5: 240 seconds delay (60 * 4)
 # After attempt 5: moved to DLQ
 ```
+
+### Scheduler Leadership in Cloud Deployments
+
+For cloud deployments, the recommended shape is:
+
+- Redis queue backend
+- multiple worker replicas if needed
+- one active scheduler leader at a time, coordinated automatically by Redis
+
+This lets you run multiple `svc-infra jobs run` processes safely without
+duplicate cron or interval triggers.
 
 ### Dead Letter Queue
 
@@ -634,6 +743,12 @@ svc-infra jobs run
 
 # With environment configuration
 JOBS_DRIVER=redis REDIS_URL=redis://localhost:6379/0 svc-infra jobs run
+
+# Use a JobRegistry target for real job processing
+JOBS_REGISTRY_TARGET=myapp.jobs:registry svc-infra jobs run
+
+# Disable automatic scheduler leadership if you truly want a single local scheduler
+JOBS_DRIVER=redis JOBS_SCHEDULER_COORDINATION=off svc-infra jobs run
 ```
 
 ### Docker Deployment
@@ -662,6 +777,7 @@ services:
     environment:
       - JOBS_DRIVER=redis
       - REDIS_URL=redis://redis:6379/0
+      - JOBS_SCHEDULER_COORDINATION=auto
     depends_on:
       - redis
 
@@ -694,6 +810,8 @@ spec:
           env:
             - name: JOBS_DRIVER
               value: "redis"
+            - name: JOBS_SCHEDULER_COORDINATION
+              value: "auto"
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1194,61 +1194,61 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "46.0.5"
+version = "46.0.6"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731"},
-    {file = "cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82"},
-    {file = "cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1"},
-    {file = "cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48"},
-    {file = "cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4"},
-    {file = "cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663"},
-    {file = "cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826"},
-    {file = "cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d"},
-    {file = "cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a"},
-    {file = "cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4"},
-    {file = "cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c"},
-    {file = "cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4"},
-    {file = "cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9"},
-    {file = "cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72"},
-    {file = "cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7"},
-    {file = "cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d"},
+    {file = "cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8"},
+    {file = "cryptography-46.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:26031f1e5ca62fcb9d1fcb34b2b60b390d1aacaa15dc8b895a9ed00968b97b30"},
+    {file = "cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a"},
+    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:67177e8a9f421aa2d3a170c3e56eca4e0128883cf52a071a7cbf53297f18b175"},
+    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d9528b535a6c4f8ff37847144b8986a9a143585f0540fbcb1a98115b543aa463"},
+    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97"},
+    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:760997a4b950ff00d418398ad73fbc91aa2894b5c1db7ccb45b4f68b42a63b3c"},
+    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3dfa6567f2e9e4c5dceb8ccb5a708158a2a871052fa75c8b78cb0977063f1507"},
+    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:cdcd3edcbc5d55757e5f5f3d330dd00007ae463a7e7aa5bf132d1f22a4b62b19"},
+    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d4e4aadb7fc1f88687f47ca20bb7227981b03afaae69287029da08096853b738"},
+    {file = "cryptography-46.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2b417edbe8877cda9022dde3a008e2deb50be9c407eef034aeeb3a8b11d9db3c"},
+    {file = "cryptography-46.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:380343e0653b1c9d7e1f55b52aaa2dbb2fdf2730088d48c43ca1c7c0abb7cc2f"},
+    {file = "cryptography-46.0.6-cp311-abi3-win32.whl", hash = "sha256:bcb87663e1f7b075e48c3be3ecb5f0b46c8fc50b50a97cf264e7f60242dca3f2"},
+    {file = "cryptography-46.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:6739d56300662c468fddb0e5e291f9b4d084bead381667b9e654c7dd81705124"},
+    {file = "cryptography-46.0.6-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:2ef9e69886cbb137c2aef9772c2e7138dc581fad4fcbcf13cc181eb5a3ab6275"},
+    {file = "cryptography-46.0.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7f417f034f91dcec1cb6c5c35b07cdbb2ef262557f701b4ecd803ee8cefed4f4"},
+    {file = "cryptography-46.0.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d24c13369e856b94892a89ddf70b332e0b70ad4a5c43cf3e9cb71d6d7ffa1f7b"},
+    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:aad75154a7ac9039936d50cf431719a2f8d4ed3d3c277ac03f3339ded1a5e707"},
+    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3c21d92ed15e9cfc6eb64c1f5a0326db22ca9c2566ca46d845119b45b4400361"},
+    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4668298aef7cddeaf5c6ecc244c2302a2b8e40f384255505c22875eebb47888b"},
+    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8ce35b77aaf02f3b59c90b2c8a05c73bac12cea5b4e8f3fbece1f5fddea5f0ca"},
+    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c89eb37fae9216985d8734c1afd172ba4927f5a05cfd9bf0e4863c6d5465b013"},
+    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:ed418c37d095aeddf5336898a132fba01091f0ac5844e3e8018506f014b6d2c4"},
+    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:69cf0056d6947edc6e6760e5f17afe4bea06b56a9ac8a06de9d2bd6b532d4f3a"},
+    {file = "cryptography-46.0.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e7304c4f4e9490e11efe56af6713983460ee0780f16c63f219984dab3af9d2d"},
+    {file = "cryptography-46.0.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b928a3ca837c77a10e81a814a693f2295200adb3352395fad024559b7be7a736"},
+    {file = "cryptography-46.0.6-cp314-cp314t-win32.whl", hash = "sha256:97c8115b27e19e592a05c45d0dd89c57f81f841cc9880e353e0d3bf25b2139ed"},
+    {file = "cryptography-46.0.6-cp314-cp314t-win_amd64.whl", hash = "sha256:c797e2517cb7880f8297e2c0f43bb910e91381339336f75d2c1c2cbf811b70b4"},
+    {file = "cryptography-46.0.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:12cae594e9473bca1a7aceb90536060643128bb274fcea0fc459ab90f7d1ae7a"},
+    {file = "cryptography-46.0.6-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:639301950939d844a9e1c4464d7e07f902fe9a7f6b215bb0d4f28584729935d8"},
+    {file = "cryptography-46.0.6-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ed3775295fb91f70b4027aeba878d79b3e55c0b3e97eaa4de71f8f23a9f2eb77"},
+    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8927ccfbe967c7df312ade694f987e7e9e22b2425976ddbf28271d7e58845290"},
+    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b12c6b1e1651e42ab5de8b1e00dc3b6354fdfd778e7fa60541ddacc27cd21410"},
+    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:063b67749f338ca9c5a0b7fe438a52c25f9526b851e24e6c9310e7195aad3b4d"},
+    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:02fad249cb0e090b574e30b276a3da6a149e04ee2f049725b1f69e7b8351ec70"},
+    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e6142674f2a9291463e5e150090b95a8519b2fb6e6aaec8917dd8d094ce750d"},
+    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:456b3215172aeefb9284550b162801d62f5f264a081049a3e94307fe20792cfa"},
+    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:341359d6c9e68834e204ceaf25936dffeafea3829ab80e9503860dcc4f4dac58"},
+    {file = "cryptography-46.0.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9a9c42a2723999a710445bc0d974e345c32adfd8d2fac6d8a251fa829ad31cfb"},
+    {file = "cryptography-46.0.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6617f67b1606dfd9fe4dbfa354a9508d4a6d37afe30306fe6c101b7ce3274b72"},
+    {file = "cryptography-46.0.6-cp38-abi3-win32.whl", hash = "sha256:7f6690b6c55e9c5332c0b59b9c8a3fb232ebf059094c17f9019a51e9827df91c"},
+    {file = "cryptography-46.0.6-cp38-abi3-win_amd64.whl", hash = "sha256:79e865c642cfc5c0b3eb12af83c35c5aeff4fa5c672dc28c43721c2c9fdd2f0f"},
+    {file = "cryptography-46.0.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:2ea0f37e9a9cf0df2952893ad145fd9627d326a59daec9b0802480fa3bcd2ead"},
+    {file = "cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a3e84d5ec9ba01f8fd03802b2147ba77f0c8f2617b2aff254cedd551844209c8"},
+    {file = "cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:12f0fa16cc247b13c43d56d7b35287ff1569b5b1f4c5e87e92cc4fcc00cd10c0"},
+    {file = "cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:50575a76e2951fe7dbd1f56d181f8c5ceeeb075e9ff88e7ad997d2f42af06e7b"},
+    {file = "cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:90e5f0a7b3be5f40c3a0a0eafb32c681d8d2c181fc2a1bdabe9b3f611d9f6b1a"},
+    {file = "cryptography-46.0.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6728c49e3b2c180ef26f8e9f0a883a2c585638db64cf265b49c9ba10652d430e"},
+    {file = "cryptography-46.0.6.tar.gz", hash = "sha256:27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759"},
 ]
 
 [package.dependencies]
@@ -1261,7 +1261,7 @@ nox = ["nox[uv] (>=2024.4.15)"]
 pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
 sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==46.0.5)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.6)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -3977,6 +3977,18 @@ files = [
 defusedxml = ">=0.7.1,<0.8.0"
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+]
+
+[[package]]
 name = "pycparser"
 version = "2.23"
 description = "C parser in Python"
@@ -4171,14 +4183,14 @@ yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
-    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 
 [package.extras]
@@ -4867,25 +4879,26 @@ typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
-    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
+    {file = "requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b"},
+    {file = "requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652"},
 ]
 
 [package.dependencies]
-certifi = ">=2017.4.17"
+certifi = ">=2023.5.7"
 charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<3"
+urllib3 = ">=1.26,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+test = ["PySocks (>=1.5.6,!=1.5.7)", "pytest (>=3)", "pytest-cov", "pytest-httpbin (==2.1.0)", "pytest-mock", "pytest-xdist"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
 name = "requests-toolbelt"
@@ -6108,4 +6121,4 @@ stripe = ["stripe"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "8f9b8dd09f9b2774338d75df87b8b8499d710cd08c61b7870566e83ee4b2060a"
+content-hash = "5ba0b308074b36f2e39215509ffbd59c19aa9af59e7057746d106f11f1598ba1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,10 @@ stripe = { version = ">=7.0.0", optional = true }
 adyen = { version = ">=10.0.0", optional = true }
 psycopg2-binary = { version = ">=2.9.0", optional = true }
 segno = "^1.6.6"
-cryptography = ">=41.0.0"
+cryptography = ">=46.0.6"
+requests = ">=2.33.0"
+pyasn1 = ">=0.6.3"
+pygments = ">=2.20.0"
 
 [tool.poetry.extras]
 # Postgres v3 (recommended)

--- a/src/svc_infra/cli/cmds/jobs/jobs_cmds.py
+++ b/src/svc_infra/cli/cmds/jobs/jobs_cmds.py
@@ -1,42 +1,97 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
+import os
 
 import typer
 
 from svc_infra.jobs.easy import easy_jobs
 from svc_infra.jobs.loader import schedule_from_env
+from svc_infra.jobs.registry import JobRegistry
+from svc_infra.jobs.targets import resolve_target
 from svc_infra.jobs.worker import process_one
 
 app = typer.Typer(help="Background jobs and scheduler commands")
+
+
+async def _noop_handler(job):
+    # Default handler does nothing; users should write their own runners
+    return None
+
+
+def _load_job_handler(
+    *,
+    handler_target: str | None,
+    registry_target: str | None,
+):
+    if handler_target and registry_target:
+        raise typer.BadParameter("Provide at most one of --handler-target or --registry-target")
+    if handler_target:
+        resolved = resolve_target(handler_target)
+
+        async def _handler(job):
+            result = resolved(job)
+            if inspect.isawaitable(result):
+                await result
+
+        return _handler
+    if registry_target:
+        resolved = resolve_target(registry_target)
+        registry = (
+            resolved() if callable(resolved) and not isinstance(resolved, JobRegistry) else resolved
+        )
+        if not isinstance(registry, JobRegistry):
+            raise typer.BadParameter(
+                "--registry-target must resolve to a JobRegistry instance or factory"
+            )
+
+        async def _handler(job):
+            result = await registry.dispatch(job)
+            if not result.success:
+                raise RuntimeError(result.message)
+
+        return _handler
+    return _noop_handler
 
 
 @app.command("run")
 def run(
     poll_interval: float = typer.Option(0.5, help="Sleep seconds between loops when idle"),
     max_loops: int | None = typer.Option(None, help="Max loops before exit (for tests)"),
+    handler_target: str | None = typer.Option(
+        None,
+        help="module:path target for a job handler function taking one job argument",
+    ),
+    registry_target: str | None = typer.Option(
+        None,
+        help="module:path target for a JobRegistry instance or factory",
+    ),
 ):
     """Run scheduler ticks and process jobs in a simple loop."""
 
     queue, scheduler = easy_jobs()
+    handler = _load_job_handler(
+        handler_target=handler_target or os.getenv("JOBS_HANDLER_TARGET"),
+        registry_target=registry_target or os.getenv("JOBS_REGISTRY_TARGET"),
+    )
     # load schedule from env JSON if provided
-    schedule_from_env(scheduler)
+    schedule_from_env(scheduler, queue=queue)
 
     async def _loop():
         loops = 0
-        while True:
-            await scheduler.tick()
-            processed = await process_one(queue, _noop_handler)
-            if not processed:
-                # idle
-                await asyncio.sleep(poll_interval)
-            if max_loops is not None:
-                loops += 1
-                if loops >= max_loops:
-                    break
-
-    async def _noop_handler(job):
-        # Default handler does nothing; users should write their own runners
-        return None
+        try:
+            while True:
+                await scheduler.tick()
+                processed = await process_one(queue, handler)
+                if not processed:
+                    # idle
+                    await asyncio.sleep(poll_interval)
+                if max_loops is not None:
+                    loops += 1
+                    if loops >= max_loops:
+                        break
+        finally:
+            scheduler.close()
 
     asyncio.run(_loop())

--- a/src/svc_infra/health/__init__.py
+++ b/src/svc_infra/health/__init__.py
@@ -36,6 +36,7 @@ Example:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -450,7 +451,11 @@ def check_redis(url: str | None) -> HealthCheckFn:
 
             client = redis_async.from_url(url, socket_connect_timeout=5.0)
             try:
-                pong = await asyncio.wait_for(client.ping(), timeout=5.0)
+                ping_result = client.ping()
+                if inspect.isawaitable(ping_result):
+                    pong = await asyncio.wait_for(ping_result, timeout=5.0)
+                else:
+                    pong = ping_result
                 if pong:
                     return HealthCheckResult(
                         name="redis",

--- a/src/svc_infra/jobs/__init__.py
+++ b/src/svc_infra/jobs/__init__.py
@@ -4,7 +4,9 @@ This module provides a flexible background job system with multiple backends:
 
 - **InMemoryJobQueue**: Simple in-memory queue for tests and local development
 - **RedisJobQueue**: Production-ready Redis-backed queue with visibility timeout
-- **InMemoryScheduler**: Interval-based scheduler for periodic tasks
+- **InMemoryScheduler**: In-process interval and cron scheduler for recurring tasks
+- **RedisSchedulerLeader**: Redis lease for cloud-safe scheduler leadership
+- **Durable Scheduled Jobs**: Emit queue jobs from cron/interval schedules
 - **JobRegistry**: Handler registry with dispatch and metrics
 
 Example:
@@ -46,7 +48,12 @@ Environment Variables:
     JOBS_DRIVER: Backend driver ("memory" or "redis"), defaults to "memory"
     REDIS_URL: Redis connection URL for redis driver
     JOB_DEFAULT_TIMEOUT_SECONDS: Per-job execution timeout
-    JOBS_SCHEDULE_JSON: JSON array of scheduled task definitions
+    JOBS_SCHEDULE_JSON: JSON array of interval/cron scheduled task definitions
+    JOBS_SCHEDULER_COORDINATION: Scheduler coordination mode ("auto", "redis", "off")
+    JOBS_SCHEDULER_LEASE_SECONDS: Redis leadership TTL for the scheduler
+    JOBS_SCHEDULER_LEASE_KEY: Redis key used for scheduler leadership
+    JOBS_HANDLER_TARGET: module:path job handler for the CLI runner
+    JOBS_REGISTRY_TARGET: module:path JobRegistry instance or factory for the CLI runner
 
 See Also:
     - docs/jobs.md for detailed documentation
@@ -57,6 +64,9 @@ from __future__ import annotations
 
 # Easy setup function
 from .easy import easy_jobs
+
+# Cloud-safe scheduler coordination
+from .leadership import RedisSchedulerLeader, SchedulerLeadership
 
 # Loader for schedule configuration
 from .loader import schedule_from_env
@@ -74,7 +84,7 @@ from .registry import JobRegistry, JobResult, JobTimeoutError, UnknownJobError
 from .runner import WorkerRunner
 
 # Scheduler for periodic tasks
-from .scheduler import InMemoryScheduler, ScheduledTask
+from .scheduler import CronSchedule, InMemoryScheduler, ScheduledTask
 
 # Worker utilities
 from .worker import process_one
@@ -88,9 +98,12 @@ __all__ = [
     "RedisJobQueue",
     # Scheduler
     "InMemoryScheduler",
+    "CronSchedule",
     "ScheduledTask",
     # Easy setup
     "easy_jobs",
+    "RedisSchedulerLeader",
+    "SchedulerLeadership",
     # Worker utilities
     "process_one",
     "WorkerRunner",

--- a/src/svc_infra/jobs/easy.py
+++ b/src/svc_infra/jobs/easy.py
@@ -4,32 +4,87 @@ import os
 
 from redis import Redis
 
+from svc_infra.deploy import get_redis_url
+
+from .leadership import RedisSchedulerLeader
 from .queue import InMemoryJobQueue, JobQueue
 from .redis_queue import RedisJobQueue
 from .scheduler import InMemoryScheduler
 
 
 class JobsConfig:
-    def __init__(self, driver: str | None = None):
+    def __init__(
+        self,
+        driver: str | None = None,
+        *,
+        scheduler_coordination: str | None = None,
+        scheduler_lease_seconds: int | None = None,
+        scheduler_lease_key: str | None = None,
+    ):
         # Future: support redis/sql drivers via extras
         self.driver = driver or os.getenv("JOBS_DRIVER", "memory").lower()
+        self.scheduler_coordination = (
+            scheduler_coordination or os.getenv("JOBS_SCHEDULER_COORDINATION", "auto")
+        ).lower()
+        self.scheduler_lease_seconds = int(
+            scheduler_lease_seconds or os.getenv("JOBS_SCHEDULER_LEASE_SECONDS", "180")
+        )
+        self.scheduler_lease_key = scheduler_lease_key or os.getenv(
+            "JOBS_SCHEDULER_LEASE_KEY", "jobs:scheduler:leader"
+        )
 
 
-def easy_jobs(*, driver: str | None = None) -> tuple[JobQueue, InMemoryScheduler]:
+def _resolve_jobs_redis_url() -> str:
+    url = (
+        os.getenv("JOBS_REDIS_URL")
+        or get_redis_url(prefer_private=True)
+        or "redis://localhost:6379/0"
+    )
+    if not url.startswith(("redis://", "rediss://", "unix://")):
+        raise ValueError(
+            "Jobs Redis coordination requires a redis://, rediss://, or unix:// URL. "
+            "REST-style Redis URLs are not supported by redis-py."
+        )
+    return url
+
+
+def easy_jobs(
+    *,
+    driver: str | None = None,
+    scheduler_coordination: str | None = None,
+    scheduler_lease_seconds: int | None = None,
+    scheduler_lease_key: str | None = None,
+) -> tuple[JobQueue, InMemoryScheduler]:
     """One-call wiring for jobs: returns (queue, scheduler).
 
     Defaults to in-memory implementations for local/dev. ENV override via JOBS_DRIVER.
     """
-    cfg = JobsConfig(driver=driver)
+    cfg = JobsConfig(
+        driver=driver,
+        scheduler_coordination=scheduler_coordination,
+        scheduler_lease_seconds=scheduler_lease_seconds,
+        scheduler_lease_key=scheduler_lease_key,
+    )
     # Choose backend
     queue: JobQueue
+    redis_client: Redis | None = None
     if cfg.driver == "redis":
-        url: str = (
-            os.getenv("JOBS_REDIS_URL") or os.getenv("REDIS_URL") or "redis://localhost:6379/0"
-        )
-        client = Redis.from_url(url)
-        queue = RedisJobQueue(client)
+        redis_client = Redis.from_url(_resolve_jobs_redis_url())
+        queue = RedisJobQueue(redis_client)
     else:
         queue = InMemoryJobQueue()
-    scheduler = InMemoryScheduler()
+    leader = None
+    if cfg.scheduler_coordination not in {"auto", "off", "none", "redis"}:
+        raise ValueError("scheduler_coordination must be one of: auto, redis, off, none")
+    use_redis_coordination = cfg.scheduler_coordination == "redis" or (
+        cfg.scheduler_coordination == "auto" and cfg.driver == "redis"
+    )
+    if use_redis_coordination:
+        redis_client = redis_client or Redis.from_url(_resolve_jobs_redis_url())
+        leader = RedisSchedulerLeader(
+            redis_client,
+            key=cfg.scheduler_lease_key,
+            lease_seconds=cfg.scheduler_lease_seconds,
+        )
+    scheduler = InMemoryScheduler(leader=leader)
     return queue, scheduler

--- a/src/svc_infra/jobs/easy.py
+++ b/src/svc_infra/jobs/easy.py
@@ -22,16 +22,26 @@ class JobsConfig:
         scheduler_lease_key: str | None = None,
     ):
         # Future: support redis/sql drivers via extras
-        self.driver = driver or os.getenv("JOBS_DRIVER", "memory").lower()
-        self.scheduler_coordination = (
-            scheduler_coordination or os.getenv("JOBS_SCHEDULER_COORDINATION", "auto")
-        ).lower()
-        self.scheduler_lease_seconds = int(
-            scheduler_lease_seconds or os.getenv("JOBS_SCHEDULER_LEASE_SECONDS", "180")
+        driver_value = driver if driver is not None else os.getenv("JOBS_DRIVER", "memory")
+        coordination_value = (
+            scheduler_coordination
+            if scheduler_coordination is not None
+            else os.getenv("JOBS_SCHEDULER_COORDINATION", "auto")
         )
-        self.scheduler_lease_key = scheduler_lease_key or os.getenv(
-            "JOBS_SCHEDULER_LEASE_KEY", "jobs:scheduler:leader"
+        lease_seconds_value = (
+            scheduler_lease_seconds
+            if scheduler_lease_seconds is not None
+            else int(os.getenv("JOBS_SCHEDULER_LEASE_SECONDS", "180"))
         )
+        lease_key_value = (
+            scheduler_lease_key
+            if scheduler_lease_key is not None
+            else os.getenv("JOBS_SCHEDULER_LEASE_KEY", "jobs:scheduler:leader")
+        )
+        self.driver = driver_value if driver is not None else driver_value.lower()
+        self.scheduler_coordination = coordination_value.lower()
+        self.scheduler_lease_seconds = lease_seconds_value
+        self.scheduler_lease_key = lease_key_value
 
 
 def _resolve_jobs_redis_url() -> str:

--- a/src/svc_infra/jobs/leadership.py
+++ b/src/svc_infra/jobs/leadership.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Protocol
+
+from redis import Redis
+
+logger = logging.getLogger(__name__)
+
+_RENEW_LUA = """
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+    return redis.call('EXPIRE', KEYS[1], ARGV[2])
+end
+return 0
+"""
+
+_RELEASE_LUA = """
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+    return redis.call('DEL', KEYS[1])
+end
+return 0
+"""
+
+
+class SchedulerLeadership(Protocol):
+    @property
+    def heartbeat_interval_seconds(self) -> float: ...
+
+    def ensure_leader(self) -> bool: ...
+
+    def release(self) -> None: ...
+
+
+class RedisSchedulerLeader:
+    """Redis-backed leadership lease for cloud-safe scheduler coordination."""
+
+    def __init__(
+        self,
+        client: Redis,
+        *,
+        key: str = "jobs:scheduler:leader",
+        lease_seconds: int = 180,
+        owner_id: str | None = None,
+    ):
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be greater than zero")
+        self._client = client
+        self._key = key
+        self._lease_seconds = lease_seconds
+        self._owner_id = owner_id or str(uuid.uuid4())
+        self._renew_script = None
+        self._release_script = None
+        try:
+            self._renew_script = client.register_script(_RENEW_LUA)
+            self._release_script = client.register_script(_RELEASE_LUA)
+        except Exception as exc:
+            logger.debug("Redis scripting unavailable for scheduler leadership: %s", exc)
+
+    @property
+    def heartbeat_interval_seconds(self) -> float:
+        return max(1.0, self._lease_seconds / 3)
+
+    def ensure_leader(self) -> bool:
+        if self._renew():
+            return True
+        return bool(self._client.set(self._key, self._owner_id, nx=True, ex=self._lease_seconds))
+
+    def release(self) -> None:
+        if self._release_script is not None:
+            try:
+                self._release_script(keys=[self._key], args=[self._owner_id])
+                return
+            except Exception as exc:
+                logger.debug("Redis release script failed for scheduler leadership: %s", exc)
+        if self._read_owner() == self._owner_id:
+            self._client.delete(self._key)
+
+    def _renew(self) -> bool:
+        if self._renew_script is not None:
+            try:
+                return bool(
+                    self._renew_script(
+                        keys=[self._key],
+                        args=[self._owner_id, self._lease_seconds],
+                    )
+                )
+            except Exception as exc:
+                logger.debug("Redis renew script failed for scheduler leadership: %s", exc)
+        if self._read_owner() != self._owner_id:
+            return False
+        return bool(self._client.expire(self._key, self._lease_seconds))
+
+    def _read_owner(self) -> str | None:
+        value = self._client.get(self._key)
+        if value is None:
+            return None
+        return value.decode() if isinstance(value, (bytes, bytearray)) else str(value)

--- a/src/svc_infra/jobs/loader.py
+++ b/src/svc_infra/jobs/loader.py
@@ -1,33 +1,20 @@
 from __future__ import annotations
 
-import asyncio
-import importlib
 import json
 import logging
 import os
-from collections.abc import Awaitable, Callable
-from typing import cast
 
+from .queue import JobQueue
 from .scheduler import InMemoryScheduler
 
 logger = logging.getLogger(__name__)
 
 
-def _resolve_target(path: str) -> Callable[[], Awaitable[None]]:
-    mod_name, func_name = path.split(":", 1)
-    mod = importlib.import_module(mod_name)
-    fn = getattr(mod, func_name)
-    if asyncio.iscoroutinefunction(fn):
-        return cast("Callable[[], Awaitable[None]]", fn)
-
-    # wrap sync into async
-    async def _wrapped():
-        fn()
-
-    return _wrapped
-
-
-def schedule_from_env(scheduler: InMemoryScheduler, env_var: str = "JOBS_SCHEDULE_JSON") -> None:
+def schedule_from_env(
+    scheduler: InMemoryScheduler,
+    queue: JobQueue | None = None,
+    env_var: str = "JOBS_SCHEDULE_JSON",
+) -> None:
     data = os.getenv(env_var)
     if not data:
         return
@@ -40,10 +27,29 @@ def schedule_from_env(scheduler: InMemoryScheduler, env_var: str = "JOBS_SCHEDUL
     for t in tasks:
         try:
             name = t["name"]
-            interval = int(t.get("interval_seconds", 60))
-            target = t["target"]
-            fn = _resolve_target(target)
-            scheduler.add_task(name, interval, fn)
+            interval_seconds = t.get("interval_seconds")
+            if interval_seconds is None and "cron" not in t:
+                interval_seconds = 60
+            kwargs = {
+                "interval_seconds": interval_seconds,
+                "cron": t.get("cron"),
+                "timezone": t.get("timezone"),
+            }
+            if "job_name" in t:
+                scheduler.add(
+                    name,
+                    job_queue=queue,
+                    job_name=t["job_name"],
+                    payload=t.get("payload"),
+                    delay_seconds=int(t.get("delay_seconds", 0)),
+                    **kwargs,
+                )
+            else:
+                scheduler.add(
+                    name,
+                    target=t["target"],
+                    **kwargs,
+                )
         except Exception as e:
             logger.warning("Failed to load scheduled job entry %s: %s", t, e)
             continue

--- a/src/svc_infra/jobs/scheduler.py
+++ b/src/svc_infra/jobs/scheduler.py
@@ -1,53 +1,499 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any, cast
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-CronFunc = Callable[[], Awaitable[None]]
+from .leadership import SchedulerLeadership
+from .targets import resolve_target
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from .queue import JobQueue
+
+ScheduledFunc = Callable[[], Awaitable[None]]
+RawScheduledFunc = Callable[[], object]
+
+_MONTH_ALIASES = {
+    "jan": 1,
+    "feb": 2,
+    "mar": 3,
+    "apr": 4,
+    "may": 5,
+    "jun": 6,
+    "jul": 7,
+    "aug": 8,
+    "sep": 9,
+    "oct": 10,
+    "nov": 11,
+    "dec": 12,
+}
+
+_WEEKDAY_ALIASES = {
+    "sun": 0,
+    "mon": 1,
+    "tue": 2,
+    "wed": 3,
+    "thu": 4,
+    "fri": 5,
+    "sat": 6,
+}
+
+_CRON_MACROS = {
+    "@yearly": "0 0 1 1 *",
+    "@annually": "0 0 1 1 *",
+    "@monthly": "0 0 1 * *",
+    "@weekly": "0 0 * * 0",
+    "@daily": "0 0 * * *",
+    "@midnight": "0 0 * * *",
+    "@hourly": "0 * * * *",
+}
+
+_MAX_CRON_LOOKAHEAD_MINUTES = 60 * 24 * 366 * 5
 
 
-@dataclass
+def _coerce_callable(func: RawScheduledFunc) -> ScheduledFunc:
+    async def _wrapped() -> None:
+        result = func()
+        if inspect.isawaitable(result):
+            await cast("Awaitable[None]", result)
+
+    return _wrapped
+
+
+def _build_enqueue_func(
+    job_queue: JobQueue,
+    job_name: str,
+    *,
+    payload: Mapping[str, Any] | None = None,
+    payload_factory: Callable[[], Mapping[str, Any]] | None = None,
+    delay_seconds: int = 0,
+) -> ScheduledFunc:
+    if payload is not None and payload_factory is not None:
+        raise ValueError("provide at most one of payload or payload_factory")
+    if delay_seconds < 0:
+        raise ValueError("delay_seconds must be greater than or equal to zero")
+
+    async def _enqueue() -> None:
+        current_payload = payload_factory() if payload_factory is not None else (payload or {})
+        job_queue.enqueue(job_name, dict(current_payload), delay_seconds=delay_seconds)
+
+    return _enqueue
+
+
+def _normalize_weekday(value: int) -> int:
+    return 0 if value == 7 else value
+
+
+def _parse_cron_value(
+    token: str,
+    *,
+    aliases: dict[str, int] | None,
+    min_value: int,
+    max_value: int,
+    normalize: Callable[[int], int] | None = None,
+) -> int:
+    lowered = token.strip().lower()
+    if aliases and lowered in aliases:
+        value = aliases[lowered]
+    else:
+        value = int(lowered)
+    if normalize is not None:
+        value = normalize(value)
+    if value < min_value or value > max_value:
+        raise ValueError(f"cron value {token!r} must be within {min_value}..{max_value}")
+    return value
+
+
+def _expand_cron_part(
+    part: str,
+    *,
+    aliases: dict[str, int] | None,
+    min_value: int,
+    max_value: int,
+    normalize: Callable[[int], int] | None = None,
+) -> set[int]:
+    base, step_text = [*part.split("/", 1), "1"][:2]
+    step = int(step_text)
+    if step <= 0:
+        raise ValueError("cron step must be greater than zero")
+
+    if base == "*":
+        start = min_value
+        end = max_value
+    elif "-" in base:
+        start_text, end_text = base.split("-", 1)
+        start = _parse_cron_value(
+            start_text,
+            aliases=aliases,
+            min_value=min_value,
+            max_value=max_value,
+            normalize=normalize,
+        )
+        end = _parse_cron_value(
+            end_text,
+            aliases=aliases,
+            min_value=min_value,
+            max_value=max_value,
+            normalize=normalize,
+        )
+        if start > end:
+            raise ValueError(f"cron range {base!r} is invalid")
+    else:
+        start = _parse_cron_value(
+            base,
+            aliases=aliases,
+            min_value=min_value,
+            max_value=max_value,
+            normalize=normalize,
+        )
+        end = max_value if "/" in part else start
+
+    values = set(range(start, end + 1, step))
+    if normalize is not None:
+        values = {normalize(value) for value in values}
+    return values
+
+
+def _parse_cron_field(
+    field: str,
+    *,
+    aliases: dict[str, int] | None,
+    min_value: int,
+    max_value: int,
+    normalize: Callable[[int], int] | None = None,
+) -> tuple[frozenset[int], bool]:
+    text = field.strip()
+    if not text:
+        raise ValueError("cron field cannot be empty")
+    if text == "*":
+        return frozenset(range(min_value, max_value + 1)), True
+
+    values: set[int] = set()
+    for part in text.split(","):
+        values.update(
+            _expand_cron_part(
+                part.strip(),
+                aliases=aliases,
+                min_value=min_value,
+                max_value=max_value,
+                normalize=normalize,
+            )
+        )
+    return frozenset(values), False
+
+
+@dataclass(frozen=True, slots=True)
+class CronSchedule:
+    expression: str
+    timezone_name: str
+    timezone: ZoneInfo
+    minute_values: frozenset[int]
+    hour_values: frozenset[int]
+    day_values: frozenset[int]
+    month_values: frozenset[int]
+    weekday_values: frozenset[int]
+    day_is_wildcard: bool
+    weekday_is_wildcard: bool
+
+    @classmethod
+    def parse(cls, expression: str, *, timezone: str = "UTC") -> CronSchedule:
+        text = expression.strip()
+        if not text:
+            raise ValueError("cron expression cannot be empty")
+        normalized = _CRON_MACROS.get(text.lower(), text)
+        parts = normalized.split()
+        if len(parts) != 5:
+            raise ValueError("cron expression must have 5 fields: minute hour day month weekday")
+        try:
+            tz = ZoneInfo(timezone)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError(f"unknown timezone {timezone!r}") from exc
+
+        minute_values, _ = _parse_cron_field(
+            parts[0],
+            aliases=None,
+            min_value=0,
+            max_value=59,
+        )
+        hour_values, _ = _parse_cron_field(
+            parts[1],
+            aliases=None,
+            min_value=0,
+            max_value=23,
+        )
+        day_values, day_is_wildcard = _parse_cron_field(
+            parts[2],
+            aliases=None,
+            min_value=1,
+            max_value=31,
+        )
+        month_values, _ = _parse_cron_field(
+            parts[3],
+            aliases=_MONTH_ALIASES,
+            min_value=1,
+            max_value=12,
+        )
+        weekday_values, weekday_is_wildcard = _parse_cron_field(
+            parts[4],
+            aliases=_WEEKDAY_ALIASES,
+            min_value=0,
+            max_value=6,
+            normalize=_normalize_weekday,
+        )
+        return cls(
+            expression=normalized,
+            timezone_name=timezone,
+            timezone=tz,
+            minute_values=minute_values,
+            hour_values=hour_values,
+            day_values=day_values,
+            month_values=month_values,
+            weekday_values=weekday_values,
+            day_is_wildcard=day_is_wildcard,
+            weekday_is_wildcard=weekday_is_wildcard,
+        )
+
+    def matches(self, dt: datetime) -> bool:
+        local_dt = dt.astimezone(self.timezone)
+        cron_weekday = (local_dt.weekday() + 1) % 7
+        day_match = local_dt.day in self.day_values
+        weekday_match = cron_weekday in self.weekday_values
+        if self.day_is_wildcard and self.weekday_is_wildcard:
+            date_match = True
+        elif self.day_is_wildcard:
+            date_match = weekday_match
+        elif self.weekday_is_wildcard:
+            date_match = day_match
+        else:
+            date_match = day_match or weekday_match
+        return (
+            local_dt.minute in self.minute_values
+            and local_dt.hour in self.hour_values
+            and local_dt.month in self.month_values
+            and date_match
+        )
+
+    def next_run_after(self, after: datetime) -> datetime:
+        if after.tzinfo is None:
+            raise ValueError("scheduler datetimes must be timezone-aware")
+        candidate = after.astimezone(self.timezone)
+        if candidate.second or candidate.microsecond:
+            candidate = candidate.replace(second=0, microsecond=0) + timedelta(minutes=1)
+        else:
+            candidate = candidate.replace(second=0, microsecond=0)
+
+        for _ in range(_MAX_CRON_LOOKAHEAD_MINUTES):
+            if self.matches(candidate):
+                return candidate.astimezone(UTC)
+            candidate += timedelta(minutes=1)
+        raise ValueError(
+            f"unable to find next run time for cron expression {self.expression!r} "
+            f"within {_MAX_CRON_LOOKAHEAD_MINUTES} minutes"
+        )
+
+
+@dataclass(slots=True)
 class ScheduledTask:
     name: str
-    interval_seconds: int
-    func: CronFunc
+    func: ScheduledFunc
     next_run_at: datetime
+    interval_seconds: float | None = None
+    cron: str | None = None
+    timezone: str = "UTC"
+    cron_schedule: CronSchedule | None = None
+    job_name: str | None = None
 
 
 class InMemoryScheduler:
-    """Interval-based scheduler for simple periodic tasks (tests/local).
+    """In-process scheduler for interval and cron jobs.
 
-    Not a full cron parser. Tracks next_run_at per task.
+    The scheduler keeps all task state in memory, which makes it a good default
+    for local development, tests, and simple service processes.
     """
 
-    def __init__(self, tick_interval: float = 60.0):
+    def __init__(
+        self,
+        tick_interval: float = 60.0,
+        *,
+        timezone: str = "UTC",
+        now_provider: Callable[[], datetime] | None = None,
+        leader: SchedulerLeadership | None = None,
+    ):
         self._tasks: dict[str, ScheduledTask] = {}
         self._tick_interval = tick_interval
+        self._default_timezone = timezone
+        self._now_provider = now_provider or (lambda: datetime.now(UTC))
+        self._leader = leader
 
-    def add_task(self, name: str, interval_seconds: int, func: CronFunc) -> None:
-        now = datetime.now(UTC)
-        self._tasks[name] = ScheduledTask(
-            name=name,
+    def add_task(self, name: str, interval_seconds: int | float, func: RawScheduledFunc) -> None:
+        self.add(name, interval_seconds=interval_seconds, func=func)
+
+    def add_cron(
+        self,
+        name: str,
+        cron: str,
+        func: RawScheduledFunc,
+        *,
+        timezone: str | None = None,
+    ) -> None:
+        self.add(name, cron=cron, func=func, timezone=timezone)
+
+    def add(
+        self,
+        name: str,
+        *,
+        interval_seconds: int | float | None = None,
+        cron: str | None = None,
+        func: RawScheduledFunc | None = None,
+        target: str | None = None,
+        job_queue: JobQueue | None = None,
+        job_name: str | None = None,
+        payload: Mapping[str, Any] | None = None,
+        payload_factory: Callable[[], Mapping[str, Any]] | None = None,
+        delay_seconds: int = 0,
+        timezone: str | None = None,
+    ) -> None:
+        if (interval_seconds is None) == (cron is None):
+            raise ValueError("provide exactly one of interval_seconds or cron")
+        action_count = sum(value is not None for value in (func, target, job_name))
+        if action_count != 1:
+            raise ValueError("provide exactly one of func, target, or job_name")
+
+        task_job_name = job_name
+        if job_name is not None:
+            if job_queue is None:
+                raise ValueError("job_queue is required when job_name is provided")
+            wrapped_func = _build_enqueue_func(
+                job_queue,
+                job_name,
+                payload=payload,
+                payload_factory=payload_factory,
+                delay_seconds=delay_seconds,
+            )
+        else:
+            if payload is not None or payload_factory is not None or delay_seconds:
+                raise ValueError(
+                    "payload, payload_factory, and delay_seconds are only valid for job_name schedules"
+                )
+            resolved = (
+                func
+                if func is not None
+                else cast("RawScheduledFunc", resolve_target(cast("str", target)))
+            )
+            wrapped_func = _coerce_callable(resolved)
+        now = self._now()
+
+        if interval_seconds is not None:
+            interval = float(interval_seconds)
+            if interval < 0:
+                raise ValueError("interval_seconds must be greater than or equal to zero")
+            task = ScheduledTask(
+                name=name,
+                func=wrapped_func,
+                interval_seconds=interval,
+                next_run_at=now + timedelta(seconds=interval),
+                job_name=task_job_name,
+            )
+        else:
+            task_timezone = timezone or self._default_timezone
+            cron_schedule = CronSchedule.parse(cast("str", cron), timezone=task_timezone)
+            task = ScheduledTask(
+                name=name,
+                func=wrapped_func,
+                next_run_at=cron_schedule.next_run_after(now),
+                cron=cron_schedule.expression,
+                timezone=task_timezone,
+                cron_schedule=cron_schedule,
+                job_name=task_job_name,
+            )
+
+        self._tasks[name] = task
+
+    def add_job(
+        self,
+        name: str,
+        *,
+        job_queue: JobQueue,
+        job_name: str,
+        interval_seconds: int | float | None = None,
+        cron: str | None = None,
+        payload: Mapping[str, Any] | None = None,
+        payload_factory: Callable[[], Mapping[str, Any]] | None = None,
+        delay_seconds: int = 0,
+        timezone: str | None = None,
+    ) -> None:
+        self.add(
+            name,
             interval_seconds=interval_seconds,
-            func=func,
-            next_run_at=now + timedelta(seconds=interval_seconds),
+            cron=cron,
+            job_queue=job_queue,
+            job_name=job_name,
+            payload=payload,
+            payload_factory=payload_factory,
+            delay_seconds=delay_seconds,
+            timezone=timezone,
         )
 
-    async def tick(self) -> None:
-        now = datetime.now(UTC)
+    async def tick(self, *, now: datetime | None = None) -> None:
+        if self._leader is not None and not self._leader.ensure_leader():
+            return
+        current = now or self._now()
         for task in self._tasks.values():
-            if task.next_run_at <= now:
-                await task.func()
-                task.next_run_at = now + timedelta(seconds=task.interval_seconds)
+            if task.next_run_at <= current:
+                await self._run_task(task.func)
+                if task.cron_schedule is not None:
+                    task.next_run_at = task.cron_schedule.next_run_after(
+                        current + timedelta(microseconds=1)
+                    )
+                else:
+                    interval = task.interval_seconds or 0.0
+                    task.next_run_at = current + timedelta(seconds=interval)
 
     async def run(self) -> None:
-        """Run the scheduler loop indefinitely.
+        """Run the scheduler loop indefinitely."""
+        sleep_interval = self._tick_interval
+        if self._leader is not None:
+            sleep_interval = min(self._tick_interval, self._leader.heartbeat_interval_seconds)
+        try:
+            while True:
+                await self.tick()
+                await asyncio.sleep(sleep_interval)
+        finally:
+            self.close()
 
-        Calls tick() at regular intervals to check and execute due tasks.
-        This method runs forever until cancelled.
-        """
+    def _now(self) -> datetime:
+        current = self._now_provider()
+        if current.tzinfo is None:
+            raise ValueError("scheduler now_provider must return a timezone-aware datetime")
+        return current.astimezone(UTC)
+
+    def close(self) -> None:
+        if self._leader is not None:
+            self._leader.release()
+
+    async def _run_task(self, func: ScheduledFunc) -> None:
+        if self._leader is None:
+            await func()
+            return
+
+        heartbeat = asyncio.create_task(self._heartbeat_while_running())
+        try:
+            await func()
+        finally:
+            heartbeat.cancel()
+            with suppress(asyncio.CancelledError):
+                await heartbeat
+
+    async def _heartbeat_while_running(self) -> None:
+        if self._leader is None:
+            return
         while True:
-            await self.tick()
-            await asyncio.sleep(self._tick_interval)
+            await asyncio.sleep(self._leader.heartbeat_interval_seconds)
+            self._leader.ensure_leader()

--- a/src/svc_infra/jobs/targets.py
+++ b/src/svc_infra/jobs/targets.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import importlib
+
+
+def resolve_target(path: str) -> object:
+    """Resolve a module:attribute(.nested) target string."""
+    mod_name, attr_path = path.split(":", 1)
+    obj: object = importlib.import_module(mod_name)
+    for part in attr_path.split("."):
+        obj = getattr(obj, part)
+    return obj

--- a/src/svc_infra/jobs/targets.py
+++ b/src/svc_infra/jobs/targets.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import importlib
+from typing import Any
 
 
-def resolve_target(path: str) -> object:
+def resolve_target(path: str) -> Any:
     """Resolve a module:attribute(.nested) target string."""
     mod_name, attr_path = path.split(":", 1)
-    obj: object = importlib.import_module(mod_name)
+    obj: Any = importlib.import_module(mod_name)
     for part in attr_path.split("."):
         obj = getattr(obj, part)
     return obj

--- a/src/svc_infra/mcp/svc_infra_mcp.py
+++ b/src/svc_infra/mcp/svc_infra_mcp.py
@@ -112,12 +112,15 @@ async def svc_infra_subcmd_help(subcommand: Subcommand) -> dict[Any, Any]:
 
 mcp = mcp_from_functions(
     name="svc-infra-cli-mcp",
-    functions=[
-        svc_infra_cmd_help,
-        svc_infra_subcmd_help,
-        svc_infra_docs_help,
-        # Docs listing is available via 'docs --help'; no separate MCP function needed.
-    ],
+    functions=cast(
+        "list[Any]",
+        [
+            svc_infra_cmd_help,
+            svc_infra_subcmd_help,
+            svc_infra_docs_help,
+            # Docs listing is available via 'docs --help'; no separate MCP function needed.
+        ],
+    ),
 )
 
 

--- a/tests/acceptance/_seed.py
+++ b/tests/acceptance/_seed.py
@@ -1,5 +1,7 @@
 import os
 
+from svc_infra.jobs import Job, JobRegistry, JobResult
+
 
 def acceptance_seed():
     """
@@ -22,3 +24,15 @@ def write_sentinel():
     with open(path, "w", encoding="utf-8") as f:
         f.write("ok")
     return None
+
+
+registry = JobRegistry(metric_prefix="acceptance_jobs")
+
+
+@registry.handler("write_sentinel_job")
+async def handle_write_sentinel_job(job: Job) -> JobResult:
+    path = job.payload.get("path") or os.environ.get("JOBS_SENTINEL", "/tmp/svc-infra-a10-jobs.ok")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("ok")
+    return JobResult(success=True, message="sentinel written", details={"path": path})

--- a/tests/acceptance/test_docs_sdks_a10_acceptance.py
+++ b/tests/acceptance/test_docs_sdks_a10_acceptance.py
@@ -103,6 +103,26 @@ def test_a1002_jobs_runner_consumes_task(tmp_path: Path):
     assert sentinel.exists() and sentinel.read_text().strip() == "ok"
 
 
+def test_a1004_jobs_runner_schedules_and_processes_queued_jobs(tmp_path: Path):
+    sentinel = tmp_path / "jobs-queued.ok"
+    schedule = [
+        {
+            "name": "queued-sentinel",
+            "interval_seconds": 0,
+            "job_name": "write_sentinel_job",
+            "payload": {"path": str(sentinel)},
+        }
+    ]
+    env = {
+        "JOBS_SCHEDULE_JSON": json.dumps(schedule),
+        "JOBS_DRIVER": "memory",
+        "JOBS_REGISTRY_TARGET": "tests.acceptance._seed:registry",
+        "PROJECT_ROOT": str(tmp_path),
+    }
+    _py(["jobs", "run", "--poll-interval", "0.1", "--max-loops", "3"], env=env)
+    assert sentinel.exists() and sentinel.read_text().strip() == "ok"
+
+
 def test_a1003_sdk_cli_dry_run(tmp_path: Path, client: httpx.Client):
     # Fetch OpenAPI and write to disk
     schema_path = tmp_path / "openapi.json"

--- a/tests/unit/jobs/test_easy.py
+++ b/tests/unit/jobs/test_easy.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from svc_infra.jobs.easy import JobsConfig, easy_jobs
 from svc_infra.jobs.queue import InMemoryJobQueue
 from svc_infra.jobs.scheduler import InMemoryScheduler
@@ -97,6 +99,17 @@ class TestEasyJobs:
 
                 mock_redis.from_url.assert_called_once_with("redis://test:6379/1")
 
+    def test_redis_driver_enables_scheduler_coordination_by_default(self) -> None:
+        """Redis-backed jobs should auto-enable scheduler leadership."""
+        with patch.dict(os.environ, {"JOBS_DRIVER": "redis", "REDIS_URL": "redis://test:6379/1"}):
+            with patch("svc_infra.jobs.easy.Redis") as mock_redis:
+                mock_client = MagicMock()
+                mock_redis.from_url.return_value = mock_client
+
+                _queue, scheduler = easy_jobs(driver="redis")
+
+                assert scheduler._leader is not None
+
     def test_redis_driver_default_url(self) -> None:
         """Redis driver should use default URL if not set."""
         env = {"JOBS_DRIVER": "redis"}
@@ -109,6 +122,35 @@ class TestEasyJobs:
                 _queue, _scheduler = easy_jobs(driver="redis")
 
                 mock_redis.from_url.assert_called_once_with("redis://localhost:6379/0")
+
+    def test_scheduler_coordination_can_be_disabled(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "JOBS_DRIVER": "redis",
+                "REDIS_URL": "redis://test:6379/1",
+                "JOBS_SCHEDULER_COORDINATION": "off",
+            },
+        ):
+            with patch("svc_infra.jobs.easy.Redis") as mock_redis:
+                mock_client = MagicMock()
+                mock_redis.from_url.return_value = mock_client
+
+                _queue, scheduler = easy_jobs(driver="redis")
+
+                assert scheduler._leader is None
+
+    def test_redis_driver_rejects_rest_style_urls(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "JOBS_DRIVER": "redis",
+                "UPSTASH_REDIS_REST_URL": "https://example.upstash.io",
+            },
+            clear=True,
+        ):
+            with pytest.raises(ValueError, match="redis://, rediss://, or unix://"):
+                easy_jobs(driver="redis")
 
 
 class TestEasyJobsIntegration:

--- a/tests/unit/jobs/test_leadership.py
+++ b/tests/unit/jobs/test_leadership.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from svc_infra.jobs.leadership import RedisSchedulerLeader
+from svc_infra.jobs.scheduler import InMemoryScheduler
+
+pytestmark = pytest.mark.jobs
+
+
+@pytest.fixture()
+def fakeredis():
+    try:
+        import fakeredis
+    except Exception:  # pragma: no cover - dependency may not exist
+        pytest.skip("fakeredis not installed")
+    return fakeredis.FakeRedis()
+
+
+def test_redis_scheduler_leader_enforces_single_owner(fakeredis):
+    leader_a = RedisSchedulerLeader(
+        fakeredis,
+        key="jobs:test:leader",
+        lease_seconds=30,
+        owner_id="worker-a",
+    )
+    leader_b = RedisSchedulerLeader(
+        fakeredis,
+        key="jobs:test:leader",
+        lease_seconds=30,
+        owner_id="worker-b",
+    )
+
+    assert leader_a.ensure_leader() is True
+    assert leader_b.ensure_leader() is False
+
+    leader_a.release()
+
+    assert leader_b.ensure_leader() is True
+
+
+@pytest.mark.asyncio
+async def test_scheduler_tick_only_runs_on_active_leader(fakeredis):
+    ran = 0
+
+    async def task():
+        nonlocal ran
+        ran += 1
+
+    leader_a = RedisSchedulerLeader(
+        fakeredis,
+        key="jobs:test:scheduler",
+        lease_seconds=30,
+        owner_id="scheduler-a",
+    )
+    leader_b = RedisSchedulerLeader(
+        fakeredis,
+        key="jobs:test:scheduler",
+        lease_seconds=30,
+        owner_id="scheduler-b",
+    )
+
+    scheduler_a = InMemoryScheduler(leader=leader_a)
+    scheduler_b = InMemoryScheduler(leader=leader_b)
+    scheduler_a.add_task("tick", interval_seconds=0, func=task)
+    scheduler_b.add_task("tick", interval_seconds=0, func=task)
+
+    await scheduler_a.tick()
+    await scheduler_b.tick()
+
+    assert ran == 1

--- a/tests/unit/jobs/test_loader.py
+++ b/tests/unit/jobs/test_loader.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from svc_infra.jobs.loader import schedule_from_env
+from svc_infra.jobs.queue import InMemoryJobQueue
+from svc_infra.jobs.scheduler import InMemoryScheduler
+
+pytestmark = pytest.mark.jobs
+
+_CALLS: list[str] = []
+
+
+def loader_sync_task() -> None:
+    _CALLS.append("sync")
+
+
+async def loader_async_task() -> None:
+    _CALLS.append("async")
+
+
+@pytest.mark.asyncio
+async def test_schedule_from_env_loads_interval_and_cron_tasks(monkeypatch: pytest.MonkeyPatch):
+    _CALLS.clear()
+    start = datetime(2026, 3, 29, 9, 0, tzinfo=UTC)
+    scheduler = InMemoryScheduler(now_provider=lambda: start)
+    monkeypatch.setenv(
+        "JOBS_SCHEDULE_JSON",
+        json.dumps(
+            [
+                {
+                    "name": "interval-task",
+                    "interval_seconds": 0,
+                    "target": f"{__name__}:loader_sync_task",
+                },
+                {
+                    "name": "cron-task",
+                    "cron": "0 9 * * *",
+                    "target": f"{__name__}:loader_async_task",
+                },
+            ]
+        ),
+    )
+
+    schedule_from_env(scheduler)
+    await scheduler.tick(now=start)
+
+    assert _CALLS == ["sync", "async"]
+
+
+def test_schedule_from_env_defaults_to_60_second_intervals(monkeypatch: pytest.MonkeyPatch):
+    scheduler = InMemoryScheduler(now_provider=lambda: datetime(2026, 3, 29, 9, 0, tzinfo=UTC))
+    monkeypatch.setenv(
+        "JOBS_SCHEDULE_JSON",
+        json.dumps(
+            [
+                {
+                    "name": "default-interval",
+                    "target": f"{__name__}:loader_sync_task",
+                }
+            ]
+        ),
+    )
+
+    schedule_from_env(scheduler)
+
+    assert scheduler._tasks["default-interval"].interval_seconds == 60
+
+
+@pytest.mark.asyncio
+async def test_schedule_from_env_loads_scheduled_job_entries(monkeypatch: pytest.MonkeyPatch):
+    queue = InMemoryJobQueue()
+    start = datetime(2026, 3, 29, 9, 0, tzinfo=UTC)
+    scheduler = InMemoryScheduler(now_provider=lambda: start)
+    monkeypatch.setenv(
+        "JOBS_SCHEDULE_JSON",
+        json.dumps(
+            [
+                {
+                    "name": "scheduled-email",
+                    "interval_seconds": 0,
+                    "job_name": "send_email",
+                    "payload": {"to": "queue@example.com"},
+                }
+            ]
+        ),
+    )
+
+    schedule_from_env(scheduler, queue=queue)
+    await scheduler.tick(now=start)
+
+    job = queue.reserve_next()
+    assert job is not None
+    assert job.name == "send_email"
+    assert job.payload == {"to": "queue@example.com"}

--- a/tests/unit/jobs/test_scheduler.py
+++ b/tests/unit/jobs/test_scheduler.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import asyncio
+from datetime import UTC, datetime
+
 import pytest
 
+from svc_infra.jobs.queue import InMemoryJobQueue
 from svc_infra.jobs.scheduler import InMemoryScheduler
 
 pytestmark = pytest.mark.jobs
@@ -15,8 +19,109 @@ async def test_scheduler_runs_task_on_tick():
         nonlocal ran
         ran = True
 
-    s = InMemoryScheduler()
-    s.add_task("t1", interval_seconds=0, func=task)
+    scheduler = InMemoryScheduler()
+    scheduler.add_task("t1", interval_seconds=0, func=task)
 
-    await s.tick()
+    await scheduler.tick()
     assert ran is True
+
+
+@pytest.mark.asyncio
+async def test_scheduler_runs_cron_task_and_advances_next_run():
+    ran = 0
+    now = datetime(2026, 3, 29, 9, 0, tzinfo=UTC)
+
+    async def task():
+        nonlocal ran
+        ran += 1
+
+    scheduler = InMemoryScheduler(now_provider=lambda: now)
+    scheduler.add_cron("daily-digest", "0 9 * * *", task)
+
+    await scheduler.tick(now=now)
+
+    assert ran == 1
+    assert scheduler._tasks["daily-digest"].next_run_at == datetime(2026, 3, 30, 9, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_scheduler_supports_cron_aliases_and_timezones():
+    ran = 0
+    now = datetime(2026, 3, 30, 12, 59, tzinfo=UTC)
+
+    async def task():
+        nonlocal ran
+        ran += 1
+
+    scheduler = InMemoryScheduler(now_provider=lambda: now)
+    scheduler.add(
+        "market-open",
+        cron="0 9 * * mon-fri",
+        func=task,
+        timezone="America/New_York",
+    )
+
+    await scheduler.tick(now=datetime(2026, 3, 30, 13, 0, tzinfo=UTC))
+
+    assert ran == 1
+
+
+@pytest.mark.asyncio
+async def test_scheduler_renews_leadership_while_task_runs():
+    class CountingLeader:
+        heartbeat_interval_seconds = 0.01
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def ensure_leader(self) -> bool:
+            self.calls += 1
+            return True
+
+        def release(self) -> None:
+            return None
+
+    leader = CountingLeader()
+
+    async def task():
+        await asyncio.sleep(0.03)
+
+    scheduler = InMemoryScheduler(leader=leader)
+    scheduler.add_task("long-task", interval_seconds=0, func=task)
+
+    await scheduler.tick()
+
+    assert leader.calls >= 2
+
+
+@pytest.mark.asyncio
+async def test_scheduler_can_enqueue_jobs_durably():
+    queue = InMemoryJobQueue()
+    scheduler = InMemoryScheduler()
+    scheduler.add_job(
+        "daily-email",
+        job_queue=queue,
+        job_name="send_email",
+        interval_seconds=0,
+        payload={"to": "user@example.com"},
+    )
+
+    await scheduler.tick()
+
+    job = queue.reserve_next()
+    assert job is not None
+    assert job.name == "send_email"
+    assert job.payload == {"to": "user@example.com"}
+
+
+def test_scheduler_add_rejects_invalid_schedule_configuration():
+    scheduler = InMemoryScheduler()
+
+    with pytest.raises(ValueError, match="exactly one of interval_seconds or cron"):
+        scheduler.add("bad", func=lambda: None)
+
+    with pytest.raises(ValueError, match="exactly one of interval_seconds or cron"):
+        scheduler.add("bad", interval_seconds=60, cron="0 * * * *", func=lambda: None)
+
+    with pytest.raises(ValueError, match="exactly one of func, target, or job_name"):
+        scheduler.add("bad", interval_seconds=60)


### PR DESCRIPTION
## Summary
- add cron-capable and interval-capable scheduler DX to `svc_infra.jobs`
- support durable scheduled queue jobs, Redis-backed scheduler leadership, and handler/registry-driven CLI workers
- align root docs, API doc stubs, and tests with the new jobs primitives

## What changed
- added scheduler leadership primitives for cloud-safe multi-replica scheduling
- added queue-backed scheduled job emission via `scheduler.add_job(...)` and `JOBS_SCHEDULE_JSON`
- expanded `easy_jobs()` and the jobs CLI to support Redis coordination plus handler/registry targets
- updated `README.md`, `docs/jobs.md`, `docs/cli.md`, `docs/environment.md`, and generated API docs under `docs/api/`
- added/updated unit and acceptance coverage for scheduling, leadership, loader behavior, and queued scheduled jobs

## Validation
- `PYTHONPATH=src pytest tests/unit/jobs/test_scheduler.py tests/unit/jobs/test_loader.py tests/unit/jobs/test_easy.py tests/unit/jobs/test_jobs_runner_cli.py tests/unit/jobs/test_leadership.py tests/unit/jobs/test_redis_queue.py tests/acceptance/test_jobs_and_scheduler_acceptance.py tests/acceptance/test_docs_sdks_a10_acceptance.py -q`
- `ruff check src/svc_infra/jobs src/svc_infra/cli/cmds/jobs tests/unit/jobs/test_scheduler.py tests/unit/jobs/test_loader.py tests/unit/jobs/test_easy.py tests/unit/jobs/test_leadership.py tests/acceptance/test_docs_sdks_a10_acceptance.py tests/acceptance/_seed.py`
- `python -m compileall src/svc_infra/jobs src/svc_infra/cli/cmds/jobs`

## Notes
- The repo's `API Docs Generation` pre-commit hook currently hangs inside `scripts/extract_api_docs.py` while resolving existing exported aliases. I verified and committed the generated `docs/api/*` changes directly, and all other pre-commit hooks passed.
