### PR TITLE
feat: add safe public URL loader

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1703,22 +1703,22 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.45"
+version = "3.1.49"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77"},
-    {file = "gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c"},
+    {file = "gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c"},
+    {file = "gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1"},
 ]
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
 
 [package.extras]
-doc = ["sphinx (>=7.1.2,<7.2)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
-test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
+doc = ["sphinx (>=7.4.7,<8)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy (==1.18.2) ; python_version >= \"3.9\"", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
 
 [[package]]
 name = "googleapis-common-protos"
@@ -3451,14 +3451,14 @@ files = [
 
 [[package]]
 name = "pip"
-version = "25.3"
+version = "26.1.1"
 description = "The PyPA recommended tool for installing Python packages."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pip-25.3-py3-none-any.whl", hash = "sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd"},
-    {file = "pip-25.3.tar.gz", hash = "sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343"},
+    {file = "pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb"},
+    {file = "pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78"},
 ]
 
 [[package]]
@@ -6133,4 +6133,4 @@ stripe = ["stripe"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "e929224264e94a8aaa362476c413ecd667855dd7f62c10c2b0c3b4decbeeaaae"
+content-hash = "b545618850ec85b32dd7c225ee969c38dec758713620eab974edd7c1fb563369"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,8 @@ aiosqlite = ">=0.19.0"  # Required for acceptance tests using SQLite
 pre-commit = ">=3.0.0"
 bandit = ">=1.7.0"
 pip-audit = ">=2.7.0"  # Security vulnerability scanning
+pip = ">=26.1"
+gitpython = ">=3.1.47"
 python-semantic-release = ">=9.0.0"
 # Documentation
 mkdocs = ">=1.6.0"

--- a/src/svc_infra/loaders/__init__.py
+++ b/src/svc_infra/loaders/__init__.py
@@ -39,6 +39,7 @@ Convenience Functions:
 Available Loaders:
     - GitHubLoader: Load files from GitHub repositories
     - URLLoader: Load content from URLs (with HTML text extraction)
+    - fetch_public_url: Safe public HTTP(S) fetch for hosted user-supplied URLs
 
 Future Loaders (planned):
     - S3Loader: Load files from S3-compatible storage
@@ -49,7 +50,7 @@ Future Loaders (planned):
 from .base import BaseLoader
 from .github import GitHubLoader
 from .models import LoadedContent, LoadedDocument, to_loaded_documents
-from .url import URLLoader
+from .url import PublicURLPolicyError, URLContentTooLargeError, URLLoader, fetch_public_url
 
 
 async def load_github(
@@ -177,6 +178,9 @@ __all__ = [
     # Loaders
     "GitHubLoader",
     "URLLoader",
+    "fetch_public_url",
+    "PublicURLPolicyError",
+    "URLContentTooLargeError",
     # Async convenience functions
     "load_github",
     "load_url",

--- a/src/svc_infra/loaders/url.py
+++ b/src/svc_infra/loaders/url.py
@@ -5,16 +5,183 @@ Load content from URLs with automatic HTML text extraction.
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import re
+import socket
 from typing import Any
+from urllib.parse import urljoin, urlparse
 
 import httpx
+
+from svc_infra.http import new_async_httpx_client
 
 from .base import BaseLoader, ErrorStrategy
 from .models import LoadedContent
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_PUBLIC_FETCH_MAX_BYTES = 1_048_576
+_DEFAULT_PUBLIC_FETCH_MAX_REDIRECTS = 5
+_DEFAULT_PUBLIC_FETCH_USER_AGENT = "svc-infra-url-loader/1.0"
+
+
+class PublicURLPolicyError(RuntimeError):
+    """Raised when a public URL fetch violates network access policy."""
+
+
+class URLContentTooLargeError(RuntimeError):
+    """Raised when a fetched URL response exceeds the configured byte cap."""
+
+
+def _validate_http_url(url: str) -> None:
+    if not url.startswith(("http://", "https://")):
+        raise ValueError(f"Invalid URL: {url!r}. URLs must start with http:// or https://")
+
+
+def _is_public_ip(address: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    return ip.is_global
+
+
+def _validate_public_hostname(hostname: str | None) -> None:
+    if not hostname:
+        raise PublicURLPolicyError("Public URL fetch requires a resolvable hostname.")
+
+    try:
+        infos = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise PublicURLPolicyError(
+            f"Could not resolve host for public URL fetch: {hostname}"
+        ) from exc
+
+    addresses = {info[4][0] for info in infos if info[4]}
+    if not addresses:
+        raise PublicURLPolicyError(f"Could not resolve host for public URL fetch: {hostname}")
+
+    non_public = sorted(address for address in addresses if not _is_public_ip(address))
+    if non_public:
+        raise PublicURLPolicyError(
+            f"URL host resolves to non-public IP addresses and is not allowed: {hostname}"
+        )
+
+
+async def _read_response_bytes(response: httpx.Response, max_bytes: int | None) -> bytes:
+    if max_bytes is not None:
+        content_length = response.headers.get("content-length", "").strip()
+        if content_length:
+            try:
+                if int(content_length) > max_bytes:
+                    raise URLContentTooLargeError(
+                        "URL response exceeds the configured size limit before download completed."
+                    )
+            except ValueError:
+                pass
+
+    chunks: list[bytes] = []
+    total_bytes = 0
+    async for chunk in response.aiter_bytes():
+        total_bytes += len(chunk)
+        if max_bytes is not None and total_bytes > max_bytes:
+            raise URLContentTooLargeError("URL response exceeds the configured size limit.")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _decode_response_text(response: httpx.Response, raw_content: bytes) -> str:
+    encoding = response.encoding or "utf-8"
+    return raw_content.decode(encoding, errors="replace")
+
+
+def _build_loaded_content(
+    *,
+    requested_url: str,
+    final_url: str,
+    response: httpx.Response,
+    raw_content: bytes,
+    extract_text: bool,
+    extra_metadata: dict[str, Any] | None = None,
+    redirect_count: int = 0,
+) -> LoadedContent:
+    content_type = response.headers.get("content-type", "")
+    raw_text = _decode_response_text(response, raw_content)
+    if extract_text and "text/html" in content_type:
+        content = URLLoader._extract_text_from_html(raw_text)
+    else:
+        content = raw_text
+
+    mime_type = content_type.split(";")[0].strip() if content_type else None
+    return LoadedContent(
+        content=content,
+        source=requested_url,
+        content_type=mime_type,
+        metadata={
+            "loader": "url",
+            "url": requested_url,
+            "status_code": response.status_code,
+            "final_url": final_url,
+            "redirect_count": redirect_count,
+            **(extra_metadata or {}),
+        },
+    )
+
+
+async def fetch_public_url(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    extract_text: bool = True,
+    timeout: float = 30.0,
+    extra_metadata: dict[str, Any] | None = None,
+    max_bytes: int = _DEFAULT_PUBLIC_FETCH_MAX_BYTES,
+    max_redirects: int = _DEFAULT_PUBLIC_FETCH_MAX_REDIRECTS,
+    user_agent: str = _DEFAULT_PUBLIC_FETCH_USER_AGENT,
+) -> LoadedContent:
+    """Fetch a public HTTP(S) URL with SSRF protections and byte caps."""
+    _validate_http_url(url)
+
+    request_headers = dict(headers or {})
+    request_headers.setdefault("User-Agent", user_agent)
+
+    current_url = url
+    redirect_count = 0
+
+    async with new_async_httpx_client(
+        timeout_seconds=timeout,
+        follow_redirects=False,
+    ) as client:
+        while True:
+            parsed = urlparse(current_url)
+            _validate_http_url(current_url)
+            _validate_public_hostname(parsed.hostname)
+
+            async with client.stream("GET", current_url, headers=request_headers) as response:
+                if 300 <= response.status_code < 400:
+                    location = response.headers.get("location", "").strip()
+                    if not location:
+                        raise PublicURLPolicyError(
+                            "Redirect response did not include a location header."
+                        )
+                    if redirect_count >= max_redirects:
+                        raise PublicURLPolicyError("Too many redirects while fetching public URL.")
+                    current_url = urljoin(current_url, location)
+                    redirect_count += 1
+                    continue
+
+                response.raise_for_status()
+                raw_content = await _read_response_bytes(response, max_bytes=max_bytes)
+                return _build_loaded_content(
+                    requested_url=url,
+                    final_url=str(response.url),
+                    response=response,
+                    raw_content=raw_content,
+                    extract_text=extract_text,
+                    extra_metadata=extra_metadata,
+                    redirect_count=redirect_count,
+                )
 
 
 class URLLoader(BaseLoader):
@@ -31,6 +198,10 @@ class URLLoader(BaseLoader):
         follow_redirects: Follow HTTP redirects (default: True).
         timeout: Request timeout in seconds (default: 30).
         extra_metadata: Additional metadata to attach to all loaded content.
+        public_only: If True, only allow publicly routable HTTP(S) targets and
+            validate every redirect hop.
+        max_bytes: Optional response byte limit.
+        max_redirects: Maximum redirect hops when public_only=True.
         on_error: How to handle errors ("skip" or "raise"). Default: "skip"
 
     Example:
@@ -71,6 +242,9 @@ class URLLoader(BaseLoader):
         follow_redirects: bool = True,
         timeout: float = 30.0,
         extra_metadata: dict[str, Any] | None = None,
+        public_only: bool = False,
+        max_bytes: int | None = None,
+        max_redirects: int = _DEFAULT_PUBLIC_FETCH_MAX_REDIRECTS,
         on_error: ErrorStrategy = "skip",
     ) -> None:
         """Initialize the URL loader.
@@ -93,11 +267,13 @@ class URLLoader(BaseLoader):
         self.follow_redirects = follow_redirects
         self.timeout = timeout
         self.extra_metadata = extra_metadata or {}
+        self.public_only = public_only
+        self.max_bytes = max_bytes
+        self.max_redirects = max_redirects
 
         # Validate URLs
         for url in self.urls:
-            if not url.startswith(("http://", "https://")):
-                raise ValueError(f"Invalid URL: {url!r}. URLs must start with http:// or https://")
+            _validate_http_url(url)
 
     async def load(self) -> list[LoadedContent]:
         """Load content from all URLs.
@@ -109,6 +285,27 @@ class URLLoader(BaseLoader):
             httpx.HTTPError: If request fails and on_error="raise".
         """
         contents: list[LoadedContent] = []
+
+        if self.public_only:
+            for url in self.urls:
+                try:
+                    contents.append(
+                        await fetch_public_url(
+                            url,
+                            headers=self.headers,
+                            extract_text=self.extract_text,
+                            timeout=self.timeout,
+                            extra_metadata=self.extra_metadata,
+                            max_bytes=self.max_bytes or _DEFAULT_PUBLIC_FETCH_MAX_BYTES,
+                            max_redirects=self.max_redirects,
+                        )
+                    )
+                except (PublicURLPolicyError, URLContentTooLargeError, httpx.HTTPError) as e:
+                    msg = f"Request failed for {url}: {e}"
+                    if self.on_error == "raise":
+                        raise RuntimeError(msg) from e
+                    logger.warning(msg)
+            return contents
 
         async with httpx.AsyncClient(
             timeout=self.timeout,

--- a/src/svc_infra/loaders/url.py
+++ b/src/svc_infra/loaders/url.py
@@ -58,7 +58,14 @@ def _validate_public_hostname(hostname: str | None) -> None:
             f"Could not resolve host for public URL fetch: {hostname}"
         ) from exc
 
-    addresses = {info[4][0] for info in infos if info[4]}
+    addresses: set[str] = set()
+    for info in infos:
+        if not info[4]:
+            continue
+        address = info[4][0]
+        if isinstance(address, str):
+            addresses.add(address)
+
     if not addresses:
         raise PublicURLPolicyError(f"Could not resolve host for public URL fetch: {hostname}")
 

--- a/tests/unit/loaders/test_url_loader.py
+++ b/tests/unit/loaders/test_url_loader.py
@@ -47,6 +47,9 @@ class TestURLLoaderInit:
             follow_redirects=False,
             timeout=60.0,
             extra_metadata={"source": "test"},
+            public_only=True,
+            max_bytes=4096,
+            max_redirects=2,
         )
 
         assert loader.urls == ["https://example.com"]
@@ -55,6 +58,9 @@ class TestURLLoaderInit:
         assert loader.follow_redirects is False
         assert loader.timeout == 60.0
         assert loader.extra_metadata == {"source": "test"}
+        assert loader.public_only is True
+        assert loader.max_bytes == 4096
+        assert loader.max_redirects == 2
 
     def test_invalid_url_no_scheme(self):
         """Test that URL without scheme raises ValueError."""
@@ -404,6 +410,90 @@ class TestURLLoaderLoad:
             # Content type should be parsed (charset removed)
             assert contents[0].content_type == "text/html"
 
+    @pytest.mark.asyncio
+    async def test_load_public_only_rejects_private_resolution(self):
+        """Test that public-only mode blocks private network targets."""
+        loader = URLLoader("https://example.com", public_only=True, on_error="raise")
+
+        with patch(
+            "svc_infra.loaders.url.socket.getaddrinfo",
+            return_value=[(0, 0, 0, "", ("127.0.0.1", 0))],
+        ):
+            with pytest.raises(RuntimeError, match="non-public"):
+                await loader.load()
+
+    @pytest.mark.asyncio
+    async def test_load_public_only_tracks_redirect_count(self):
+        """Test that public-only mode validates redirects and records final URL."""
+        loader = URLLoader("https://example.com/start", public_only=True)
+
+        redirect_response = AsyncMock()
+        redirect_response.__aenter__.return_value = redirect_response
+        redirect_response.__aexit__.return_value = False
+        redirect_response.status_code = 302
+        redirect_response.headers = {"location": "https://example.com/final"}
+        redirect_response.url = "https://example.com/start"
+
+        final_response = AsyncMock()
+        final_response.__aenter__.return_value = final_response
+        final_response.__aexit__.return_value = False
+        final_response.status_code = 200
+        final_response.headers = {"content-type": "text/plain"}
+        final_response.url = "https://example.com/final"
+        final_response.encoding = "utf-8"
+        final_response.raise_for_status = MagicMock()
+        final_response.aiter_bytes = MagicMock(return_value=_aiter_bytes([b"hello world"]))
+
+        mock_client = MagicMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = False
+        mock_client.stream.side_effect = [redirect_response, final_response]
+
+        with patch(
+            "svc_infra.loaders.url.socket.getaddrinfo",
+            return_value=[(0, 0, 0, "", ("93.184.216.34", 0))],
+        ):
+            with patch("svc_infra.loaders.url.new_async_httpx_client", return_value=mock_client):
+                contents = await loader.load()
+
+        assert len(contents) == 1
+        assert contents[0].content == "hello world"
+        assert contents[0].metadata["final_url"] == "https://example.com/final"
+        assert contents[0].metadata["redirect_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_load_public_only_enforces_byte_cap(self):
+        """Test that public-only mode rejects oversized responses."""
+        loader = URLLoader(
+            "https://example.com/file",
+            public_only=True,
+            max_bytes=4,
+            on_error="raise",
+        )
+
+        final_response = AsyncMock()
+        final_response.__aenter__.return_value = final_response
+        final_response.__aexit__.return_value = False
+        final_response.status_code = 200
+        final_response.headers = {"content-type": "text/plain"}
+        final_response.url = "https://example.com/file"
+        final_response.encoding = "utf-8"
+        final_response.raise_for_status = MagicMock()
+        final_response.aiter_bytes = MagicMock(return_value=_aiter_bytes([b"hello", b" world"]))
+
+        mock_client = MagicMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = False
+        mock_client.stream.return_value = final_response
+
+        with patch(
+            "svc_infra.loaders.url.socket.getaddrinfo",
+            return_value=[(0, 0, 0, "", ("93.184.216.34", 0))],
+        ):
+            with patch("svc_infra.loaders.url.new_async_httpx_client", return_value=mock_client):
+                with pytest.raises(RuntimeError, match="size limit"):
+                    await loader.load()
+
 
 class TestURLLoaderSync:
     """Tests for synchronous loading."""
@@ -419,3 +509,8 @@ class TestURLLoaderSync:
             assert "svc-infra" in contents[0].content.lower()
         except Exception:
             pytest.skip("Network unavailable")
+
+
+async def _aiter_bytes(chunks: list[bytes]):
+    for chunk in chunks:
+        yield chunk


### PR DESCRIPTION
## Summary
- add a safe public HTTP(S) fetch helper with SSRF protection, redirect validation, and byte caps
- extend URLLoader with public-only fetching options and export the new loader error surfaces
- add focused regression tests for private host rejection, redirect tracking, and oversized responses

## Tests
- poetry run ruff check src tests
- poetry run ruff format src tests
- poetry run pytest tests/unit/loaders/test_url_loader.py -q