### PR TITLE
feat: Add configurable auth email customization

### DIFF
--- a/docs/email.md
+++ b/docs/email.md
@@ -1,479 +1,254 @@
-# Email Module
+# Email
 
-Production-ready email infrastructure with pluggable backends, templating, and FastAPI integration.
+`svc-infra` provides production-ready email delivery with pluggable backends, Jinja templates, and a high-level sender API that also powers authentication flows.
 
 ## Quick Start
 
-### Basic Setup
+### FastAPI Sender
 
 ```python
-from fastapi import FastAPI
-from svc_infra.email import add_sender, get_sender, EmailSender
+from fastapi import Depends, FastAPI
+
+from svc_infra.email import EmailSender, add_sender, get_sender
 
 app = FastAPI()
-add_sender(app, app_name="MyApp")
+
+add_sender(
+    app,
+    app_name="Acme",
+    app_url="https://app.acme.com",
+    support_email="support@acme.com",
+)
+
 
 @app.post("/register")
 async def register(email: str, sender: EmailSender = Depends(get_sender)):
     await sender.send_verification(
         to=email,
-        token="abc123",
-        base_url="https://myapp.com",
+        verification_url="https://app.acme.com/verify?token=abc123",
+        user_name="Avery",
+        expires_in="24 hours",
     )
     return {"message": "Verification email sent"}
 ```
 
-### One-Line API
-
-For simple scripts or one-off emails:
+### Standalone Sender
 
 ```python
-from svc_infra.email import easy_email
+from svc_infra.email import easy_sender
 
-await easy_email(
+sender = easy_sender(
+    app_name="Acme",
+    app_url="https://app.acme.com",
+    support_email="support@acme.com",
+)
+
+result = await sender.send_password_reset(
     to="user@example.com",
-    subject="Hello!",
-    html="<p>Welcome to our app!</p>",
+    reset_url="https://app.acme.com/reset-password?token=reset123",
+    user_name="Avery",
 )
 ```
 
----
+## Environment Configuration
 
-## Provider Configuration
-
-Configure email providers using environment variables.
-
-### Console (Development)
-
-Default backend - prints emails to stdout for development.
+Common settings:
 
 ```bash
-EMAIL_PROVIDER=console  # or omit entirely
+EMAIL_BACKEND=console
+EMAIL_FROM=hello@example.com
+EMAIL_REPLY_TO=support@example.com
+EMAIL_TEMPLATES_PATH=/absolute/path/to/templates
+```
+
+Provider-specific settings:
+
+### Console
+
+```bash
+EMAIL_BACKEND=console
 ```
 
 ### SMTP
 
-Standard SMTP server.
-
 ```bash
-EMAIL_PROVIDER=smtp
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_USER=apikey
-SMTP_PASSWORD=your-password
+EMAIL_BACKEND=smtp
+EMAIL_SMTP_HOST=smtp.example.com
+EMAIL_SMTP_PORT=587
+EMAIL_SMTP_USERNAME=apikey
+EMAIL_SMTP_PASSWORD=your-password
 EMAIL_FROM=noreply@example.com
 ```
 
 ### Resend
 
-Modern email API with excellent deliverability.
-
 ```bash
-EMAIL_PROVIDER=resend
-RESEND_API_KEY=re_xxx...
+EMAIL_BACKEND=resend
+EMAIL_RESEND_API_KEY=re_xxx
 EMAIL_FROM=noreply@example.com
 ```
 
 ### SendGrid
 
-Enterprise email delivery.
-
 ```bash
-EMAIL_PROVIDER=sendgrid
-SENDGRID_API_KEY=SG.xxx...
+EMAIL_BACKEND=sendgrid
+EMAIL_SENDGRID_API_KEY=SG.xxx
 EMAIL_FROM=noreply@example.com
 ```
 
 ### AWS SES
 
-Amazon Simple Email Service.
-
 ```bash
-EMAIL_PROVIDER=ses
-AWS_REGION=us-east-1
-# Uses default AWS credential chain (env vars, IAM role, etc.)
+EMAIL_BACKEND=ses
+EMAIL_SES_REGION=us-east-1
 EMAIL_FROM=noreply@example.com
 ```
 
 ### Postmark
 
-Transactional email with high deliverability.
-
 ```bash
-EMAIL_PROVIDER=postmark
-POSTMARK_SERVER_TOKEN=xxx...
+EMAIL_BACKEND=postmark
+EMAIL_POSTMARK_API_TOKEN=xxx
 EMAIL_FROM=noreply@example.com
 ```
 
----
+### Mailgun
 
-## API Reference
+```bash
+EMAIL_BACKEND=mailgun
+EMAIL_MAILGUN_API_KEY=key-xxx
+EMAIL_MAILGUN_DOMAIN=mg.example.com
+EMAIL_FROM=noreply@example.com
+```
 
-### High-Level API
+### Brevo
 
-#### add_sender
+```bash
+EMAIL_BACKEND=brevo
+EMAIL_BREVO_API_KEY=xxx
+EMAIL_FROM=noreply@example.com
+```
 
-Add email sender to FastAPI app.
+## Built-In Templates
+
+`EmailSender` ships with these templates:
+
+| Template | Use case | Key context |
+|----------|----------|-------------|
+| `verification` | Email verification | `verification_url` or `code` |
+| `password_reset` | Password reset | `reset_url` |
+| `invitation` | Team/workspace invites | `invitation_url`, `inviter_name` |
+| `welcome` | Post-signup onboarding | `user_name` |
+
+These variables are available automatically in template rendering:
+
+- `app_name`
+- `app_url`
+- `support_email`
+- `unsubscribe_url`
+
+Use `EMAIL_TEMPLATES_PATH` to provide a custom template directory. If your directory contains `base.html`, you own the full visual system. If it only contains `verification.html` or `password_reset.html`, `svc-infra` falls back to the built-in files for everything else.
+
+## Auth Email Customization
+
+Authentication flows can use the same email system through `AuthEmailConfig`.
 
 ```python
-from svc_infra.email import add_sender
+from svc_infra.api.fastapi.auth import (
+    AuthEmailConfig,
+    AuthEmailTemplateConfig,
+    add_auth_users,
+)
 
-sender = add_sender(
+auth_email_config = AuthEmailConfig(
+    frontend_url="https://accounts.acme.com",
+    app_name="Acme",
+    support_email="support@acme.com",
+    verification=AuthEmailTemplateConfig(
+        path="/verify",
+        template="verification",
+        subject="Verify your Acme account",
+    ),
+    password_reset=AuthEmailTemplateConfig(
+        path="/reset-password",
+        template="password_reset",
+        subject="Reset your Acme password",
+    ),
+)
+
+add_auth_users(
     app,
-    app_name="MyApp",              # Required for templates
-    app_url="https://myapp.com",   # Optional: for links
-    support_email="help@myapp.com", # Optional: for support links
+    user_model=User,
+    schema_read=UserRead,
+    schema_create=UserCreate,
+    schema_update=UserUpdate,
+    auth_email_config=auth_email_config,
 )
 ```
 
-#### get_sender
+What `AuthEmailConfig` can control:
 
-Dependency to get sender in routes.
+- verification and reset URL paths
+- app branding and support links
+- subjects, tags, and metadata
+- template context via `context_builder`
+- full message rendering via `render`
 
-```python
-from svc_infra.email import get_sender, EmailSender
+If you need complete control over subject, HTML, text, headers, and tracking metadata, return an `AuthEmailMessage` from `AuthEmailTemplateConfig.render`.
 
-@app.post("/send")
-async def send_email(sender: EmailSender = Depends(get_sender)):
-    await sender.send(to="...", subject="...", html="...")
+## Ready-To-Copy Branded Auth Templates
+
+The repo includes a ready-to-copy auth email set at:
+
+```text
+examples/email/auth_branding/templates
 ```
 
-### EmailSender Methods
+That example includes:
 
-#### send
+- a custom `base.html` for full UI override
+- branded `verification.html`
+- branded `password_reset.html`
+- usage instructions in `examples/email/auth_branding/README.md`
 
-Send email with HTML or template.
+Recommended rollout:
+
+1. Copy the example `templates/` directory into your application repo.
+2. Change colors, copy, support links, and footer treatment.
+3. Set `EMAIL_TEMPLATES_PATH` to that copied directory.
+4. Pass `AuthEmailConfig` into `add_auth_users(...)`.
+
+## Generic Send API
+
+Use `send()` when you want full control without a convenience helper.
 
 ```python
-# With raw HTML
 result = await sender.send(
     to="user@example.com",
-    subject="Welcome!",
-    html="<p>Hello, welcome to MyApp!</p>",
-)
-
-# With template
-result = await sender.send(
-    to="user@example.com",
-    subject="Verify your email",
-    template="verification",
-    context={
-        "verification_url": "https://...",
-        "expires_in": "24 hours",
-    },
-)
-```
-
-#### Convenience Methods
-
-```python
-# Send verification email
-await sender.send_verification(
-    to="user@example.com",
-    token="abc123",
-    base_url="https://myapp.com",  # URL with /verify/{token}
-    expires_in="24 hours",         # Optional
-)
-
-# Send password reset email
-await sender.send_password_reset(
-    to="user@example.com",
-    token="reset123",
-    base_url="https://myapp.com",
-    expires_in="1 hour",
-)
-
-# Send invitation email
-await sender.send_invitation(
-    to="newuser@example.com",
-    inviter_name="John Doe",
-    token="invite123",
-    base_url="https://myapp.com",
-    message="Join us!",  # Optional custom message
-)
-
-# Send welcome email
-await sender.send_welcome(
-    to="user@example.com",
-    user_name="Alice",
-)
-```
-
-### Low-Level API
-
-#### add_email
-
-Add just the backend (no templates/convenience methods).
-
-```python
-from svc_infra.email import add_email, get_email
-
-backend = add_email(app)
-
-@app.post("/send")
-async def send(email = Depends(get_email)):
-    msg = EmailMessage(
-        to=["user@example.com"],
-        subject="Hello",
-        html="<p>Hi</p>",
-    )
-    return await email.send(msg)
-```
-
----
-
-## Templates
-
-### Built-in Templates
-
-Four templates are included:
-
-| Template | Purpose | Required Context |
-|----------|---------|------------------|
-| `verification` | Email verification | `verification_url` |
-| `password_reset` | Password reset | `reset_url`, `expires_in` |
-| `invitation` | Team/app invitation | `invitation_url`, `inviter_name` |
-| `welcome` | Welcome after signup | `user_name` |
-
-### Template Context
-
-All templates receive these variables automatically:
-
-- `app_name` - Your application name
-- `app_url` - Your application URL
-- `support_email` - Support contact email
-- `current_year` - Current year for footer
-
-### Custom Templates
-
-You can use custom template directories:
-
-```python
-from svc_infra.email import EmailSender, EmailTemplateLoader
-
-loader = EmailTemplateLoader(
-    template_dirs=["/path/to/my/templates"],
-    app_name="MyApp",
-)
-sender = EmailSender(backend, loader)
-
-# Use custom template
-await sender.send(
-    to="user@example.com",
-    subject="Custom Email",
+    subject="Quarterly launch update",
     template="my_custom_template",
-    context={"foo": "bar"},
+    context={"headline": "Spring release"},
+    tags=["announcement"],
+    metadata={"campaign": "spring-release"},
 )
 ```
-
-Template files should be Jinja2 HTML:
-
-```html
-<!-- my_custom_template.html -->
-<!DOCTYPE html>
-<html>
-<body>
-  <h1>Hello from {{ app_name }}</h1>
-  <p>Custom content: {{ foo }}</p>
-</body>
-</html>
-```
-
----
 
 ## Health Check
-
-Monitor email configuration:
 
 ```python
 from svc_infra.email import health_check_email
 
-@app.get("/health/email")
-async def email_health():
-    return await health_check_email()
-```
-
-Response:
-
-```json
-{
-  "status": "healthy",
-  "configured": true,
-  "provider": "resend"
-}
-```
-
----
-
-## Migration Guide
-
-### From Old sender.py
-
-If you were using the old `sender.py` module:
-
-```python
-# OLD - sender.py
-from svc_infra.auth.sender import add_email, get_email, send_verification_email
-
-add_email(app)
-
-@app.post("/register")
-async def register(email = Depends(get_email)):
-    await send_verification_email(email, "user@...", "token", "https://...")
-```
-
-```python
-# NEW - email module
-from svc_infra.email import add_sender, get_sender
-
-add_sender(app, app_name="MyApp")
-
-@app.post("/register")
-async def register(sender = Depends(get_sender)):
-    await sender.send_verification(
-        to="user@...",
-        token="token",
-        base_url="https://...",
-    )
-```
-
-### Key Differences
-
-1. **Unified sender**: Use `EmailSender` for all email types
-2. **Branding**: Configure `app_name`, `app_url` once in `add_sender`
-3. **Templates**: Rich HTML templates with consistent branding
-4. **Convenience methods**: `send_verification`, `send_password_reset`, etc.
-5. **Better typing**: Full type hints and Pydantic models
-
-### Backward Compatibility
-
-The old `sender.py` module still works but uses the new email module internally. Gradual migration is supported.
-
----
-
-## Best Practices
-
-### Error Handling
-
-```python
-from svc_infra.email import EmailSendResult
-
-result = await sender.send(to="...", subject="...", html="...")
-
-if result.status == "sent":
-    logger.info(f"Email sent: {result.message_id}")
-elif result.status == "queued":
-    logger.info(f"Email queued: {result.message_id}")
-else:
-    logger.error(f"Email failed: {result.error}")
-```
-
-### Async Context
-
-All send methods are async. For sync code:
-
-```python
-import asyncio
-from svc_infra.email import easy_email
-
-asyncio.run(easy_email(to="...", subject="...", html="..."))
-```
-
-### Testing
-
-Use console backend in tests:
-
-```python
-import os
-
-os.environ["EMAIL_PROVIDER"] = "console"
-
-# Emails will be printed, not sent
-```
-
-Or mock the backend:
-
-```python
-from unittest.mock import AsyncMock
-
-sender.backend.send = AsyncMock(return_value=EmailSendResult(...))
-```
-
----
-
-## Troubleshooting
-
-### Email not sending
-
-1. Check `EMAIL_PROVIDER` is set correctly
-2. Verify API keys are valid
-3. Check `EMAIL_FROM` is a verified sender address
-
-### Template not found
-
-1. Check template name matches file name (without `.html`)
-2. Ensure template directory is accessible
-3. Use `loader.get_available_templates()` to list available templates
-
-### Health check shows "unconfigured"
-
-1. Call `add_email` or `add_sender` before health check
-2. Verify app startup order
-
----
-
-## Complete Example
-
-```python
-from fastapi import Depends, FastAPI
-from svc_infra.email import add_sender, get_sender, EmailSender, health_check_email
-
-app = FastAPI()
-
-# Configure on startup
-add_sender(
-    app,
-    app_name="Acme Inc",
-    app_url="https://acme.com",
-    support_email="support@acme.com",
-)
-
 
 @app.get("/health/email")
 async def email_health():
     return await health_check_email()
-
-
-@app.post("/auth/register")
-async def register(
-    email: str,
-    sender: EmailSender = Depends(get_sender),
-):
-    # Create user, generate token...
-    token = "abc123"
-
-    await sender.send_verification(
-        to=email,
-        token=token,
-        base_url="https://acme.com",
-    )
-
-    return {"message": "Check your email to verify"}
-
-
-@app.post("/auth/forgot-password")
-async def forgot_password(
-    email: str,
-    sender: EmailSender = Depends(get_sender),
-):
-    # Lookup user, generate token...
-    token = "reset456"
-
-    await sender.send_password_reset(
-        to=email,
-        token=token,
-        base_url="https://acme.com",
-    )
-
-    return {"message": "Check your email for reset link"}
 ```
+
+## Examples
+
+See the example directory for working reference code:
+
+- `examples/email/basic_send.py`
+- `examples/email/with_templates.py`
+- `examples/email/fastapi_integration.py`
+- `examples/email/auth_branding/`

--- a/examples/email/README.md
+++ b/examples/email/README.md
@@ -24,6 +24,18 @@ Template-based emails for common use cases:
 EMAIL_FROM=noreply@example.com python with_templates.py
 ```
 
+### auth_branding/
+
+Ready-to-copy branded auth email templates for verification and password reset.
+
+Contents:
+- `templates/base.html` for full UI control
+- `templates/verification.html` for signup verification
+- `templates/password_reset.html` for reset flows
+- `README.md` with `AuthEmailConfig` setup instructions
+
+Use this when you want a company-specific look and copy instead of the built-in defaults.
+
 ### fastapi_integration.py
 
 Full FastAPI application with email integration:

--- a/examples/email/auth_branding/README.md
+++ b/examples/email/auth_branding/README.md
@@ -1,0 +1,76 @@
+# Branded Auth Email Templates
+
+This directory contains a ready-to-copy set of auth email templates for teams that want to fully control verification and password-reset email copy and UI.
+
+Included files:
+
+- `templates/base.html` overrides the full layout, typography, colors, and footer.
+- `templates/verification.html` handles email verification.
+- `templates/password_reset.html` handles password reset.
+
+## Use It In Your App
+
+1. Copy the `templates/` directory into your application repository.
+2. Point `EMAIL_TEMPLATES_PATH` at that copied directory.
+3. Pass `AuthEmailConfig` into `add_auth_users(...)`.
+
+```python
+from svc_infra.api.fastapi.auth import (
+    AuthEmailConfig,
+    AuthEmailTemplateConfig,
+    add_auth_users,
+)
+
+auth_email_config = AuthEmailConfig(
+    frontend_url="https://accounts.example.com",
+    app_name="Northstar",
+    support_email="support@example.com",
+    verification=AuthEmailTemplateConfig(
+        path="/verify",
+        template="verification",
+    ),
+    password_reset=AuthEmailTemplateConfig(
+        path="/reset-password",
+        template="password_reset",
+    ),
+)
+
+add_auth_users(
+    app,
+    user_model=User,
+    schema_read=UserRead,
+    schema_create=UserCreate,
+    schema_update=UserUpdate,
+    auth_email_config=auth_email_config,
+)
+```
+
+```bash
+export EMAIL_TEMPLATES_PATH=/absolute/path/to/your/templates
+export EMAIL_BACKEND=resend
+export EMAIL_FROM=hello@example.com
+```
+
+## What You Can Customize
+
+- Change copy directly in `verification.html` and `password_reset.html`.
+- Override `base.html` when you want full control over the layout and visual system.
+- Keep only one file if you want partial overrides. `svc-infra` falls back to the built-in templates for files you do not provide.
+- Use `subject`, `context_builder`, or `render` in `AuthEmailTemplateConfig` when runtime logic needs to alter the message.
+
+## Full-Control Rendering
+
+If templates are still too limiting, use a custom renderer:
+
+```python
+from svc_infra.api.fastapi.auth import AuthEmailMessage
+
+AuthEmailTemplateConfig(
+    path="/reset-password",
+    render=lambda ctx: AuthEmailMessage(
+        subject=f"Reset your {ctx.app_name} password",
+        html=f"<h1>Reset Password</h1><p><a href='{ctx.action_url}'>Continue</a></p>",
+        text=ctx.action_url,
+    ),
+)
+```

--- a/examples/email/auth_branding/templates/base.html
+++ b/examples/email/auth_branding/templates/base.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>{% block title %}{{ subject | default(app_name) }}{% endblock %}</title>
+    <style>
+        body, table, td, p, a, li {
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+        table, td {
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+        body {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            background: #efe6dc;
+            color: #2d2a26;
+            font-family: Arial, Helvetica, sans-serif;
+        }
+        a {
+            color: #bf5a3d;
+        }
+        .canvas {
+            width: 100%;
+            padding: 32px 12px;
+            background: linear-gradient(180deg, #173042 0%, #224659 38%, #efe6dc 38%, #efe6dc 100%);
+        }
+        .shell {
+            max-width: 640px;
+            margin: 0 auto;
+            background: #fffaf4;
+            border-radius: 24px;
+            overflow: hidden;
+            box-shadow: 0 22px 60px rgba(18, 31, 42, 0.18);
+        }
+        .hero {
+            padding: 28px 40px 24px;
+            background: #173042;
+            color: #f7efe5;
+        }
+        .mark {
+            display: inline-block;
+            padding: 6px 10px;
+            border: 1px solid rgba(255, 255, 255, 0.22);
+            border-radius: 999px;
+            font-size: 11px;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+        }
+        .hero h1 {
+            margin: 16px 0 8px;
+            font-family: Georgia, "Times New Roman", serif;
+            font-size: 32px;
+            line-height: 1.15;
+            font-weight: 700;
+            color: #fff6eb;
+        }
+        .hero p {
+            margin: 0;
+            font-size: 15px;
+            line-height: 1.6;
+            color: rgba(247, 239, 229, 0.82);
+        }
+        .content {
+            padding: 36px 40px 24px;
+        }
+        .content h2 {
+            margin: 0 0 14px;
+            font-family: Georgia, "Times New Roman", serif;
+            font-size: 26px;
+            line-height: 1.2;
+            color: #1e2b33;
+        }
+        .content p {
+            margin: 0 0 16px;
+            font-size: 16px;
+            line-height: 1.7;
+            color: #4e4842;
+        }
+        .button {
+            display: inline-block;
+            padding: 15px 28px;
+            margin: 18px 0;
+            border-radius: 999px;
+            background: #bf5a3d;
+            color: #fff8f1 !important;
+            font-weight: 700;
+            font-size: 15px;
+            text-decoration: none;
+        }
+        .panel {
+            margin: 24px 0;
+            padding: 18px 20px;
+            border-radius: 18px;
+            background: #f7efe5;
+            border: 1px solid #e7d4c0;
+        }
+        .panel p:last-child {
+            margin-bottom: 0;
+        }
+        .signal {
+            margin: 26px 0;
+            padding: 18px 20px;
+            border-left: 4px solid #bf5a3d;
+            background: #fff2e7;
+            border-radius: 0 16px 16px 0;
+        }
+        .signal p {
+            margin: 0;
+        }
+        .code-block {
+            display: inline-block;
+            margin: 12px 0;
+            padding: 14px 22px;
+            border-radius: 16px;
+            background: #173042;
+            color: #fff6eb;
+            font-family: "Courier New", Courier, monospace;
+            font-size: 28px;
+            letter-spacing: 0.2em;
+            font-weight: 700;
+        }
+        .link-block {
+            word-break: break-word;
+            font-size: 14px;
+        }
+        .list {
+            margin: 18px 0;
+            padding-left: 20px;
+            color: #4e4842;
+        }
+        .list li {
+            margin-bottom: 10px;
+            line-height: 1.6;
+        }
+        .footer {
+            padding: 24px 40px 36px;
+            border-top: 1px solid #ead8c5;
+            background: #fcf6ef;
+        }
+        .footer p {
+            margin: 0 0 10px;
+            font-size: 13px;
+            line-height: 1.6;
+            color: #756d65;
+        }
+        @media only screen and (max-width: 620px) {
+            .canvas {
+                padding: 0;
+            }
+            .shell {
+                border-radius: 0;
+            }
+            .hero, .content, .footer {
+                padding-left: 22px !important;
+                padding-right: 22px !important;
+            }
+            .hero h1 {
+                font-size: 28px;
+            }
+            .code-block {
+                font-size: 22px;
+                letter-spacing: 0.12em;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="canvas">
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+            <tr>
+                <td align="center">
+                    <div class="shell">
+                        <div class="hero">
+                            <span class="mark">Secure account flow</span>
+                            <h1>{% block hero_title %}{{ app_name }}{% endblock %}</h1>
+                            <p>{% block hero_copy %}Account emails that match your brand, not generic boilerplate.{% endblock %}</p>
+                        </div>
+                        <div class="content">
+                            {% block content %}{% endblock %}
+                        </div>
+                        <div class="footer">
+                            {% block footer %}
+                            <p>
+                                {% if support_email %}
+                                Need help? Contact <a href="mailto:{{ support_email }}">{{ support_email }}</a>.
+                                {% else %}
+                                This message was sent by {{ app_name }}.
+                                {% endif %}
+                            </p>
+                            {% if unsubscribe_url %}
+                            <p><a href="{{ unsubscribe_url }}">Unsubscribe</a> from non-essential emails.</p>
+                            {% endif %}
+                            <p>&copy; {{ current_year | default(2026) }} {{ app_name }}</p>
+                            {% endblock %}
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        </table>
+    </div>
+</body>
+</html>

--- a/examples/email/auth_branding/templates/password_reset.html
+++ b/examples/email/auth_branding/templates/password_reset.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+
+{% block title %}Reset your password - {{ app_name }}{% endblock %}
+{% block hero_title %}Reset your password{% endblock %}
+{% block hero_copy %}Secure the account, choose a new password, and keep moving.{% endblock %}
+
+{% block content %}
+<h2>Choose a new password</h2>
+
+<p>Hi{{ " " + user_name if user_name else "" }},</p>
+
+<p>
+    We received a request to reset the password for your {{ app_name }} account. Use the button below to open the secure reset flow.
+</p>
+
+<p style="text-align: center;">
+    <a href="{{ reset_url }}" class="button">Reset password</a>
+</p>
+
+<div class="panel">
+    <p style="margin-bottom: 8px;"><strong>Manual fallback</strong></p>
+    <p class="link-block"><a href="{{ reset_url }}">{{ reset_url }}</a></p>
+</div>
+
+<div class="signal">
+    <p>This reset link expires in {{ expires_in | default("1 hour") }}.</p>
+</div>
+
+<div class="panel">
+    <p><strong>Reset checklist</strong></p>
+    <ul class="list">
+        <li>Use at least 12 characters.</li>
+        <li>Do not reuse a password from another service.</li>
+        <li>Store the new password in your password manager.</li>
+    </ul>
+</div>
+
+<p style="font-size: 14px; color: #756d65;">
+    If you did not request this reset, you can ignore this email. Your current password remains unchanged until you complete the reset flow.
+</p>
+{% endblock %}

--- a/examples/email/auth_branding/templates/verification.html
+++ b/examples/email/auth_branding/templates/verification.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block title %}Verify your email - {{ app_name }}{% endblock %}
+{% block hero_title %}Confirm your access{% endblock %}
+{% block hero_copy %}One quick verification step and your account is ready to go.{% endblock %}
+
+{% block content %}
+<h2>Verify your email address</h2>
+
+<p>Hi{{ " " + user_name if user_name else "" }},</p>
+
+<p>
+    Welcome to {{ app_name }}. Use the secure verification link below to activate your account and continue into the product.
+</p>
+
+{% if verification_url %}
+<p style="text-align: center;">
+    <a href="{{ verification_url }}" class="button">Verify email</a>
+</p>
+<div class="panel">
+    <p style="margin-bottom: 8px;"><strong>Manual fallback</strong></p>
+    <p class="link-block"><a href="{{ verification_url }}">{{ verification_url }}</a></p>
+</div>
+{% endif %}
+
+{% if code %}
+<div class="signal">
+    <p>Enter this verification code in the app:</p>
+</div>
+<p style="text-align: center;">
+    <span class="code-block">{{ code }}</span>
+</p>
+{% endif %}
+
+<div class="panel">
+    <p><strong>What happens next</strong></p>
+    <ul class="list">
+        <li>Your email address is confirmed.</li>
+        <li>Your first session is unlocked.</li>
+        <li>You can return to {{ app_name }} and sign in immediately.</li>
+    </ul>
+</div>
+
+<div class="signal">
+    <p>This {{ "link" if verification_url else "code" }} expires in {{ expires_in | default("24 hours") }}.</p>
+</div>
+
+<p style="font-size: 14px; color: #756d65;">
+    If you did not create an account with {{ app_name }}, you can ignore this email.
+</p>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
   - Core Features:
       - API Framework: api.md
       - Authentication: auth.md
+      - Email: email.md
       - Connect (OAuth): connect.md
       - MCP OAuth Discovery: connect-mcp-oauth.md
       - Database: database.md

--- a/src/svc_infra/api/fastapi/auth/__init__.py
+++ b/src/svc_infra/api/fastapi/auth/__init__.py
@@ -4,6 +4,7 @@ Provides user authentication, authorization, and security primitives.
 
 Key exports:
 - add_auth_users: Add authentication routes to FastAPI app
+- AuthEmailConfig: Configure verification/reset email URLs, templates, and renderers
 - Identity, OptionalIdentity: Annotated dependencies for auth
 - RequireUser, RequireRoles, RequireScopes: Authorization guards
 - Principal: Unified identity (user via JWT/cookie or service via API key)
@@ -15,6 +16,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 # These imports are safe (no circular dependency)
+from .email import AuthEmailConfig, AuthEmailContext, AuthEmailMessage, AuthEmailTemplateConfig
 from .policy import AuthPolicy, DefaultAuthPolicy
 from .security import (
     Identity,
@@ -35,6 +37,10 @@ if TYPE_CHECKING:
 __all__ = [
     # Main setup
     "add_auth_users",
+    "AuthEmailConfig",
+    "AuthEmailContext",
+    "AuthEmailMessage",
+    "AuthEmailTemplateConfig",
     # Identity/Auth guards
     "Identity",
     "OptionalIdentity",

--- a/src/svc_infra/api/fastapi/auth/add.py
+++ b/src/svc_infra/api/fastapi/auth/add.py
@@ -5,6 +5,7 @@ from typing import Literal, cast
 from fastapi import Depends, FastAPI
 from starlette.middleware.sessions import SessionMiddleware
 
+from svc_infra.api.fastapi.auth.email import AuthEmailConfig
 from svc_infra.api.fastapi.auth.gaurd import auth_session_router, login_client_gaurd
 from svc_infra.api.fastapi.auth.mfa.pre_auth import get_mfa_pre_jwt_writer
 from svc_infra.api.fastapi.auth.mfa.router import mfa_router
@@ -247,6 +248,7 @@ def add_auth_users(
     apikey_table_name: str = "api_keys",
     provider_account_model=None,
     auth_policy: AuthPolicy | None = None,
+    auth_email_config: AuthEmailConfig | None = None,
 ) -> None:
     (
         fapi,
@@ -263,6 +265,7 @@ def add_auth_users(
         user_schema_create=schema_create,
         user_schema_update=schema_update,
         public_auth_prefix=auth_prefix,
+        auth_email_config=auth_email_config,
     )
 
     # Make the boot-time strategy and model available to resolvers

--- a/src/svc_infra/api/fastapi/auth/email.py
+++ b/src/svc_infra/api/fastapi/auth/email.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import html
+import logging
+import os
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+from urllib.parse import quote
+
+from fastapi import HTTPException, status
+
+from svc_infra.email import EmailSender, easy_sender
+
+logger = logging.getLogger(__name__)
+
+AuthEmailKind = Literal["verification", "password_reset"]
+
+
+@dataclass(frozen=True)
+class AuthEmailContext:
+    """Resolved context passed to auth email subject/context/render hooks."""
+
+    kind: AuthEmailKind
+    user: Any
+    token: str
+    request: Any | None
+    recipient: str
+    user_name: str | None
+    action_url: str
+    expires_in: str
+    app_name: str
+    app_url: str
+    support_email: str
+    unsubscribe_url: str
+    templates_available: bool
+
+
+@dataclass(frozen=True)
+class AuthEmailMessage:
+    """Fully rendered auth email payload."""
+
+    subject: str
+    template: str | None = None
+    context: dict[str, Any] = field(default_factory=dict)
+    html: str | None = None
+    text: str | None = None
+    from_addr: str | None = None
+    reply_to: str | None = None
+    cc: list[str] | None = None
+    bcc: list[str] | None = None
+    headers: dict[str, str] | None = None
+    tags: list[str] | None = None
+    metadata: dict[str, str] | None = None
+
+
+class AuthEmailRenderer(Protocol):
+    """Protocol for fully custom auth email renderers."""
+
+    def __call__(self, context: AuthEmailContext) -> AuthEmailMessage: ...
+
+
+@dataclass(frozen=True)
+class AuthEmailTemplateConfig:
+    """Per-email customization for auth flows."""
+
+    path: str
+    subject: str | Callable[[AuthEmailContext], str] | None = None
+    template: str | None = None
+    expires_in: str | None = None
+    tags: list[str] | Callable[[AuthEmailContext], list[str]] | None = None
+    metadata: dict[str, str] | Callable[[AuthEmailContext], dict[str, str]] | None = None
+    context_builder: Callable[[AuthEmailContext], Mapping[str, Any]] | None = None
+    render: AuthEmailRenderer | None = None
+
+
+def _default_verification_config() -> AuthEmailTemplateConfig:
+    return AuthEmailTemplateConfig(
+        path="/verify",
+        template="verification",
+        expires_in="24 hours",
+        tags=["verification", "transactional"],
+    )
+
+
+def _default_password_reset_config() -> AuthEmailTemplateConfig:
+    return AuthEmailTemplateConfig(
+        path="/reset-password",
+        template="password_reset",
+        expires_in="1 hour",
+        tags=["password_reset", "transactional"],
+    )
+
+
+@dataclass(frozen=True)
+class AuthEmailConfig:
+    """Top-level auth email customization for add_auth_users/get_fastapi_users."""
+
+    frontend_url: str | None = None
+    app_name: str = "Our Service"
+    app_url: str | None = None
+    support_email: str = ""
+    unsubscribe_url: str = ""
+    sender: EmailSender | None = None
+    sender_factory: Callable[[], EmailSender] | None = None
+    verification: AuthEmailTemplateConfig = field(default_factory=_default_verification_config)
+    password_reset: AuthEmailTemplateConfig = field(default_factory=_default_password_reset_config)
+
+
+def _build_auth_action_url(
+    *,
+    path: str,
+    token: str,
+    request: Any | None = None,
+    frontend_url: str | None = None,
+) -> str:
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    encoded_token = quote(token, safe="")
+
+    resolved_frontend_url = (frontend_url or os.environ.get("FRONTEND_URL", "")).strip()
+    if resolved_frontend_url:
+        return f"{resolved_frontend_url.rstrip('/')}{normalized_path}?token={encoded_token}"
+
+    if request is not None and getattr(request, "base_url", None) is not None:
+        return f"{str(request.base_url).rstrip('/')}{normalized_path}?token={encoded_token}"
+
+    return f"{normalized_path}?token={encoded_token}"
+
+
+def _resolve_auth_email_sender(config: AuthEmailConfig | None) -> EmailSender:
+    if config and config.sender is not None:
+        return config.sender
+
+    if config and config.sender_factory is not None:
+        return config.sender_factory()
+
+    frontend_url = (config.frontend_url if config else None) or os.environ.get("FRONTEND_URL", "")
+    app_url = config.app_url if config and config.app_url is not None else frontend_url
+
+    return easy_sender(
+        app_name=config.app_name if config else "Our Service",
+        app_url=app_url or "",
+        support_email=config.support_email if config else "",
+        unsubscribe_url=config.unsubscribe_url if config else "",
+    )
+
+
+def _resolve_subject(
+    value: str | Callable[[AuthEmailContext], str] | None,
+    *,
+    context: AuthEmailContext,
+) -> str:
+    if callable(value):
+        return value(context)
+    if value is not None:
+        return value
+    if context.kind == "verification":
+        return f"Verify Your Email - {context.app_name}"
+    return f"Reset Your Password - {context.app_name}"
+
+
+def _resolve_tags(
+    value: list[str] | Callable[[AuthEmailContext], list[str]] | None,
+    *,
+    context: AuthEmailContext,
+) -> list[str] | None:
+    if callable(value):
+        return value(context)
+    return value
+
+
+def _resolve_metadata(
+    value: dict[str, str] | Callable[[AuthEmailContext], dict[str, str]] | None,
+    *,
+    context: AuthEmailContext,
+) -> dict[str, str] | None:
+    if callable(value):
+        return value(context)
+    return value
+
+
+def _build_default_template_context(context: AuthEmailContext) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "action_url": context.action_url,
+        "token": context.token,
+        "recipient": context.recipient,
+        "user_name": context.user_name,
+        "expires_in": context.expires_in,
+        "app_name": context.app_name,
+        "app_url": context.app_url,
+        "support_email": context.support_email,
+        "unsubscribe_url": context.unsubscribe_url,
+    }
+    if context.kind == "verification":
+        payload["verification_url"] = context.action_url
+    else:
+        payload["reset_url"] = context.action_url
+    return payload
+
+
+def _build_fallback_message(
+    *,
+    context: AuthEmailContext,
+    subject: str,
+    tags: list[str] | None,
+    metadata: dict[str, str] | None,
+) -> AuthEmailMessage:
+    display_name = html.escape(context.user_name or "there")
+    escaped_url = html.escape(context.action_url, quote=True)
+
+    if context.kind == "verification":
+        html_body = f"""
+            <p>Hi {display_name},</p>
+            <p>Please verify your email address to finish setting up your account.</p>
+            <p><a href="{escaped_url}">Verify Email Address</a></p>
+            <p>If the button does not work, copy and paste this link into your browser:</p>
+            <p><a href="{escaped_url}">{escaped_url}</a></p>
+            <p>This link expires in {html.escape(context.expires_in)}.</p>
+        """
+        text_body = (
+            f"Hi {context.user_name or 'there'},\n\n"
+            "Please verify your email address to finish setting up your account.\n\n"
+            f"Verify Email Address: {context.action_url}\n\n"
+            f"This link expires in {context.expires_in}."
+        )
+    else:
+        html_body = f"""
+            <p>Hi {display_name},</p>
+            <p>We received a request to reset your password.</p>
+            <p><a href="{escaped_url}">Reset Your Password</a></p>
+            <p>If the button does not work, copy and paste this link into your browser:</p>
+            <p><a href="{escaped_url}">{escaped_url}</a></p>
+            <p>This link expires in {html.escape(context.expires_in)}.</p>
+            <p>If you did not request this, you can ignore this email.</p>
+        """
+        text_body = (
+            f"Hi {context.user_name or 'there'},\n\n"
+            "We received a request to reset your password.\n\n"
+            f"Reset Your Password: {context.action_url}\n\n"
+            f"This link expires in {context.expires_in}.\n\n"
+            "If you did not request this, you can ignore this email."
+        )
+
+    return AuthEmailMessage(
+        subject=subject,
+        html=html_body,
+        text=text_body,
+        tags=tags,
+        metadata=metadata,
+    )
+
+
+def _build_auth_email_message(
+    *,
+    kind: AuthEmailKind,
+    user: Any,
+    token: str,
+    request: Any | None,
+    config: AuthEmailConfig | None,
+    sender: EmailSender,
+) -> AuthEmailMessage:
+    resolved_config = config or AuthEmailConfig()
+    variant = (
+        resolved_config.verification if kind == "verification" else resolved_config.password_reset
+    )
+    recipient = str(user.email)
+
+    action_url = _build_auth_action_url(
+        path=variant.path,
+        token=token,
+        request=request,
+        frontend_url=resolved_config.frontend_url,
+    )
+    context = AuthEmailContext(
+        kind=kind,
+        user=user,
+        token=token,
+        request=request,
+        recipient=recipient,
+        user_name=getattr(user, "full_name", None),
+        action_url=action_url,
+        expires_in=variant.expires_in or ("24 hours" if kind == "verification" else "1 hour"),
+        app_name=getattr(sender, "app_name", "Our Service") or "Our Service",
+        app_url=getattr(sender, "app_url", "")
+        or (resolved_config.app_url or resolved_config.frontend_url or ""),
+        support_email=getattr(sender, "support_email", "") or resolved_config.support_email,
+        unsubscribe_url=getattr(sender, "unsubscribe_url", "") or resolved_config.unsubscribe_url,
+        templates_available=getattr(sender, "template_loader", None) is not None,
+    )
+
+    if variant.render is not None:
+        return variant.render(context)
+
+    subject = _resolve_subject(variant.subject, context=context)
+    tags = _resolve_tags(variant.tags, context=context)
+    metadata = _resolve_metadata(variant.metadata, context=context)
+
+    template_context = _build_default_template_context(context)
+    if variant.context_builder is not None:
+        template_context.update(dict(variant.context_builder(context)))
+
+    if context.templates_available and variant.template:
+        return AuthEmailMessage(
+            subject=subject,
+            template=variant.template,
+            context=template_context,
+            tags=tags,
+            metadata=metadata,
+        )
+
+    return _build_fallback_message(
+        context=context,
+        subject=subject,
+        tags=tags,
+        metadata=metadata,
+    )
+
+
+def _send_auth_email(
+    *,
+    kind: AuthEmailKind,
+    user: Any,
+    token: str,
+    request: Any | None,
+    config: AuthEmailConfig | None,
+    unavailable_message: str,
+) -> None:
+    try:
+        sender = _resolve_auth_email_sender(config)
+        recipient = str(user.email)
+        message = _build_auth_email_message(
+            kind=kind,
+            user=user,
+            token=token,
+            request=request,
+            config=config,
+            sender=sender,
+        )
+        sender.send_sync(
+            to=recipient,
+            subject=message.subject,
+            html=message.html,
+            text=message.text,
+            template=message.template,
+            context=message.context,
+            from_addr=message.from_addr,
+            reply_to=message.reply_to,
+            cc=message.cc,
+            bcc=message.bcc,
+            headers=message.headers,
+            tags=message.tags,
+            metadata=message.metadata,
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception(
+            "Failed to send auth email",
+            extra={
+                "recipient": getattr(user, "email", None),
+                "kind": kind,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": "EMAIL_DELIVERY_UNAVAILABLE",
+                "message": unavailable_message,
+            },
+        ) from None

--- a/src/svc_infra/api/fastapi/db/sql/users.py
+++ b/src/svc_infra/api/fastapi/db/sql/users.py
@@ -13,6 +13,7 @@ from fastapi_users.authentication import (
 )
 from fastapi_users.manager import BaseUserManager, UUIDIDMixin
 
+from svc_infra.api.fastapi.auth.email import AuthEmailConfig, _send_auth_email
 from svc_infra.api.fastapi.auth.settings import get_auth_settings, resolve_jwt_secret
 from svc_infra.api.fastapi.dual.dualize import dualize_public, dualize_user
 from svc_infra.api.fastapi.dual.router import DualAPIRouter
@@ -20,7 +21,6 @@ from svc_infra.app.env import CURRENT_ENVIRONMENT, DEV_ENV, LOCAL_ENV
 from svc_infra.security.jwt_rotation import RotatingJWTStrategy
 
 from ...auth.security import auth_login_path
-from ...auth.sender import get_sender
 from .session import SqlSessionDep
 
 
@@ -31,6 +31,7 @@ def get_fastapi_users(
     user_schema_update: Any,
     *,
     public_auth_prefix: str = "/auth",
+    auth_email_config: AuthEmailConfig | None = None,
 ) -> tuple[
     FastAPIUsers,
     AuthenticationBackend,
@@ -58,29 +59,23 @@ def get_fastapi_users(
             await self.request_verify(user, request)
 
         async def on_after_request_verify(self, user: Any, token: str, request=None):
-            verify_url = f"{public_auth_prefix}/verify?token={token}"
-            sender = get_sender()
-            sender.send(
-                to=user.email,
-                subject="Verify your account",
-                html_body=f"""
-                    <p>Hi {getattr(user, "full_name", "") or "there"},</p>
-                    <p>Click to verify your account:</p>
-                    <p><a href="{verify_url}">{verify_url}</a></p>
-                """,
+            _send_auth_email(
+                kind="verification",
+                user=user,
+                token=token,
+                request=request,
+                config=auth_email_config,
+                unavailable_message="Verification email is temporarily unavailable.",
             )
 
         async def on_after_forgot_password(self, user: Any, token: str, request=None):
-            reset_url = f"{public_auth_prefix}/reset-password?token={token}"
-            sender = get_sender()
-            sender.send(
-                to=user.email,
-                subject="Reset your password",
-                html_body=f"""
-                    <p>We received a request to reset your password.</p>
-                    <p><a href="{reset_url}">{reset_url}</a></p>
-                    <p>If you didn’t request this, you can ignore this email.</p>
-                """,
+            _send_auth_email(
+                kind="password_reset",
+                user=user,
+                token=token,
+                request=request,
+                config=auth_email_config,
+                unavailable_message="Password reset email is temporarily unavailable.",
             )
 
         async def on_after_reset_password(self, user: Any, request=None):

--- a/tests/unit/api/fastapi/auth/test_user_email_failures.py
+++ b/tests/unit/api/fastapi/auth/test_user_email_failures.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, status
+
+from svc_infra.api.fastapi.auth.email import (
+    AuthEmailConfig,
+    AuthEmailMessage,
+    AuthEmailTemplateConfig,
+    _build_auth_action_url,
+    _build_auth_email_message,
+    _send_auth_email,
+)
+
+
+def test_send_auth_email_calls_sender() -> None:
+    sender = MagicMock()
+    sender.app_name = "Acme"
+    sender.app_url = "https://app.acme.com"
+    sender.support_email = "support@acme.com"
+    sender.unsubscribe_url = ""
+    sender.template_loader = None
+    user = SimpleNamespace(email="user@example.com", full_name="Jane Doe")
+
+    with patch("svc_infra.api.fastapi.auth.email._resolve_auth_email_sender", return_value=sender):
+        _send_auth_email(
+            kind="verification",
+            user=user,
+            token="abc123",
+            request=None,
+            config=None,
+            unavailable_message="Verification email is temporarily unavailable.",
+        )
+
+    sender.send_sync.assert_called_once()
+    send_kwargs = sender.send_sync.call_args.kwargs
+    assert send_kwargs["to"] == "user@example.com"
+    assert send_kwargs["subject"] == "Verify Your Email - Acme"
+    assert send_kwargs["template"] is None
+    assert "Verify Email Address" in send_kwargs["html"]
+    assert send_kwargs["text"] is not None
+
+
+def test_send_auth_email_uses_custom_template_config() -> None:
+    sender = MagicMock()
+    sender.app_name = "Acme"
+    sender.app_url = "https://app.acme.com"
+    sender.support_email = "support@acme.com"
+    sender.unsubscribe_url = ""
+    sender.template_loader = object()
+    user = SimpleNamespace(email="user@example.com", full_name="Jane Doe")
+    config = AuthEmailConfig(
+        frontend_url="https://auth.acme.com",
+        verification=AuthEmailTemplateConfig(
+            path="/welcome/verify",
+            subject=lambda ctx: f"Welcome to {ctx.app_name}",
+            template="company_verify",
+            expires_in="3 days",
+            tags=lambda ctx: [ctx.kind, "brand"],
+            context_builder=lambda ctx: {"headline": f"Hello {ctx.user_name}"},
+        ),
+    )
+
+    with patch("svc_infra.api.fastapi.auth.email._resolve_auth_email_sender", return_value=sender):
+        _send_auth_email(
+            kind="verification",
+            user=user,
+            token="abc123",
+            request=None,
+            config=config,
+            unavailable_message="Verification email is temporarily unavailable.",
+        )
+
+    sender.send_sync.assert_called_once_with(
+        to="user@example.com",
+        subject="Welcome to Acme",
+        html=None,
+        text=None,
+        template="company_verify",
+        context={
+            "action_url": "https://auth.acme.com/welcome/verify?token=abc123",
+            "token": "abc123",
+            "recipient": "user@example.com",
+            "user_name": "Jane Doe",
+            "expires_in": "3 days",
+            "app_name": "Acme",
+            "app_url": "https://app.acme.com",
+            "support_email": "support@acme.com",
+            "unsubscribe_url": "",
+            "verification_url": "https://auth.acme.com/welcome/verify?token=abc123",
+            "headline": "Hello Jane Doe",
+        },
+        from_addr=None,
+        reply_to=None,
+        cc=None,
+        bcc=None,
+        headers=None,
+        tags=["verification", "brand"],
+        metadata=None,
+    )
+
+
+def test_send_auth_email_wraps_sender_failures() -> None:
+    sender = MagicMock()
+    sender.app_name = "Acme"
+    sender.app_url = "https://app.acme.com"
+    sender.support_email = "support@acme.com"
+    sender.unsubscribe_url = ""
+    sender.template_loader = None
+    sender.send_sync.side_effect = RuntimeError("boom")
+    user = SimpleNamespace(email="user@example.com", full_name="Jane Doe")
+
+    with patch("svc_infra.api.fastapi.auth.email._resolve_auth_email_sender", return_value=sender):
+        with pytest.raises(HTTPException) as exc_info:
+            _send_auth_email(
+                kind="verification",
+                user=user,
+                token="abc123",
+                request=None,
+                config=None,
+                unavailable_message="Verification email is temporarily unavailable.",
+            )
+
+    assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert exc_info.value.detail == {
+        "code": "EMAIL_DELIVERY_UNAVAILABLE",
+        "message": "Verification email is temporarily unavailable.",
+    }
+
+
+def test_build_auth_action_url_prefers_frontend_url() -> None:
+    with patch.dict("os.environ", {"FRONTEND_URL": "https://pulse.nfrax.com/"}, clear=False):
+        url = _build_auth_action_url(path="/verify", token="abc+123")
+
+    assert url == "https://pulse.nfrax.com/verify?token=abc%2B123"
+
+
+def test_build_auth_action_url_falls_back_to_request_base_url() -> None:
+    request = SimpleNamespace(base_url="https://preview.api.pulse.nfrax.com/")
+
+    with patch.dict("os.environ", {}, clear=True):
+        url = _build_auth_action_url(path="/reset-password", token="abc123", request=request)
+
+    assert url == "https://preview.api.pulse.nfrax.com/reset-password?token=abc123"
+
+
+def test_build_auth_action_url_prefers_configured_frontend_url() -> None:
+    request = SimpleNamespace(base_url="https://preview.api.pulse.nfrax.com/")
+
+    url = _build_auth_action_url(
+        path="/verify",
+        token="abc123",
+        request=request,
+        frontend_url="https://accounts.acme.com",
+    )
+
+    assert url == "https://accounts.acme.com/verify?token=abc123"
+
+
+def test_build_auth_email_message_uses_custom_renderer() -> None:
+    sender = MagicMock()
+    sender.app_name = "Acme"
+    sender.app_url = "https://app.acme.com"
+    sender.support_email = "support@acme.com"
+    sender.unsubscribe_url = ""
+    sender.template_loader = object()
+    user = SimpleNamespace(email="user@example.com", full_name="Jane Doe")
+    config = AuthEmailConfig(
+        frontend_url="https://auth.acme.com",
+        password_reset=AuthEmailTemplateConfig(
+            path="/security/reset",
+            render=lambda ctx: AuthEmailMessage(
+                subject=f"Reset for {ctx.user_name}",
+                html=f"<strong>{ctx.action_url}</strong>",
+                text=ctx.action_url,
+                headers={"X-Customer": "acme"},
+                metadata={"flow": ctx.kind},
+                tags=["custom-reset"],
+            ),
+        ),
+    )
+
+    message = _build_auth_email_message(
+        kind="password_reset",
+        user=user,
+        token="abc123",
+        request=None,
+        config=config,
+        sender=sender,
+    )
+
+    assert message.subject == "Reset for Jane Doe"
+    assert message.html == "<strong>https://auth.acme.com/security/reset?token=abc123</strong>"
+    assert message.text == "https://auth.acme.com/security/reset?token=abc123"
+    assert message.headers == {"X-Customer": "acme"}
+    assert message.metadata == {"flow": "password_reset"}
+    assert message.tags == ["custom-reset"]


### PR DESCRIPTION
## Summary
- add `AuthEmailConfig` and `AuthEmailTemplateConfig` so FastAPI auth verification and reset emails can be fully customized
- route auth emails through the shared email sender/template system and add focused regression coverage
- add a branded auth email example set and refresh the email docs/navigation to document the new customization flow

## Tests
- `poetry run ruff check src/svc_infra/api/fastapi/auth src/svc_infra/api/fastapi/db/sql/users.py tests/unit/api/fastapi/auth/test_user_email_failures.py`
- `.venv/bin/python -m pytest -q tests/unit/api/fastapi/auth/test_user_email_failures.py`