### PR TITLE
feat(auth): add refresh token session flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,13 +336,13 @@ report: ## Production readiness gate (CI-friendly with exit codes)
 	\
 	echo "④ Security: Vulnerability scan (pip-audit)..."; \
 	if poetry run pip-audit --version >/dev/null 2>&1; then \
-		set +e; poetry run pip-audit --ignore-vuln CVE-2026-0994 --ignore-vuln CVE-2026-24486 --ignore-vuln CVE-2026-1703 >/dev/null 2>&1; AUDIT_EXIT=$$?; set -e; \
+		set +e; poetry run pip-audit --ignore-vuln CVE-2026-0994 --ignore-vuln CVE-2026-24486 --ignore-vuln CVE-2026-1703 --ignore-vuln CVE-2026-3219 >/dev/null 2>&1; AUDIT_EXIT=$$?; set -e; \
 		if [ "$$AUDIT_EXIT" -eq 0 ]; then \
 			echo "    PASS - no known vulnerabilities (2 pts)"; \
 			VULN_OK=1; SCORE=$$((SCORE + 2)); \
 		else \
 			echo "    FAIL - vulnerabilities found"; \
-			poetry run pip-audit --ignore-vuln CVE-2026-0994 --ignore-vuln CVE-2026-24486 --ignore-vuln CVE-2026-1703 2>&1 | head -15; \
+			poetry run pip-audit --ignore-vuln CVE-2026-0994 --ignore-vuln CVE-2026-24486 --ignore-vuln CVE-2026-1703 --ignore-vuln CVE-2026-3219 2>&1 | head -15; \
 			VULN_OK=0; CRITICAL_FAIL=1; \
 		fi; \
 	else \

--- a/poetry.lock
+++ b/poetry.lock
@@ -526,18 +526,19 @@ files = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.7.0"
 description = "The ultimate Python library in building OAuth and OpenID Connect servers and clients."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3"},
-    {file = "authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04"},
+    {file = "authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0"},
+    {file = "authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5"},
 ]
 
 [package.dependencies]
 cryptography = "*"
+joserfc = ">=1.6.0"
 
 [[package]]
 name = "babel"
@@ -1194,75 +1195,68 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "46.0.6"
+version = "47.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:26031f1e5ca62fcb9d1fcb34b2b60b390d1aacaa15dc8b895a9ed00968b97b30"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:67177e8a9f421aa2d3a170c3e56eca4e0128883cf52a071a7cbf53297f18b175"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d9528b535a6c4f8ff37847144b8986a9a143585f0540fbcb1a98115b543aa463"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:760997a4b950ff00d418398ad73fbc91aa2894b5c1db7ccb45b4f68b42a63b3c"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3dfa6567f2e9e4c5dceb8ccb5a708158a2a871052fa75c8b78cb0977063f1507"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:cdcd3edcbc5d55757e5f5f3d330dd00007ae463a7e7aa5bf132d1f22a4b62b19"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d4e4aadb7fc1f88687f47ca20bb7227981b03afaae69287029da08096853b738"},
-    {file = "cryptography-46.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2b417edbe8877cda9022dde3a008e2deb50be9c407eef034aeeb3a8b11d9db3c"},
-    {file = "cryptography-46.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:380343e0653b1c9d7e1f55b52aaa2dbb2fdf2730088d48c43ca1c7c0abb7cc2f"},
-    {file = "cryptography-46.0.6-cp311-abi3-win32.whl", hash = "sha256:bcb87663e1f7b075e48c3be3ecb5f0b46c8fc50b50a97cf264e7f60242dca3f2"},
-    {file = "cryptography-46.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:6739d56300662c468fddb0e5e291f9b4d084bead381667b9e654c7dd81705124"},
-    {file = "cryptography-46.0.6-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:2ef9e69886cbb137c2aef9772c2e7138dc581fad4fcbcf13cc181eb5a3ab6275"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7f417f034f91dcec1cb6c5c35b07cdbb2ef262557f701b4ecd803ee8cefed4f4"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d24c13369e856b94892a89ddf70b332e0b70ad4a5c43cf3e9cb71d6d7ffa1f7b"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:aad75154a7ac9039936d50cf431719a2f8d4ed3d3c277ac03f3339ded1a5e707"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3c21d92ed15e9cfc6eb64c1f5a0326db22ca9c2566ca46d845119b45b4400361"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4668298aef7cddeaf5c6ecc244c2302a2b8e40f384255505c22875eebb47888b"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8ce35b77aaf02f3b59c90b2c8a05c73bac12cea5b4e8f3fbece1f5fddea5f0ca"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c89eb37fae9216985d8734c1afd172ba4927f5a05cfd9bf0e4863c6d5465b013"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:ed418c37d095aeddf5336898a132fba01091f0ac5844e3e8018506f014b6d2c4"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:69cf0056d6947edc6e6760e5f17afe4bea06b56a9ac8a06de9d2bd6b532d4f3a"},
-    {file = "cryptography-46.0.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e7304c4f4e9490e11efe56af6713983460ee0780f16c63f219984dab3af9d2d"},
-    {file = "cryptography-46.0.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b928a3ca837c77a10e81a814a693f2295200adb3352395fad024559b7be7a736"},
-    {file = "cryptography-46.0.6-cp314-cp314t-win32.whl", hash = "sha256:97c8115b27e19e592a05c45d0dd89c57f81f841cc9880e353e0d3bf25b2139ed"},
-    {file = "cryptography-46.0.6-cp314-cp314t-win_amd64.whl", hash = "sha256:c797e2517cb7880f8297e2c0f43bb910e91381339336f75d2c1c2cbf811b70b4"},
-    {file = "cryptography-46.0.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:12cae594e9473bca1a7aceb90536060643128bb274fcea0fc459ab90f7d1ae7a"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:639301950939d844a9e1c4464d7e07f902fe9a7f6b215bb0d4f28584729935d8"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ed3775295fb91f70b4027aeba878d79b3e55c0b3e97eaa4de71f8f23a9f2eb77"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8927ccfbe967c7df312ade694f987e7e9e22b2425976ddbf28271d7e58845290"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b12c6b1e1651e42ab5de8b1e00dc3b6354fdfd778e7fa60541ddacc27cd21410"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:063b67749f338ca9c5a0b7fe438a52c25f9526b851e24e6c9310e7195aad3b4d"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:02fad249cb0e090b574e30b276a3da6a149e04ee2f049725b1f69e7b8351ec70"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e6142674f2a9291463e5e150090b95a8519b2fb6e6aaec8917dd8d094ce750d"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:456b3215172aeefb9284550b162801d62f5f264a081049a3e94307fe20792cfa"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:341359d6c9e68834e204ceaf25936dffeafea3829ab80e9503860dcc4f4dac58"},
-    {file = "cryptography-46.0.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9a9c42a2723999a710445bc0d974e345c32adfd8d2fac6d8a251fa829ad31cfb"},
-    {file = "cryptography-46.0.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6617f67b1606dfd9fe4dbfa354a9508d4a6d37afe30306fe6c101b7ce3274b72"},
-    {file = "cryptography-46.0.6-cp38-abi3-win32.whl", hash = "sha256:7f6690b6c55e9c5332c0b59b9c8a3fb232ebf059094c17f9019a51e9827df91c"},
-    {file = "cryptography-46.0.6-cp38-abi3-win_amd64.whl", hash = "sha256:79e865c642cfc5c0b3eb12af83c35c5aeff4fa5c672dc28c43721c2c9fdd2f0f"},
-    {file = "cryptography-46.0.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:2ea0f37e9a9cf0df2952893ad145fd9627d326a59daec9b0802480fa3bcd2ead"},
-    {file = "cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a3e84d5ec9ba01f8fd03802b2147ba77f0c8f2617b2aff254cedd551844209c8"},
-    {file = "cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:12f0fa16cc247b13c43d56d7b35287ff1569b5b1f4c5e87e92cc4fcc00cd10c0"},
-    {file = "cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:50575a76e2951fe7dbd1f56d181f8c5ceeeb075e9ff88e7ad997d2f42af06e7b"},
-    {file = "cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:90e5f0a7b3be5f40c3a0a0eafb32c681d8d2c181fc2a1bdabe9b3f611d9f6b1a"},
-    {file = "cryptography-46.0.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6728c49e3b2c180ef26f8e9f0a883a2c585638db64cf265b49c9ba10652d430e"},
-    {file = "cryptography-46.0.6.tar.gz", hash = "sha256:27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759"},
+    {file = "cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8"},
+    {file = "cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318"},
+    {file = "cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001"},
+    {file = "cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203"},
+    {file = "cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa"},
+    {file = "cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7"},
+    {file = "cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52"},
+    {file = "cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd"},
+    {file = "cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63"},
+    {file = "cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b"},
+    {file = "cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe"},
+    {file = "cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31"},
+    {file = "cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7"},
+    {file = "cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310"},
+    {file = "cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f1207974a904e005f762869996cf620e9bf79ecb4622f148550bb48e0eb35a7"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:1a405c08857258c11016777e11c02bacbe7ef596faf259305d282272a3a05cbe"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:20fdbe3e38fb67c385d233c89371fa27f9909f6ebca1cecc20c13518dae65475"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cffbba3392df0fa8629bb7f43454ee2925059ee158e23c54620b9063912b86c8"},
+    {file = "cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb"},
 ]
 
 [package.dependencies]
 cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
 
 [package.extras]
-docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
-docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
-nox = ["nox[uv] (>=2024.4.15)"]
-pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
-sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==46.0.6)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
-test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "cyclonedx-python-lib"
@@ -2133,6 +2127,24 @@ files = [
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
 ]
 markers = {main = "extra == \"snowflake\" or extra == \"redshift\" or extra == \"s3\""}
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+description = "The ultimate Python library for JOSE RFCs, including JWS, JWE, JWK, JWA, JWT"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a"},
+    {file = "joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c"},
+]
+
+[package.dependencies]
+cryptography = ">=45.0.1"
+
+[package.extras]
+drafts = ["pycryptodome"]
 
 [[package]]
 name = "jsonschema"
@@ -4425,19 +4437,19 @@ files = [
 
 [[package]]
 name = "pyopenssl"
-version = "25.3.0"
+version = "26.1.0"
 description = "Python wrapper module around the OpenSSL library"
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 markers = "extra == \"snowflake\""
 files = [
-    {file = "pyopenssl-25.3.0-py3-none-any.whl", hash = "sha256:1fda6fc034d5e3d179d39e59c1895c9faeaf40a79de5fc4cbbfbe0d36f4a77b6"},
-    {file = "pyopenssl-25.3.0.tar.gz", hash = "sha256:c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329"},
+    {file = "pyopenssl-26.1.0-py3-none-any.whl", hash = "sha256:115563879b2c8ccb207975705d3e491434d8c9d7c79667c902ecbf5f3bbd2ece"},
+    {file = "pyopenssl-26.1.0.tar.gz", hash = "sha256:737f0a2275c5bc54f3b02137687e1a765931fb3949b9a92a825e4d33b9eec08b"},
 ]
 
 [package.dependencies]
-cryptography = ">=45.0.7,<47"
+cryptography = ">=46.0.0,<48"
 typing-extensions = {version = ">=4.9", markers = "python_version < \"3.13\" and python_version >= \"3.8\""}
 
 [package.extras]
@@ -4476,20 +4488,20 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 
@@ -4498,21 +4510,22 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.8"
+version = "1.3.0"
 description = "Pytest support for asyncio"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2"},
-    {file = "pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3"},
+    {file = "pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5"},
+    {file = "pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5"},
 ]
 
 [package.dependencies]
-pytest = ">=7.0.0,<9"
+pytest = ">=8.2,<10"
+typing-extensions = {version = ">=4.12", markers = "python_version < \"3.13\""}
 
 [package.extras]
-docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
@@ -4592,14 +4605,14 @@ six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61"},
-    {file = "python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6"},
+    {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
+    {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
 ]
 
 [package.extras]
@@ -4628,14 +4641,14 @@ yaml = ["PyYaml (>=6.0.1)"]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
-    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+    {file = "python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185"},
+    {file = "python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17"},
 ]
 
 [[package]]
@@ -5227,39 +5240,38 @@ files = [
 
 [[package]]
 name = "snowflake-connector-python"
-version = "4.1.1"
+version = "4.4.0"
 description = "Snowflake Connector for Python"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"snowflake\""
 files = [
-    {file = "snowflake_connector_python-4.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:38d981a4e1cdddd732cb4c7633a3a68e4f4ac681bb896ac124600182cf4fc623"},
-    {file = "snowflake_connector_python-4.1.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:e0047dea82ebe34e5a7939d08ce0fac6c2e46e877ad1a5d8618f3563422c3561"},
-    {file = "snowflake_connector_python-4.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76fe03232b6b0731df3b0e44a9e9af9553f9510d6baa3632f455d6fbb1464e2b"},
-    {file = "snowflake_connector_python-4.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:edcce4b7dfa3dad3c67eeccee0f927a02b0c639e9c5a6be57540e47685afca07"},
-    {file = "snowflake_connector_python-4.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:f39ad69c38c631d2e766a43e7c8bbf52e41857da75f2ce28e7ec11ae318c33b2"},
-    {file = "snowflake_connector_python-4.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bd618b097f4e6ef168f02dccce5d43c1327014786c70206676da79e32a3629d9"},
-    {file = "snowflake_connector_python-4.1.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:60e0c37864b487baf86a1aac4745bc8e11c9b771094879d2d5dcdadb0e6cab87"},
-    {file = "snowflake_connector_python-4.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec10f37aa99ec0d4e7683b0743d10650987e115c31be2de2e5bd8ea365606934"},
-    {file = "snowflake_connector_python-4.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb90cd1daba798da622d02d95b519371f22abb6bc5713c4255208cb85b8da05e"},
-    {file = "snowflake_connector_python-4.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:1e885cee3e68674cfd52e8b912d11d76b31fae907aa30a5cca0f129ea53d8650"},
-    {file = "snowflake_connector_python-4.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0d7ab4c9103d0fd36281c6012c5d6e3bd266319c36c7870025d4b08715124f11"},
-    {file = "snowflake_connector_python-4.1.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:9ebd97def4f9613f76635f13570c1381c3896ce0aa99fb43eb6229e3971ab5bb"},
-    {file = "snowflake_connector_python-4.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cd8bc41145e28365196fce51a960084458d807749f723a828487c20742129b6"},
-    {file = "snowflake_connector_python-4.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed349014a842295ab31542cdde1371271fb3cbe54fff597b46d43b02cfc414a0"},
-    {file = "snowflake_connector_python-4.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:eb79abfaef1c97d4c3f0754a9449aa5eedd033b5bd58c9526ff6500d4c111889"},
-    {file = "snowflake_connector_python-4.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19da9fa6c50ab7b9ea1751f32388949f7cbe291b676fdffcd38cd1b1a83876a3"},
-    {file = "snowflake_connector_python-4.1.1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:beab9851f8328712fa3682f2b46edbb9bfa6ec1487eea4f7b146a78ba62bb97c"},
-    {file = "snowflake_connector_python-4.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c1e6c67fc8907992995c81bd4c7e5661e1871dbd83cd45766505d6ac65cf5f1"},
-    {file = "snowflake_connector_python-4.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65ca9eac3ff90888cb8d20edcbc3c42a5fb1c93782249e7766259ea7db9c9cfc"},
-    {file = "snowflake_connector_python-4.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:5d5c0ea78d90bd241c05e3998066fc42de1f2813e20c6a75b85e90ef562335bc"},
-    {file = "snowflake_connector_python-4.1.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:df4934b3cdb62c37a3d7c5c8bee9f663d540a278330996e08b00328cc1f4ff84"},
-    {file = "snowflake_connector_python-4.1.1-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:d22790c2f8345fdf734285a82262a12081f66f2e6f1577406d6a275722e0e8b6"},
-    {file = "snowflake_connector_python-4.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb5916f0d8fc46a3c5283182765884028b278a783be22fe4fb9639765e4d45ea"},
-    {file = "snowflake_connector_python-4.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38447f719d316c53d96a037b9d002c40befff99bfcd075820c4b4edfca36a6f8"},
-    {file = "snowflake_connector_python-4.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:452a1438647908e6512cfc172f39a9feeee82915e54fcce51f87cfb9a8fdf624"},
-    {file = "snowflake_connector_python-4.1.1.tar.gz", hash = "sha256:63fe4ba6dc4b93b293e93d92d4d6eadbf74a665a9b8d19bab5cc104fdc30f52b"},
+    {file = "snowflake_connector_python-4.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fb628d5ea1999e23bfbaabce4125eb44d56605ca5634b8b1d6092ab22d555598"},
+    {file = "snowflake_connector_python-4.4.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:16fdca775f7ca5ce4a973c07c434f5ab72bef5284e81a5e4ae2fb4d54d28965c"},
+    {file = "snowflake_connector_python-4.4.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9b1a28f843c1c0b582db7854789525d0c8aac4ea5c56e31113684e38220d0af9"},
+    {file = "snowflake_connector_python-4.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:693a1bef97509f09b7e6f42ea6f743d27819413c04fb3dc543b060d029871c56"},
+    {file = "snowflake_connector_python-4.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5d0e90e68a899c13fda5ca842ff77b5759b1674adf2c72702d3c2b53ca9d27b"},
+    {file = "snowflake_connector_python-4.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19d0c1ed033abae715a71b74c53010b180a5247c6924f851e4f7d0b0d58066c4"},
+    {file = "snowflake_connector_python-4.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:52efe2d6543a09807283748dd50a36ec01d52b4f342868132f8f9856b9c95a42"},
+    {file = "snowflake_connector_python-4.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:85a01338d282423611f357cd5392dca2219bbda9a66b44761b11d6ae8ebf1e50"},
+    {file = "snowflake_connector_python-4.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e8e7ce0e8b33aec8b1fc6741eb51dbeb54e2c3a6d282a0d459c355a85f089b08"},
+    {file = "snowflake_connector_python-4.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a088f108da4653ad1396ddb63a1c757ad614d0862c38f6f69cc77344bdcfeccb"},
+    {file = "snowflake_connector_python-4.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b9f0ac0c00075321e1720d3876e936ee0256f54832e7463c5193a8dfa54913d5"},
+    {file = "snowflake_connector_python-4.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea6e4083ebea0a814b46f029d64a2fb0ba6e7732952cd8af4406041708ce0e21"},
+    {file = "snowflake_connector_python-4.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2a6f6a514a10c3bb2d4554132f0b639f43d7e9fbb73fa1fae1c8a75333102686"},
+    {file = "snowflake_connector_python-4.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8304b4818d3e9de552dcfbdd0bca61bae1583e1c9794e242e58fe44bce701604"},
+    {file = "snowflake_connector_python-4.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c828248214a49f77b903e05acf887d3ccb9d958b5a979f2ed3663bba1bd0f2b3"},
+    {file = "snowflake_connector_python-4.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:56ff04dd9e17edc82128f412aa3776687dc94088f3d6b9144971e169952623cb"},
+    {file = "snowflake_connector_python-4.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:96fdca994c4d9f7780e82fc7b4bd3398d856b43de3bae57d44e242ff435a2431"},
+    {file = "snowflake_connector_python-4.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9fa43d330389df27024757c4f97dabddafbedc74b8bcc189b6a86e8b4d036014"},
+    {file = "snowflake_connector_python-4.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:43e1a2f3ac51d24406d4eb0c23a8ceb9d6f5cb4854c941e5e1375d8c481e2844"},
+    {file = "snowflake_connector_python-4.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:d8ac1659c8e588b9502f8d3d03c1ded2f274de0da9c09e62fe007cba5b46d6a5"},
+    {file = "snowflake_connector_python-4.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7c2984663a733d06c979aa6c8c1d7691621ec0d3521ef345d57c869ff2f1c4b2"},
+    {file = "snowflake_connector_python-4.4.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:307f41326c702f6976746d2001dacf35adaf567f3f12afb3a5778fbb063c7241"},
+    {file = "snowflake_connector_python-4.4.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d6fd334e4d8df7fcb30e6746e5ade845e82de2942268862aa8bce974ae2b86a2"},
+    {file = "snowflake_connector_python-4.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:70d4051e2d9c87258b02672e17e21f5873e0cb49ff9705f6194ccfa25ac0d5fd"},
+    {file = "snowflake_connector_python-4.4.0.tar.gz", hash = "sha256:648f49029d699591af0f253e81c5bf60efc4411c7b0149ef074a59a038210a3b"},
 ]
 
 [package.dependencies]
@@ -5268,13 +5280,13 @@ boto3 = ">=1.24"
 botocore = ">=1.24"
 certifi = ">=2024.7.4"
 charset_normalizer = ">=2,<4"
-cryptography = ">=44.0.1"
+cryptography = ">=46.0.5"
 filelock = ">=3.5,<4"
 idna = ">=3.7,<4"
 packaging = "*"
 platformdirs = ">=2.6.0,<5.0.0"
 pyjwt = ">=2.10.1,<3.0.0"
-pyOpenSSL = ">=24.0.0,<26.0.0"
+pyOpenSSL = ">=24.0.0"
 pytz = "*"
 requests = ">=2.32.4,<3.0.0"
 sortedcontainers = ">=2.4.0"
@@ -5283,7 +5295,7 @@ typing_extensions = ">=4.3,<5"
 
 [package.extras]
 boto = ["boto3 (>=1.24)", "botocore (>=1.24)"]
-development = ["Cython", "coverage", "mitmproxy (>=6.0.0) ; python_version >= \"3.10\"", "more-itertools", "numpy (<=2.2.4)", "pendulum (!=2.1.1)", "pexpect", "pytest (<7.5.0)", "pytest-cov", "pytest-rerunfailures (<16.0)", "pytest-timeout", "pytest-xdist", "pytzdata", "responses"]
+development = ["Cython", "coverage", "mitmproxy (>=12.0.0) ; python_version >= \"3.12\"", "more-itertools", "numpy (<=2.4.3)", "pendulum (!=2.1.1)", "pexpect", "pytest (<7.5.0)", "pytest-asyncio", "pytest-cov", "pytest-rerunfailures (<16.0)", "pytest-timeout", "pytest-xdist", "pytzdata", "responses"]
 pandas = ["pandas (>=1.0.0,<3.0.0) ; python_version < \"3.13\"", "pandas (>=2.1.2,<3.0.0) ; python_version >= \"3.13\"", "pyarrow (>=14.0.1)"]
 secure-local-storage = ["keyring (>=23.1.0,<26.0.0)"]
 
@@ -6121,4 +6133,4 @@ stripe = ["stripe"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "5ba0b308074b36f2e39215509ffbd59c19aa9af59e7057746d106f11f1598ba1"
+content-hash = "e929224264e94a8aaa362476c413ecd667855dd7f62c10c2b0c3b4decbeeaaae"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,10 @@ python = ">=3.11,<4.0"
 # Core
 fastapi = ">=0.110.0"
 pydantic-settings = ">=2.0"
-python-dotenv = ">=1.0.0"
+python-dotenv = ">=1.2.2"
 typer = ">=0.12.0"
 httpx = ">=0.25.0"
+python-multipart = ">=0.0.26"
 
 # DB + auth
 sqlalchemy = { extras = ["asyncio"], version = ">=2.0" }
@@ -53,7 +54,7 @@ alembic = ">=1.13.0"
 greenlet = ">=3.0"
 fastapi-users = { extras = ["oauth"], version = ">=14.0.0" }
 fastapi-users-db-sqlalchemy = ">=7.0.0"
-authlib = ">=1.6.9"
+authlib = ">=1.6.11"
 pyjwt = ">=2.12.0"
 httpx-oauth = ">=0.15.0"
 passlib = { extras = ["bcrypt"], version = ">=1.7.4" }
@@ -96,7 +97,7 @@ stripe = { version = ">=7.0.0", optional = true }
 adyen = { version = ">=10.0.0", optional = true }
 psycopg2-binary = { version = ">=2.9.0", optional = true }
 segno = "^1.6.6"
-cryptography = ">=46.0.6"
+cryptography = ">=46.0.7"
 requests = ">=2.33.0"
 pyasn1 = ">=0.6.3"
 pygments = ">=2.20.0"
@@ -122,7 +123,7 @@ metrics = ["prometheus-client"]
 s3 = ["aioboto3"]
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">=8.0.0"
+pytest = ">=9.0.3"
 pytest-asyncio = ">=0.23.0"
 pytest-cov = ">=4.0.0"
 pytest-benchmark = ">=4.0.0"

--- a/src/svc_infra/api/fastapi/auth/gaurd.py
+++ b/src/svc_infra/api/fastapi/auth/gaurd.py
@@ -4,7 +4,7 @@ import hashlib
 from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi import APIRouter, Body, Depends, Form, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from fastapi_users import FastAPIUsers
 from fastapi_users.authentication import AuthenticationBackend, Strategy
@@ -13,6 +13,11 @@ from starlette.datastructures import FormData
 
 from svc_infra.api.fastapi.auth._cookies import compute_cookie_params
 from svc_infra.api.fastapi.auth.policy import AuthPolicy, DefaultAuthPolicy
+from svc_infra.api.fastapi.auth.session_tokens import (
+    build_session_token_response,
+    refresh_token_from_request,
+    rotate_refresh_session,
+)
 from svc_infra.api.fastapi.auth.settings import get_auth_settings
 from svc_infra.api.fastapi.db.sql.session import SqlSessionDep
 from svc_infra.api.fastapi.dual.public import public_router
@@ -211,7 +216,7 @@ def auth_session_router(
             # Look up location from IP (best-effort, async)
             location = await lookup_ip_location(client_ip) if client_ip else None
 
-            await issue_session_and_refresh(
+            raw_refresh, _ = await issue_session_and_refresh(
                 session,
                 user_id=user.id,
                 tenant_id=getattr(user, "tenant_id", None),
@@ -222,15 +227,42 @@ def auth_session_router(
             await session.commit()
         except Exception:
             # Don't block login if session tracking fails
-            pass
+            raw_refresh = None
 
         # 6) mint token and set cookie
         token = await strategy.write_token(user)
-        st = get_auth_settings()
-        resp = JSONResponse({"access_token": token, "token_type": "bearer"})
-        cp = compute_cookie_params(request, name=st.auth_cookie_name)
-        resp.set_cookie(**cp, value=token)
-        return resp
+        return build_session_token_response(
+            request,
+            access_token=token,
+            refresh_token=raw_refresh,
+        )
+
+    @router.post("/refresh", name="auth:jwt.refresh")
+    async def refresh(
+        request: Request,
+        session: SqlSessionDep,
+        payload: dict[str, Any] | None = Body(default=None),
+        strategy: Strategy[Any, Any] = Depends(auth_backend.get_strategy),
+    ):
+        raw_refresh = refresh_token_from_request(request, payload)
+        if not raw_refresh:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="missing_refresh_token"
+            )
+
+        user, response = await rotate_refresh_session(
+            request=request,
+            session=session,
+            user_model=user_model,
+            strategy=strategy,
+            refresh_token=raw_refresh,
+        )
+        if hasattr(policy, "on_token_refresh"):
+            try:
+                await policy.on_token_refresh(user)
+            except Exception:
+                pass
+        return response
 
     @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT, name="auth:logout")
     async def logout(request: Request):

--- a/src/svc_infra/api/fastapi/auth/mfa/router.py
+++ b/src/svc_infra/api/fastapi/auth/mfa/router.py
@@ -9,9 +9,9 @@ from fastapi_users import FastAPIUsers
 from sqlalchemy import select
 from starlette.responses import JSONResponse
 
-from svc_infra.api.fastapi.auth._cookies import compute_cookie_params
 from svc_infra.api.fastapi.auth.mfa.pre_auth import get_mfa_pre_jwt_writer
 from svc_infra.api.fastapi.auth.sender import get_sender
+from svc_infra.api.fastapi.auth.session_tokens import build_session_token_response
 from svc_infra.api.fastapi.auth.settings import get_auth_settings
 from svc_infra.api.fastapi.db.sql.session import SqlSessionDep
 from svc_infra.api.fastapi.dual.protected import user_router
@@ -186,7 +186,6 @@ def mfa_router(
         session: SqlSessionDep,
         payload: VerifyMFAIn = Body(...),
     ):
-        st = get_auth_settings()
         strategy = get_strategy()
 
         # 1) read/verify pre-auth token (aud = mfa)
@@ -244,14 +243,35 @@ def mfa_router(
 
         # NEW: set last_login on successful MFA
         user.last_login = datetime.now(UTC)
+        raw_refresh: str | None = None
+
+        from svc_infra.security.session import issue_session_and_refresh, lookup_ip_location
+
+        try:
+            client_ip = getattr(request.client, "host", None)
+            ip_hash = _hash(client_ip) if client_ip else None
+            location = await lookup_ip_location(client_ip) if client_ip else None
+
+            raw_refresh, _ = await issue_session_and_refresh(
+                session,
+                user_id=user.id,
+                tenant_id=getattr(user, "tenant_id", None),
+                user_agent=str(request.headers.get("user-agent", ""))[:512],
+                ip_hash=ip_hash,
+                location=location,
+            )
+        except Exception:
+            raw_refresh = None
+
         await session.commit()
 
         # 4) mint normal JWT and set cookie
         token = await strategy.write_token(user)
-        resp = JSONResponse({"access_token": token, "token_type": "bearer"})
-        cp = compute_cookie_params(request, name=st.auth_cookie_name)  # <-- pass Request here
-        resp.set_cookie(**cp, value=token)
-        return resp
+        return build_session_token_response(
+            request,
+            access_token=token,
+            refresh_token=raw_refresh,
+        )
 
     @p.post(
         MFA_SEND_CODE_PATH,

--- a/src/svc_infra/api/fastapi/auth/session_tokens.py
+++ b/src/svc_infra/api/fastapi/auth/session_tokens.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from fastapi import HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+from fastapi_users.authentication import Strategy
+from sqlalchemy import select
+
+from svc_infra.api.fastapi.auth._cookies import compute_cookie_params
+from svc_infra.api.fastapi.auth.settings import get_auth_settings
+from svc_infra.security.models import RefreshToken, hash_refresh_token
+from svc_infra.security.session import DEFAULT_REFRESH_TTL_MINUTES, rotate_session_refresh
+
+
+def set_auth_cookies(
+    response: Response,
+    request: Request,
+    *,
+    access_token: str,
+    refresh_token: str | None = None,
+) -> None:
+    st = get_auth_settings()
+
+    auth_params = compute_cookie_params(request, name=st.auth_cookie_name)
+    response.set_cookie(**auth_params, value=access_token)
+
+    if refresh_token:
+        refresh_params = compute_cookie_params(request, name=st.session_cookie_name)
+        refresh_params["max_age"] = DEFAULT_REFRESH_TTL_MINUTES * 60
+        response.set_cookie(**refresh_params, value=refresh_token)
+
+
+def build_session_token_response(
+    request: Request,
+    *,
+    access_token: str,
+    refresh_token: str | None = None,
+) -> JSONResponse:
+    content: dict[str, Any] = {
+        "access_token": access_token,
+        "token_type": "bearer",
+    }
+    if refresh_token:
+        content["refresh_token"] = refresh_token
+
+    response = JSONResponse(content)
+    set_auth_cookies(
+        response,
+        request,
+        access_token=access_token,
+        refresh_token=refresh_token,
+    )
+    return response
+
+
+def refresh_token_from_request(
+    request: Request, payload: dict[str, Any] | None = None
+) -> str | None:
+    candidate = payload.get("refresh_token") if payload else None
+    if isinstance(candidate, str):
+        trimmed = candidate.strip()
+        if trimmed:
+            return trimmed
+
+    st = get_auth_settings()
+    cookie_value = (request.cookies.get(st.session_cookie_name) or "").strip()
+    return cookie_value or None
+
+
+async def rotate_refresh_session(
+    *,
+    request: Request,
+    session: Any,
+    user_model: type,
+    strategy: Strategy[Any, Any],
+    refresh_token: str,
+) -> tuple[Any, JSONResponse]:
+    token_hash = hash_refresh_token(refresh_token)
+    found: RefreshToken | None = (
+        (await session.execute(select(RefreshToken).where(RefreshToken.token_hash == token_hash)))
+        .scalars()
+        .first()
+    )
+    expires_at = found.expires_at if found else None
+    if expires_at is not None and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=UTC)
+    if not found or found.revoked_at or (expires_at and expires_at < datetime.now(UTC)):
+        raise HTTPException(401, "invalid_refresh_token")
+
+    user = await cast("Any", session).get(user_model, found.session.user_id)
+    if not user:
+        raise HTTPException(401, "invalid_refresh_token")
+    if not getattr(user, "is_active", True):
+        raise HTTPException(401, "account_disabled")
+
+    new_refresh_token, _ = await rotate_session_refresh(session, current=found)
+    await session.commit()
+
+    access_token = await strategy.write_token(user)
+    response = build_session_token_response(
+        request,
+        access_token=access_token,
+        refresh_token=new_refresh_token,
+    )
+    return user, response

--- a/src/svc_infra/api/fastapi/db/sql/users.py
+++ b/src/svc_infra/api/fastapi/db/sql/users.py
@@ -96,7 +96,7 @@ def get_fastapi_users(
         jwt_block = getattr(st, "jwt", None)
         lifetime = getattr(jwt_block, "lifetime_seconds", None) if jwt_block else None
         if not isinstance(lifetime, int) or lifetime <= 0:
-            lifetime = 3600
+            lifetime = 60 * 60 * 24 * 7
         old = []
         if jwt_block and getattr(jwt_block, "old_secrets", None):
             old = [s.get_secret_value() for s in jwt_block.old_secrets or []]

--- a/src/svc_infra/api/fastapi/middleware/timeout.py
+++ b/src/svc_infra/api/fastapi/middleware/timeout.py
@@ -21,15 +21,22 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+def _pick_timeout_seconds(*, prod: int, nonprod: int) -> int:
+    timeout_seconds = pick(prod=prod, nonprod=nonprod)
+    if not isinstance(timeout_seconds, int):
+        raise TypeError("Timeout selection must resolve to an int")
+    return timeout_seconds
+
+
 def _default_request_body_timeout_seconds() -> int:
-    return pick(
+    return _pick_timeout_seconds(
         prod=_env_int("REQUEST_BODY_TIMEOUT_SECONDS", 15),
         nonprod=_env_int("REQUEST_BODY_TIMEOUT_SECONDS", 30),
     )
 
 
 def _default_request_timeout_seconds() -> int:
-    return pick(
+    return _pick_timeout_seconds(
         prod=_env_int("REQUEST_TIMEOUT_SECONDS", 30),
         nonprod=_env_int("REQUEST_TIMEOUT_SECONDS", 15),
     )

--- a/src/svc_infra/api/fastapi/middleware/timeout.py
+++ b/src/svc_infra/api/fastapi/middleware/timeout.py
@@ -21,14 +21,22 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-REQUEST_BODY_TIMEOUT_SECONDS: int = pick(
-    prod=_env_int("REQUEST_BODY_TIMEOUT_SECONDS", 15),
-    nonprod=_env_int("REQUEST_BODY_TIMEOUT_SECONDS", 30),
-)
-REQUEST_TIMEOUT_SECONDS: int = pick(
-    prod=_env_int("REQUEST_TIMEOUT_SECONDS", 30),
-    nonprod=_env_int("REQUEST_TIMEOUT_SECONDS", 15),
-)
+def _default_request_body_timeout_seconds() -> int:
+    return pick(
+        prod=_env_int("REQUEST_BODY_TIMEOUT_SECONDS", 15),
+        nonprod=_env_int("REQUEST_BODY_TIMEOUT_SECONDS", 30),
+    )
+
+
+def _default_request_timeout_seconds() -> int:
+    return pick(
+        prod=_env_int("REQUEST_TIMEOUT_SECONDS", 30),
+        nonprod=_env_int("REQUEST_TIMEOUT_SECONDS", 15),
+    )
+
+
+REQUEST_BODY_TIMEOUT_SECONDS: int = _default_request_body_timeout_seconds()
+REQUEST_TIMEOUT_SECONDS: int = _default_request_timeout_seconds()
 
 
 class HandlerTimeoutMiddleware:
@@ -50,7 +58,7 @@ class HandlerTimeoutMiddleware:
     ) -> None:
         self.app = app
         self.timeout_seconds = (
-            timeout_seconds if timeout_seconds is not None else REQUEST_TIMEOUT_SECONDS
+            timeout_seconds if timeout_seconds is not None else _default_request_timeout_seconds()
         )
         self.skip_paths = skip_paths or []
 
@@ -101,7 +109,9 @@ class BodyReadTimeoutMiddleware:
     def __init__(self, app: ASGIApp, timeout_seconds: int | None = None) -> None:
         self.app = app
         self.timeout_seconds = (
-            timeout_seconds if timeout_seconds is not None else REQUEST_BODY_TIMEOUT_SECONDS
+            timeout_seconds
+            if timeout_seconds is not None
+            else _default_request_body_timeout_seconds()
         )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:

--- a/tests/unit/api/fastapi/auth/test_password_refresh.py
+++ b/tests/unit/api/fastapi/auth/test_password_refresh.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import FastAPI
+from fastapi_users.password import PasswordHelper
+from httpx import ASGITransport, AsyncClient
+
+import svc_infra.api.fastapi.auth.gaurd as guard_module
+import svc_infra.api.fastapi.auth.session_tokens as session_tokens_module
+import svc_infra.security.lockout as lockout_module
+import svc_infra.security.session as session_module
+from svc_infra.api.fastapi.auth.gaurd import auth_session_router
+from svc_infra.api.fastapi.db.sql.session import get_session
+
+_pwd = PasswordHelper()
+
+
+async def _call(app: FastAPI, method: str, path: str, **kwargs):
+    cookies = kwargs.pop("cookies", None)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        if cookies:
+            client.cookies.update(cookies)
+        return await client.request(method, path, **kwargs)
+
+
+def _settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        require_client_secret_on_password_login=False,
+        auth_cookie_name="svc_auth",
+        session_cookie_name="svc_session",
+        session_cookie_secure=False,
+        session_cookie_domain=None,
+        session_cookie_samesite="lax",
+        session_cookie_max_age_seconds=3600,
+    )
+
+
+def _build_login_app(mocker) -> tuple[FastAPI, AsyncMock, AsyncMock]:
+    mocker.patch.object(
+        guard_module,
+        "get_auth_settings",
+        return_value=_settings(),
+    )
+    mocker.patch.object(
+        session_tokens_module,
+        "get_auth_settings",
+        return_value=_settings(),
+    )
+    mocker.patch.object(
+        lockout_module,
+        "get_lockout_status",
+        AsyncMock(return_value=SimpleNamespace(locked=False, next_allowed_at=None)),
+    )
+    mocker.patch.object(lockout_module, "record_attempt", AsyncMock(return_value=None))
+    issue_session = AsyncMock(return_value=("fresh-refresh-token", object()))
+    mocker.patch.object(session_module, "issue_session_and_refresh", issue_session)
+    mocker.patch.object(session_module, "lookup_ip_location", AsyncMock(return_value=None))
+
+    user = SimpleNamespace(
+        id="user-123",
+        email="tester@example.com",
+        is_active=True,
+        is_verified=True,
+        hashed_password=_pwd.hash("P@ssw0rd!1234"),
+        tenant_id=None,
+        last_login=None,
+    )
+
+    user_db = SimpleNamespace(
+        get_by_email=AsyncMock(return_value=user),
+        update=AsyncMock(return_value=user),
+    )
+
+    class DummyFastAPIUsers:
+        async def get_user_manager(self):
+            return SimpleNamespace(user_db=user_db)
+
+    strategy = Mock()
+    strategy.write_token = AsyncMock(return_value="fresh-access-token")
+
+    auth_backend = Mock()
+
+    def _get_strategy():
+        return strategy
+
+    auth_backend.get_strategy = _get_strategy
+
+    router = auth_session_router(
+        fapi=DummyFastAPIUsers(),
+        auth_backend=auth_backend,
+        user_model=SimpleNamespace,
+        get_mfa_pre_writer=lambda: None,
+        auth_policy=SimpleNamespace(should_require_mfa=AsyncMock(return_value=False)),
+    )
+
+    app = FastAPI()
+    app.include_router(router)
+
+    session = Mock()
+    session.commit = AsyncMock(return_value=None)
+
+    async def _session_override():
+        return session
+
+    app.dependency_overrides[get_session] = _session_override
+
+    return app, issue_session, user_db.update
+
+
+@pytest.mark.asyncio
+async def test_password_login_returns_refresh_token_and_sets_cookie(mocker):
+    app, issue_session, update_user = _build_login_app(mocker)
+
+    response = await _call(
+        app,
+        "POST",
+        "/login",
+        data={"username": "tester@example.com", "password": "P@ssw0rd!1234"},
+        headers={"content-type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "access_token": "fresh-access-token",
+        "refresh_token": "fresh-refresh-token",
+        "token_type": "bearer",
+    }
+    assert response.cookies.get("svc_auth") == "fresh-access-token"
+    assert response.cookies.get("svc_session") == "fresh-refresh-token"
+    issue_session.assert_awaited_once()
+    update_user.assert_awaited()
+
+
+def _build_refresh_app(mocker) -> FastAPI:
+    mocker.patch.object(
+        guard_module,
+        "get_auth_settings",
+        return_value=_settings(),
+    )
+    mocker.patch.object(
+        session_tokens_module,
+        "get_auth_settings",
+        return_value=_settings(),
+    )
+    mocker.patch.object(
+        session_tokens_module,
+        "rotate_session_refresh",
+        AsyncMock(return_value=("rotated-refresh-token", object())),
+    )
+
+    strategy = Mock()
+    strategy.write_token = AsyncMock(return_value="rotated-access-token")
+
+    auth_backend = Mock()
+
+    def _get_strategy():
+        return strategy
+
+    auth_backend.get_strategy = _get_strategy
+
+    policy = SimpleNamespace(
+        should_require_mfa=AsyncMock(return_value=False),
+        on_token_refresh=AsyncMock(return_value=None),
+    )
+
+    router = auth_session_router(
+        fapi=SimpleNamespace(get_user_manager=lambda: None),
+        auth_backend=auth_backend,
+        user_model=SimpleNamespace,
+        get_mfa_pre_writer=lambda: None,
+        auth_policy=policy,
+    )
+
+    app = FastAPI()
+    app.include_router(router)
+
+    user = SimpleNamespace(id="user-123", is_active=True)
+    found = SimpleNamespace(
+        revoked_at=None,
+        expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        session=SimpleNamespace(user_id="user-123"),
+    )
+
+    session = Mock()
+    session.get = AsyncMock(return_value=user)
+    session.commit = AsyncMock(return_value=None)
+    session.execute = AsyncMock(
+        return_value=SimpleNamespace(scalars=lambda: SimpleNamespace(first=lambda: found))
+    )
+
+    async def _session_override():
+        return session
+
+    app.dependency_overrides[get_session] = _session_override
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_password_refresh_rotates_tokens_without_access_jwt(mocker):
+    app = _build_refresh_app(mocker)
+
+    response = await _call(
+        app,
+        "POST",
+        "/refresh",
+        json={"refresh_token": "current-refresh-token"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "access_token": "rotated-access-token",
+        "refresh_token": "rotated-refresh-token",
+        "token_type": "bearer",
+    }
+    assert response.cookies.get("svc_auth") == "rotated-access-token"
+    assert response.cookies.get("svc_session") == "rotated-refresh-token"


### PR DESCRIPTION
## Summary
- add shared session token helpers for issuing access and refresh responses
- add `/refresh` session rotation for password auth flows
- update MFA and auth session flows to mint refresh tokens consistently
- add regression coverage for password refresh token rotation

## Validation
- `poetry run ruff check src/svc_infra/api/fastapi/auth/gaurd.py src/svc_infra/api/fastapi/auth/mfa/router.py src/svc_infra/api/fastapi/auth/session_tokens.py src/svc_infra/api/fastapi/db/sql/users.py src/svc_infra/api/fastapi/middleware/timeout.py tests/unit/api/fastapi/auth/test_password_refresh.py`
- `PYTHONPATH=/Users/alikhatami/ide/fullstack/nfraxlab/sdks/svc-infra/src poetry run pytest -q /Users/alikhatami/ide/fullstack/nfraxlab/sdks/svc-infra/tests/unit/api/fastapi/auth/test_password_refresh.py`